### PR TITLE
Fix for "Failed To disable watchdog timerERROR=std::get: wrong index for variant"

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -563,7 +563,7 @@ void pldm::responder::oem_ibm_platform::Handler::disableWatchDogTimer()
     }
     try
     {
-        pldm::utils::DBusHandler().setDbusProperty(dbusMapping, "false");
+        pldm::utils::DBusHandler().setDbusProperty(dbusMapping, false);
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
The Host watchdog timer is started when the BMC is
powered on with a predefined timer interval. BMC
monitors if the Host boots without failures and
Host is supposed to ping the BMC(through
PlatformEventMessages) within the watchdog timer
interval expiration and BMC resets the watchdog
timer on receiving pings from Host and in case
the Host fails to ping the BMC within the timer
interval expiration, then BMC will trigger a host
dump.

This commit is to disable the watchdog timer after
host poweron completion, which will be followed by
surveillance(monitoring of BMC by Host).

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>
Change-Id: I734e6e98f6c2936aebd04c0b56bdfebba4cfd40b

Conflicts:
	oem/ibm/libpldmresponder/oem_ibm_handler.cpp