### PR TITLE
PLDM : Temporary fix in the pldmRepoChangeEvent

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -521,6 +521,11 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                 }
             }
 
+            if (eventDataOperation == PLDM_RECORDS_MODIFIED)
+            {
+                return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+            }
+
             changeRecordData +=
                 dataOffset + (numberOfChangeEntries * sizeof(ChangeEntry));
             changeRecordDataSize -=


### PR DESCRIPTION
This commit fixes the unsupported eventDataOperation
in the pldmRepoChangeEvent handler. This unsupported
operation was causing a interleaved recordHandles of
PDRs from the host.

Tested: Using pldmtool, no looping of PDRs was observed.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>
Change-Id: I94fbab0107deefe5d6d2accdc640cf3f86aee8ad