### PR TITLE
Fix the looping behaviour in the getstatesensorreading command

### DIFF
--- a/common/types.hpp
+++ b/common/types.hpp
@@ -48,7 +48,8 @@ using PossibleStates = std::set<uint8_t>;
 //!< composite efffecter/sensor
 using CompositeSensorStates = std::vector<PossibleStates>;
 using EntityInfo = std::tuple<ContainerID, EntityType, EntityInstance>;
-using SensorInfo = std::tuple<EntityInfo, CompositeSensorStates>;
+using SensorInfo =
+    std::tuple<EntityInfo, CompositeSensorStates, std::vector<StateSetId>>;
 
 } // namespace pdr
 

--- a/libpldmresponder/pdr_utils.cpp
+++ b/libpldmresponder/pdr_utils.cpp
@@ -150,6 +150,7 @@ std::tuple<TerminusHandle, SensorID, SensorInfo>
     CompositeSensorStates sensors{};
     auto statesPtr = pdr->possible_states;
     auto compositeSensorCount = pdr->composite_sensor_count;
+    std::vector<StateSetId> stateSetIds{};
 
     while (compositeSensorCount--)
     {
@@ -173,6 +174,8 @@ std::tuple<TerminusHandle, SensorID, SensorInfo>
                       updateStates);
 
         sensors.emplace_back(std::move(possibleStates));
+        stateSetIds.emplace_back(state->state_set_id);
+
         if (compositeSensorCount)
         {
             statesPtr += sizeof(state_sensor_possible_states) +
@@ -184,8 +187,8 @@ std::tuple<TerminusHandle, SensorID, SensorInfo>
         std::make_tuple(static_cast<ContainerID>(pdr->container_id),
                         static_cast<EntityType>(pdr->entity_type),
                         static_cast<EntityInstance>(pdr->entity_instance));
-    auto sensorInfo =
-        std::make_tuple(std::move(entityInfo), std::move(sensors));
+    auto sensorInfo = std::make_tuple(std::move(entityInfo), std::move(sensors),
+                                      std::move(stateSetIds));
     return std::make_tuple(pdr->terminus_handle, pdr->sensor_id,
                            std::move(sensorInfo));
 }

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -409,10 +409,11 @@ int Handler::sensorEvent(const pldm_msg* request, size_t payloadLength,
 
         pldm::pdr::EntityInfo entityInfo{};
         pldm::pdr::CompositeSensorStates compositeSensorStates{};
+        std::vector<pldm::pdr::StateSetId> stateSetIds{};
 
         try
         {
-            std::tie(entityInfo, compositeSensorStates) =
+            std::tie(entityInfo, compositeSensorStates, stateSetIds) =
                 hostPDRHandler->lookupSensorInfo(sensorEntry);
         }
         catch (const std::out_of_range& e)
@@ -423,7 +424,7 @@ int Handler::sensorEvent(const pldm_msg* request, size_t payloadLength,
             try
             {
                 sensorEntry.terminusID = PLDM_TID_RESERVED;
-                std::tie(entityInfo, compositeSensorStates) =
+                std::tie(entityInfo, compositeSensorStates, stateSetIds) =
                     hostPDRHandler->lookupSensorInfo(sensorEntry);
             }
             // If there is no mapping for events return PLDM_SUCCESS


### PR DESCRIPTION
This bug was actually caused by two host sensors that has the
exact same entity id, instance id, container id but being used
to implement different state sets.

The old host code had two sensors on processor module that implements
both stateset 1 & 11 that caused this regression and using this PR we
have improved the sensor parsing abilities so that we can compare the
state setId as well before deciding that a sensor is unique.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>