### PR TITLE
Add host_container_id sent from Host

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -204,9 +204,9 @@ void HostPDRHandler::mergeEntityAssociations(const std::vector<uint8_t>& pdr)
             auto node = pldm_entity_association_tree_find(entityTree, &parent);
             if (node)
             {
-                pldm_entity_association_tree_add(entityTree, &entities[i],
-                                                 0xFFFF, node,
-                                                 entityPdr->association_type);
+                pldm_entity_association_tree_add(
+                    entityTree, &entities[i], 0xFFFF, node,
+                    entityPdr->association_type, true);
                 merged = true;
             }
         }

--- a/libpldm/pdr.c
+++ b/libpldm/pdr.c
@@ -352,6 +352,7 @@ typedef struct pldm_entity_node {
 	pldm_entity_node *first_child;
 	pldm_entity_node *next_sibling;
 	uint8_t association_type;
+	uint16_t host_container_id;
 } pldm_entity_node;
 
 static inline uint16_t next_container_id(pldm_entity_association_tree *tree)
@@ -367,6 +368,13 @@ pldm_entity pldm_entity_extract(pldm_entity_node *node)
 	assert(node != NULL);
 
 	return node->entity;
+}
+
+uint16_t pldm_extract_host_container_id(const pldm_entity_node *entity)
+{
+	assert(entity != NULL);
+
+	return entity->host_container_id;
 }
 
 pldm_entity_association_tree *pldm_entity_association_tree_init()
