### PR TITLE
oem-ibm: Resource dump related fixes

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -115,23 +115,6 @@ int DumpHandler::newFileAvailable(uint64_t length)
     {
         // Setting the Notify path for resource dump
         notifyObjPath = resDumpObjPath;
-
-        uint32_t sourceDumpId = fileHandle;
-        auto path = findDumpObjPath(fileHandle);
-
-        pldm::utils::PropertyValue propValue{sourceDumpId};
-
-        DBusMapping dbusMapping{path, resDumpEntry, "SourceDumpId", "uint32_t"};
-        try
-        {
-            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, propValue);
-        }
-        catch (const std::exception& e)
-        {
-            std::cerr << "failed to make a d-bus call to DUMP manager to set "
-                         "resource dump SourceDumpId, ERROR="
-                      << e.what() << "\n";
-        }
     }
 
     try

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -113,28 +113,6 @@ void DbusToFileHandler::reportResourceDumpFailure()
 void DbusToFileHandler::processNewResourceDump(
     const std::string& vspString, const std::string& resDumpReqPass)
 {
-    // This needs special handling in later point of time. Resource dump without
-    // the vsp string is supposed to be a non-disruptive system dump.
-    if (vspString.empty())
-    {
-        std::cerr << "Empty vsp string"
-                  << "\n";
-        PropertyValue value{resDumpStatus};
-        DBusMapping dbusMapping{resDumpCurrentObjPath, resDumpProgressIntf,
-                                "Status", "string"};
-        try
-        {
-            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
-        }
-        catch (const std::exception& e)
-        {
-            std::cerr << "failed to set resource dump operation status, "
-                         "ERROR="
-                      << e.what() << "\n";
-        }
-        return;
-    }
-
     namespace fs = std::filesystem;
     const fs::path resDumpDirPath = "/var/lib/pldm/resourcedump";
 


### PR DESCRIPTION
This commit include following changes:

1. Allow the empty string as resource dump selector
2. Avoid setting the resource dump dump explicitly as notify method
   takes care of the same. This code was causing error when the
   resource dump is getting initiated from host

Tested and verified that resource dump initiation from host is
getting completed without any error.

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I58f51cb115d86ae22099d57474a1159d8952cefa