### PR TITLE
host-bmc: Implemented Enable interface for Core objects

### DIFF
--- a/host-bmc/custom_dbus.cpp
+++ b/host-bmc/custom_dbus.cpp
@@ -82,7 +82,20 @@ void CustomDBus::implementCpuCoreInterface(const std::string& path)
         cpuCore.emplace(
             path, std::make_unique<CoreIntf>(pldm::utils::DBusHandler::getBus(),
                                              path.c_str()));
+        implementObjectEnableIface(path);
     }
 }
+
+void CustomDBus::implementObjectEnableIface(const std::string& path)
+{
+    if (_enabledStatus.find(path) == _enabledStatus.end())
+    {
+        _enabledStatus.emplace(
+            path, std::make_unique<EnableIface>(
+                      pldm::utils::DBusHandler::getBus(), path.c_str()));
+        _enabledStatus.at(path)->enabled(false);
+    }
+}
+
 } // namespace dbus
 } // namespace pldm

--- a/host-bmc/custom_dbus.hpp
+++ b/host-bmc/custom_dbus.hpp
@@ -6,6 +6,7 @@
 #include <xyz/openbmc_project/Inventory/Decorator/LocationCode/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/CpuCore/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/server.hpp>
+#include <xyz/openbmc_project/Object/Enable/server.hpp>
 #include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
 
 #include <map>
@@ -29,6 +30,8 @@ using ItemIntf = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Inventory::server::Item>;
 using CoreIntf = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Inventory::Item::server::CpuCore>;
+using EnableIface = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Object::server::Enable>;
 
 /** @class CustomDBus
  *  @brief This is a custom D-Bus object, used to add D-Bus interface and
@@ -93,8 +96,22 @@ class CustomDBus
 
     /** @brief Implement CpuCore Interface
      *  @param[in] path - The object path
+     *
+     * @note This API will also implement the following interface
+     *       xyz.openbmc_project.Object.Enable::Enabled dbus property
+     *       which is mapped with the "Processor:Enabled" Redfish property
+     *       to do either enable or disable the particular resource
+     *       via Redfish client so the Enabled dbus property needs to host
+     *       in the PLDM created core inventory item object.
      */
     void implementCpuCoreInterface(const std::string& path);
+
+    /**
+     * @brief Implement the xyz.openbmc_project.Object.Enable interface
+     *
+     * @param[in] path - The object path to implement Enable interface
+     */
+    void implementObjectEnableIface(const std::string& path);
 
   private:
     std::map<ObjectPath, std::unique_ptr<LocationIntf>> location;
@@ -104,6 +121,9 @@ class CustomDBus
 
     std::unordered_map<ObjectPath, std::unique_ptr<ItemIntf>> presentStatus;
     std::unordered_map<ObjectPath, std::unique_ptr<CoreIntf>> cpuCore;
+
+    /** @brief Used to hold the objects which will contain EnableIface */
+    std::unordered_map<ObjectPath, std::unique_ptr<EnableIface>> _enabledStatus;
 };
 
 } // namespace dbus


### PR DESCRIPTION
- Upstream Gerrit [link](https://gerrit.openbmc-project.xyz/c/openbmc/pldm/+/46229) for the same patch