@@ -404,7 +412,7 @@ static pldm_entity_node *find_insertion_at(pldm_entity_node *start,
 pldm_entity_node *pldm_entity_association_tree_add(
     pldm_entity_association_tree *tree, pldm_entity *entity,
     uint16_t entity_instance_number, pldm_entity_node *parent,
-    uint8_t association_type)
+    uint8_t association_type, bool is_remote)
 {
 	assert(tree != NULL);
 	assert(entity != NULL);
@@ -429,6 +437,8 @@ pldm_entity_node *pldm_entity_association_tree_add(
 	node->entity.entity_instance_num =
 	    entity_instance_number != 0xFFFF ? entity_instance_number : 1;
 	node->association_type = association_type;
+	node->host_container_id =
+	    is_remote ? entity->entity_container_id : 0xFFFF;
 
 	if (tree->root == NULL) {
 		assert(parent == NULL);
@@ -823,6 +833,7 @@ static void entity_association_tree_copy(pldm_entity_node *org_node,
 	*new_node = malloc(sizeof(pldm_entity_node));
 	(*new_node)->entity = org_node->entity;
 	(*new_node)->association_type = org_node->association_type;
+	(*new_node)->host_container_id = org_node->host_container_id;
 	(*new_node)->first_child = NULL;
 	(*new_node)->next_sibling = NULL;
 	entity_association_tree_copy(org_node->first_child,

--- a/libpldm/pdr.h
+++ b/libpldm/pdr.h
@@ -243,13 +243,15 @@ pldm_entity_association_tree *pldm_entity_association_tree_init();
  *  @param[in] parent - pointer to the node that should be the parent of input
  *                      entity. If this is NULL, then the entity is the root
  *  @param[in] association_type - relation with the parent : logical or physical
+ *  @param[in] is_remote - used to denote whether we are adding a BMC entity to
+ *                        the tree or a host entity
  *
  *  @return pldm_entity_node* - opaque pointer to added entity
  */
 pldm_entity_node *pldm_entity_association_tree_add(
     pldm_entity_association_tree *tree, pldm_entity *entity,
     uint16_t entity_instance_number, pldm_entity_node *parent,
-    uint8_t association_type);
+    uint8_t association_type, bool is_remote);
 
 /** @brief Visit and note each entity in the entity association tree
  *
@@ -268,6 +270,14 @@ void pldm_entity_association_tree_visit(pldm_entity_association_tree *tree,
  *  @return pldm_entity - pldm entity
  */
 pldm_entity pldm_entity_extract(pldm_entity_node *node);
+
+/** @brief Extract host container id by the pldm_entity_node
+ *
+ *  @param[in] entity         - opaque pointer to added entity
+ *
+ *  @return host container id - host container id
+ */
+uint16_t pldm_extract_host_container_id(const pldm_entity_node *entity);
 
 /** @brief Destroy entity association tree
  *

--- a/libpldm/tests/libpldm_pdr_test.cpp
+++ b/libpldm/tests/libpldm_pdr_test.cpp
@@ -532,31 +532,37 @@ TEST(EntityAssociationPDR, testBuild)
     auto tree = pldm_entity_association_tree_init();
 
     auto l1 = pldm_entity_association_tree_add(
-        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(
-        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2c, nullptr);
-    auto l3a = pldm_entity_association_tree_add(
-        tree, &entities[4], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3a = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l3a, nullptr);
-    auto l3b = pldm_entity_association_tree_add(
-        tree, &entities[5], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3b = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l3b, nullptr);
-    auto l3c = pldm_entity_association_tree_add(
-        tree, &entities[6], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3c = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l3b, nullptr);
-    auto l4a = pldm_entity_association_tree_add(
-        tree, &entities[7], 0xFFFF, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l4a = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l3a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l4a, nullptr);
-    auto l4b = pldm_entity_association_tree_add(
-        tree, &entities[8], 0xFFFF, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l4b = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l3b,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l4b, nullptr);
 
     EXPECT_EQ(pldm_entity_is_node_parent(l1), true);
@@ -676,7 +682,8 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     // A
     auto tree = pldm_entity_association_tree_init();
     auto node = pldm_entity_association_tree_add(
-        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(node, nullptr);
     size_t num{};
     pldm_entity* out = nullptr;
@@ -691,13 +698,16 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     // A-A-A
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
-                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                            false);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, nullptr,
-                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                            false);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, nullptr,
-                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                            false);
     EXPECT_NE(node, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 3u);
@@ -720,13 +730,16 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     // A
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
-                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                            false);
     EXPECT_NE(node, nullptr);
     auto node1 = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[1], 0xFFFF, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(node1, nullptr);
     auto node2 = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, node1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[2], 0xFFFF, node1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(node2, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 3u);
@@ -747,16 +760,20 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     //   A-A
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
-                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                            false);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
-                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                            PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                            false);
     EXPECT_NE(node, nullptr);
     node1 = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, node,
-                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                             false);
     EXPECT_NE(node1, nullptr);
     node2 = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, node,
-                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                             false);
     EXPECT_NE(node2, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 4u);
@@ -814,43 +831,49 @@ TEST(EntityAssociationPDR, testPDR)
     auto tree = pldm_entity_association_tree_init();
 
     auto l1 = pldm_entity_association_tree_add(
-        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l1, nullptr);
     auto l1a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[1], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l1a, nullptr);
 
     auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2a, nullptr);
-    auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
-                                                PLDM_ENTITY_ASSOCIAION_LOGICAL);
+    auto l2b = pldm_entity_association_tree_add(
+        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(
-        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2c, nullptr);
-    auto l2d = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l1,
-                                                PLDM_ENTITY_ASSOCIAION_LOGICAL);
+    auto l2d = pldm_entity_association_tree_add(
+        tree, &entities[4], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
     EXPECT_NE(l2d, nullptr);
 
-    auto l3a = pldm_entity_association_tree_add(
-        tree, &entities[5], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3a = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l3a, nullptr);
-    auto l3b = pldm_entity_association_tree_add(
-        tree, &entities[6], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3b = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l3b, nullptr);
-    auto l3c = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l2a,
-                                                PLDM_ENTITY_ASSOCIAION_LOGICAL);
+    auto l3c = pldm_entity_association_tree_add(
+        tree, &entities[7], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
     EXPECT_NE(l3c, nullptr);
-    auto l3d = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l2a,
-                                                PLDM_ENTITY_ASSOCIAION_LOGICAL);
+    auto l3d = pldm_entity_association_tree_add(
+        tree, &entities[8], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
     EXPECT_NE(l3d, nullptr);
 
-    auto l4a = pldm_entity_association_tree_add(
-        tree, &entities[9], 0xFFFF, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l4a = pldm_entity_association_tree_add(tree, &entities[9], 0xFFFF, l3a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l4a, nullptr);
-    auto l4b = pldm_entity_association_tree_add(
-        tree, &entities[10], 0xFFFF, l3b, PLDM_ENTITY_ASSOCIAION_LOGICAL);
+    auto l4b =
+        pldm_entity_association_tree_add(tree, &entities[10], 0xFFFF, l3b,
+                                         PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
     EXPECT_NE(l4b, nullptr);
 
     EXPECT_EQ(pldm_entity_get_num_children(l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL),
@@ -1111,31 +1134,37 @@ TEST(EntityAssociationPDR, testFind)
     auto tree = pldm_entity_association_tree_init();
 
     auto l1 = pldm_entity_association_tree_add(
-        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(
-        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2c, nullptr);
-    auto l3a = pldm_entity_association_tree_add(
-        tree, &entities[4], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3a = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l3a, nullptr);
-    auto l3b = pldm_entity_association_tree_add(
-        tree, &entities[5], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3b = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l3b, nullptr);
-    auto l3c = pldm_entity_association_tree_add(
-        tree, &entities[6], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3c = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l3c, nullptr);
-    auto l4a = pldm_entity_association_tree_add(
-        tree, &entities[7], 0xFFFF, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l4a = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l3a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l4a, nullptr);
-    auto l4b = pldm_entity_association_tree_add(
-        tree, &entities[8], 0xFFFF, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l4b = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l3b,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false);
     EXPECT_NE(l4b, nullptr);
 
     pldm_entity entity{};
@@ -1181,18 +1210,21 @@ TEST(EntityAssociationPDR, testCopyTree)
 
     auto orgTree = pldm_entity_association_tree_init();
     auto newTree = pldm_entity_association_tree_init();
-    auto l1 =
-        pldm_entity_association_tree_add(orgTree, &entities[0], 0xFFFF, nullptr,
-                                         PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l1 = pldm_entity_association_tree_add(
+        orgTree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(
-        orgTree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        orgTree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(
-        orgTree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        orgTree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(
-        orgTree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        orgTree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l2c, nullptr);
     size_t orgNum{};
     pldm_entity* orgOut = nullptr;
@@ -1289,16 +1321,17 @@ TEST(EntityAssociationPDR, testGetChildren)
 
     auto tree = pldm_entity_association_tree_init();
     auto l1 = pldm_entity_association_tree_add(
-        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(
-        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_NE(l2c, nullptr);
 
     pldm_entity et1;
@@ -1342,11 +1375,12 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     uint16_t containerId{};
 
     auto node = pldm_entity_association_tree_add(
-        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
     EXPECT_NE(node, nullptr);
 
-    auto l1 = pldm_entity_association_tree_add(tree, &entities[1], 63, node,
-                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l1 = pldm_entity_association_tree_add(
+        tree, &entities[1], 63, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     auto first = pldm_pdr_add_fru_record_set(
         repo, 1, 1, entities[1].entity_type, entities[1].entity_instance_num,
         entities[1].entity_container_id, 1);
@@ -1359,8 +1393,8 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 2);
     EXPECT_EQ(entityInstanceNum, 63);
 
-    auto l2 = pldm_entity_association_tree_add(tree, &entities[2], 37, node,
-                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l2 = pldm_entity_association_tree_add(
+        tree, &entities[2], 37, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     auto second = pldm_pdr_add_fru_record_set(
         repo, 1, 2, entities[2].entity_type, entities[2].entity_instance_num,
         entities[2].entity_container_id, 2);
@@ -1373,8 +1407,8 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 2);
     EXPECT_EQ(entityInstanceNum, 37);
 
-    auto l3 = pldm_entity_association_tree_add(tree, &entities[3], 44, node,
-                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l3 = pldm_entity_association_tree_add(
+        tree, &entities[3], 44, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     auto third = pldm_pdr_add_fru_record_set(
         repo, 1, 3, entities[3].entity_type, entities[3].entity_instance_num,
         entities[3].entity_container_id, 3);
@@ -1387,8 +1421,8 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 2);
     EXPECT_EQ(entityInstanceNum, 44);
 
-    auto l4 = pldm_entity_association_tree_add(tree, &entities[4], 89, node,
-                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l4 = pldm_entity_association_tree_add(
+        tree, &entities[4], 89, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     auto fourth = pldm_pdr_add_fru_record_set(
         repo, 1, 4, entities[4].entity_type, entities[4].entity_instance_num,
         entities[4].entity_container_id, 4);
@@ -1402,7 +1436,8 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityInstanceNum, 89);
 
     auto l5 = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, node,
-                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false);
     auto fifth = pldm_pdr_add_fru_record_set(
         repo, 1, 5, entities[5].entity_type, entities[5].entity_instance_num,
         entities[5].entity_container_id, 5);
@@ -1415,12 +1450,12 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 2);
     EXPECT_EQ(entityInstanceNum, 90);
 
-    auto l6 = pldm_entity_association_tree_add(tree, &entities[6], 90, node,
-                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l6 = pldm_entity_association_tree_add(
+        tree, &entities[6], 90, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     EXPECT_EQ(l6, nullptr);
 
-    auto l7 = pldm_entity_association_tree_add(tree, &entities[7], 100, l1,
-                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l7 = pldm_entity_association_tree_add(
+        tree, &entities[7], 100, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     auto seventh = pldm_pdr_add_fru_record_set(
         repo, 1, 7, entities[7].entity_type, entities[7].entity_instance_num,
         entities[7].entity_container_id, 7);
@@ -1433,8 +1468,8 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 3);
     EXPECT_EQ(entityInstanceNum, 100);
 
-    auto l8 = pldm_entity_association_tree_add(tree, &entities[8], 100, l2,
-                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    auto l8 = pldm_entity_association_tree_add(
+        tree, &entities[8], 100, l2, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
     auto eighth = pldm_pdr_add_fru_record_set(
         repo, 1, 8, entities[8].entity_type, entities[8].entity_instance_num,
         entities[8].entity_container_id, 8);
@@ -1446,6 +1481,43 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
                                     &entityInstanceNum, &containerId)));
     EXPECT_EQ(entityType, 3);
     EXPECT_EQ(entityInstanceNum, 100);
+
+    pldm_pdr_destroy(repo);
+    pldm_entity_association_tree_destroy(tree);
+}
+
+TEST(EntityAssociationPDR, testHostContainerID)
+{
+    pldm_entity entities[3]{};
+
+    entities[0].entity_type = 1;
+    entities[1].entity_type = 2;
+    entities[2].entity_type = 3;
+    entities[2].entity_container_id = 30;
+
+    auto tree = pldm_entity_association_tree_init();
+    auto repo = pldm_pdr_init();
+
+    auto node = pldm_entity_association_tree_add(
+        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        false);
+    EXPECT_NE(node, nullptr);
+
+    auto l1 = pldm_entity_association_tree_add(
+        tree, &entities[1], 63, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    EXPECT_NE(l1, nullptr);
+    EXPECT_EQ(entities[1].entity_type, 2);
+    EXPECT_EQ(entities[1].entity_instance_num, 63);
+    EXPECT_EQ(entities[1].entity_container_id, 1);
+    EXPECT_EQ(pldm_extract_host_container_id(l1), 0xFFFF);
+
+    auto l2 = pldm_entity_association_tree_add(
+        tree, &entities[2], 37, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    EXPECT_NE(l2, nullptr);
+    EXPECT_EQ(entities[2].entity_type, 3);
+    EXPECT_EQ(entities[2].entity_instance_num, 37);
+    EXPECT_EQ(entities[2].entity_container_id, 1);
+    EXPECT_EQ(pldm_extract_host_container_id(l2), 30);
 
     pldm_pdr_destroy(repo);
     pldm_entity_association_tree_destroy(tree);

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -89,7 +89,7 @@ void FruImpl::buildFRUTable()
 
                     auto node = pldm_entity_association_tree_add(
                         entityTree, &entity, 0xFFFF, parent,
-                        PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+                        PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
                     objToEntityNode[object.first.str] = node;
 
                     auto recordInfos = parser.getRecordInfo(interface.first);


### PR DESCRIPTION
Currently bmc normalizes the entity association PDRs that are sent
by Host, and bmc will generate a new container ID.

Since the new container ID is inconsistent with the container ID sent
by Host, we also need to temporarily save the host_container_id sent
by Host.

Tested: built pldm successfully and Unit Test passes.

Signed-off-by: George Liu <liuxiwei@inspur.com>
Change-Id: Ib564554b191d1ffe2007b831cb22b5cf9b67d57f