### PR TITLE
Fix for discovering the HostState

### DIFF
--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -268,10 +268,6 @@ int main(int argc, char** argv)
     sdbusplus::xyz::openbmc_project::PLDM::server::Event dbusImplEvent(
         bus, "/xyz/openbmc_project/pldm");
 
-    if (hostPDRHandler)
-    {
-        hostPDRHandler->setHostFirmwareCondition();
-    }
 #endif
 
     pldm::utils::CustomFD socketFd(sockfd);
@@ -397,7 +393,12 @@ int main(int argc, char** argv)
     bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
     bus.request_name("xyz.openbmc_project.PLDM");
     IO io(event, socketFd(), EPOLLIN, std::move(callback));
-
+#ifdef LIBPLDMRESPONDER
+    if (hostPDRHandler)
+    {
+        hostPDRHandler->setHostFirmwareCondition();
+    }
+#endif
     stdplus::signal::block(SIGUSR1);
     Signal(event, SIGUSR1, interruptFlightRecorderCallBack).set_floating(true);
     event.loop();


### PR DESCRIPTION
- 20aa3e09fb866c1b99c1d3d702f2a2f1908558af commit moved the
  setHostFirmwarecondition() function call prior to the code
  that connects to the mctp socket.

- That led us to fail in sending the message with ENOTCONN Errno,
  as demonstrated by the below strace log.
```
------
23:16:50.596833 connect(3, {sa_family=AF_UNIX, sun_path=@"mctp-mux"}, 11) = 0

Change-Id: Icd3a20e4bb0218517d44d14a57c0407c7b7702e2
---
23:16:50.593800 sendmsg(3, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base="\t\1",
 iov_len=2}, {iov_base="\200\0\3\0\0\0\0\1\0", iov_len=9}], msg_iovlen=2, msg_controllen=0,
 msg_flags=0}, 0) = -1 ENOTCONN
-----
```
- Without this change , we would get ENOTCONN(107 errono) for the
  getPLDMVersion command that pldm sends at the beginning to discover the
  host state.

tested by:
1. when the host is off :
Response not received for the request, instance ID expired. EID = 9 INSTANCE_ID = 0 TYPE = 0 COMMAND = 3
Failed to receive a response for getPLDMVersion command, Host seems to be off

2. when host is Running :
Sending Msg
80 00 03 00 00 00 00 01 00
Received Msg
09 01 00 00 03 00 00 00 00 00 05 f1 f1 f0 00
Getting the response. PLDM RC = 0

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
Change-Id: I5c7c3bc92c8654016db90855de49b7c30f161275