### PR TITLE
oem_ibm:Add Slot enable infrastructure in BMC

### DIFF
--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -43,6 +43,7 @@ if get_option('oem-ibm').enabled()
     '../oem/ibm/libpldmresponder/fru_oem_ibm.cpp',
     '../oem/ibm/libpldmresponder/oem_ibm_handler.cpp',
     '../oem/ibm/libpldmresponder/inband_code_update.cpp',
+    '../oem/ibm/libpldmresponder/collect_slot_vpd.cpp',
     '../oem/ibm/requester/dbus_to_file_handler.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_progress_src.cpp',
   ]

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -41,8 +41,9 @@ class Handler : public CmdHandler
     virtual int getOemStateSensorReadingsHandler(
         pldm::pdr::EntityType entityType,
         pldm::pdr::EntityInstance entityInstance,
+        pldm::pdr::ContainerID entityContainerId,
         pldm::pdr::StateSetId stateSetId,
-        pldm::pdr::CompositeCount compSensorCnt,
+        pldm::pdr::CompositeCount compSensorCnt, uint16_t sensorId,
         std::vector<get_sensor_state_field>& stateField) = 0;
 
     /** @brief Interface to set the effecter requested by pldm requester

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -645,13 +645,15 @@ Response Handler::getStateSensorReadings(const pldm_msg* request,
     uint16_t entityType{};
     uint16_t entityInstance{};
     uint16_t stateSetId{};
+    uint16_t containerId{};
 
     if (isOemStateSensor(*this, sensorId, sensorRearmCount, comSensorCnt,
-                         entityType, entityInstance, stateSetId) &&
+                         entityType, entityInstance, stateSetId, containerId) &&
         oemPlatformHandler != nullptr)
     {
         rc = oemPlatformHandler->getOemStateSensorReadingsHandler(
-            entityType, entityInstance, stateSetId, comSensorCnt, stateField);
+            entityType, entityInstance, containerId, stateSetId, comSensorCnt,
+            sensorId, stateField);
     }
     else
     {
@@ -691,7 +693,7 @@ void Handler::_processPostGetPDRActions(
 bool isOemStateSensor(Handler& handler, uint16_t sensorId,
                       uint8_t sensorRearmCount, uint8_t& compSensorCnt,
                       uint16_t& entityType, uint16_t& entityInstance,
-                      uint16_t& stateSetId)
+                      uint16_t& stateSetId, uint16_t& containerId)
 {
     pldm_state_sensor_pdr* pdr = nullptr;
 
@@ -719,6 +721,7 @@ bool isOemStateSensor(Handler& handler, uint16_t sensorId,
         }
         auto tmpEntityType = pdr->entity_type;
         auto tmpEntityInstance = pdr->entity_instance;
+        auto tmpEntityContainerId = pdr->container_id;
         auto tmpCompSensorCnt = pdr->composite_sensor_count;
         auto tmpPossibleStates =
             reinterpret_cast<state_sensor_possible_states*>(
@@ -743,6 +746,7 @@ bool isOemStateSensor(Handler& handler, uint16_t sensorId,
             entityInstance = tmpEntityInstance;
             stateSetId = tmpStateSetId;
             compSensorCnt = tmpCompSensorCnt;
+            containerId = tmpEntityContainerId;
             return true;
         }
         else

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -481,7 +481,7 @@ class Handler : public CmdHandler
 bool isOemStateSensor(Handler& handler, uint16_t sensorId,
                       uint8_t sensorRearmCount, uint8_t& compSensorCnt,
                       uint16_t& entityType, uint16_t& entityInstance,
-                      uint16_t& stateSetId);
+                      uint16_t& stateSetId, uint16_t& containerId);
 
 /** @brief Function to check if an effecter falls in OEM range
  *         An effecter is considered to be oem if either of entity

--- a/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
+++ b/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
@@ -1,0 +1,338 @@
+#include "collect_slot_vpd.hpp"
+
+#include "oem_ibm_handler.hpp"
+#include "xyz/openbmc_project/Common/error.hpp"
+
+namespace pldm
+{
+
+namespace responder
+{
+using namespace oem_ibm_platform;
+void SlotHandler::timeOutHandler()
+{
+    std::cerr << "Timer expired waiting for Event from Inventory" << std::endl;
+
+    // Disable the timer
+    timer.setEnabled(false);
+
+    // obtain the sensor Id
+    auto sensorId = pldm::utils::findStateSensorId(
+        pdrRepo, 0, PLDM_ENTITY_SLOT,
+        current_on_going_slot_entity.entity_instance_num,
+        current_on_going_slot_entity.entity_container_id,
+        PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE);
+
+    std::cerr << "sensor id for sending event : " << (unsigned)sensorId
+              << std::endl;
+    // send the sensor event to host with error state
+    sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
+                         uint8_t(SlotEnableSensorState::SLOT_STATE_ERROR),
+                         uint8_t(SlotEnableSensorState::SLOT_STATE_UNKOWN));
+}
+
+void SlotHandler::enableSlot(uint16_t effecterId,
+                             const AssociatedEntityMap& fruAssociationMap,
+                             uint8_t stateFileValue)
+
+{
+    std::cerr << (unsigned)effecterId << std::endl;
+    const pldm_entity entity = getEntityIDfromEffecterID(effecterId);
+
+    for (const auto& [key, value] : fruAssociationMap)
+    {
+        if (entity.entity_instance_num == value.entity_instance_num &&
+            entity.entity_type == value.entity_type &&
+            entity.entity_container_id == value.entity_container_id)
+        {
+            std::cerr << key << std::endl;
+            std::cerr << (unsigned)value.entity_type << std::endl;
+            std::cerr << (unsigned)value.entity_instance_num << std::endl;
+            this->current_on_going_slot_entity.entity_type = value.entity_type;
+            this->current_on_going_slot_entity.entity_instance_num =
+                value.entity_instance_num;
+            this->current_on_going_slot_entity.entity_container_id =
+                value.entity_container_id;
+            std::cerr << "current entity type : "
+                      << current_on_going_slot_entity.entity_type << std::endl;
+            std::cerr << "current entity instance num :"
+                      << current_on_going_slot_entity.entity_instance_num
+                      << std::endl;
+            std::cerr << "current container id : "
+                      << current_on_going_slot_entity.entity_container_id
+                      << std::endl;
+            processSlotOperations(key, value, stateFileValue);
+        }
+    }
+
+    std::cerr << "Entered the enable Slot" << std::endl;
+    //  timer.restart(std::chrono::seconds(5));
+}
+
+void SlotHandler::processSlotOperations(const std::string& slotObjectPath,
+                                        const pldm_entity& entity,
+                                        uint8_t stateFiledValue)
+{
+    std::cerr << "entered process slot operations" << std::endl;
+
+    std::string adapterObjPath;
+    try
+    {
+        // get the adapter dbus object path from the slot dbus object path
+        adapterObjPath = getAdapterObjPath(slotObjectPath).value();
+    }
+    catch (const std::bad_optional_access& e)
+    {
+        std::cerr << e.what() << '\n';
+        return;
+    }
+
+    // create a presence match for the adpter present property
+    createPresenceMatch(adapterObjPath, entity, stateFiledValue);
+
+    // call the VPD Manager to collect/remove VPD objects
+    callVPDManager(adapterObjPath, stateFiledValue);
+
+    // start the 1 min timer
+    timer.restart(std::chrono::seconds(60));
+}
+
+void SlotHandler::callVPDManager(const std::string& adapterObjPath,
+                                 uint8_t stateFiledValue)
+{
+    static constexpr auto VPDObjPath = "/com/ibm/VPD/Manager";
+    static constexpr auto VPDInterface = "com.ibm.VPD.Manager";
+    auto& bus = pldm::utils::DBusHandler::getBus();
+    try
+    {
+        auto service =
+            pldm::utils::DBusHandler().getService(VPDObjPath, VPDInterface);
+        if (stateFiledValue == uint8_t(SlotEnableEffecterState::ADD))
+        {
+            auto method = bus.new_method_call(service.c_str(), VPDObjPath,
+                                              VPDInterface, "CollectFRUVPD");
+            method.append(
+                static_cast<sdbusplus::message::object_path>(adapterObjPath));
+            bus.call_noreply(method);
+        }
+        else if (stateFiledValue == uint8_t(SlotEnableEffecterState::REMOVE) ||
+                 stateFiledValue == uint8_t(SlotEnableEffecterState::REPLACE))
+        {
+            auto method = bus.new_method_call(service.c_str(), VPDObjPath,
+                                              VPDInterface, "deleteFRUVPD");
+            method.append(
+                static_cast<sdbusplus::message::object_path>(adapterObjPath));
+            bus.call_noreply(method);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "failed to make a d-bus call to VPD Manager , Operation ="
+                  << (unsigned)stateFiledValue << ", ERROR=" << e.what()
+                  << "\n";
+    }
+}
+
+std::optional<std::string>
+    SlotHandler::getAdapterObjPath(const std::string& slotObjPath)
+{
+    static constexpr auto searchpath = "/xyz/openbmc_project/inventory";
+    int depth = 0;
+    std::vector<std::string> pcieAdapterInterface = {
+        "xyz.openbmc_project.Inventory.Item.PCIeDevice"};
+    pldm::utils::MapperGetSubTreeResponse response =
+        pldm::utils::DBusHandler().getSubtree(searchpath, depth,
+                                              pcieAdapterInterface);
+    for (const auto& [objPath, serviceMap] : response)
+    {
+        // An adapter is a child of a PCIe Slot Object
+        if (objPath.find(slotObjPath) != std::string::npos)
+        {
+            // Found the Adapter under the slot
+            return objPath;
+        }
+    }
+    return std::nullopt;
+}
+
+void SlotHandler::createPresenceMatch(const std::string& adapterObjectPath,
+                                      const pldm_entity& entity,
+                                      uint8_t stateFieldValue)
+{
+
+    std::cerr << "Create presence match for present property under"
+              << adapterObjectPath << std::endl;
+    fruPresenceMatch = std::make_unique<sdbusplus::bus::match::match>(
+        pldm::utils::DBusHandler::getBus(),
+        propertiesChanged(adapterObjectPath,
+                          "xyz.openbmc_project.Inventory.Item"),
+        [this, adapterObjectPath, stateFieldValue,
+         entity](sdbusplus::message::message& msg) {
+            pldm::utils::DbusChangedProps props{};
+            std::string intf;
+            msg.read(intf, props);
+            const auto itr = props.find("Present");
+            if (itr != props.end())
+            {
+                bool value = std::get<bool>(itr->second);
+                // Present Property is found
+                this->processPropertyChangeFromVPD(value, adapterObjectPath,
+                                                   stateFieldValue, entity);
+            }
+        });
+}
+
+void SlotHandler::processPropertyChangeFromVPD(
+    bool presentValue, const std::string& /*adapterObjectPath*/,
+    uint8_t stateFiledvalue, const pldm_entity& entity)
+{
+    // irrespective of true->false or false->true change, we should stop the
+    // timer
+    timer.setEnabled(false);
+
+    // remove the prence match so that it does not monitor the change
+    // even after we captured the property changed signal
+    fruPresenceMatch = nullptr;
+
+    // obtain the sensor id attached with this slot
+    auto sensorId = pldm::utils::findStateSensorId(
+        pdrRepo, 0, PLDM_ENTITY_SLOT, entity.entity_instance_num,
+        entity.entity_container_id, PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE);
+
+    uint8_t sensorOpState = uint8_t(SlotEnableSensorState::SLOT_STATE_UNKOWN);
+    if (presentValue)
+    {
+        sensorOpState = uint8_t(SlotEnableSensorState::SLOT_STATE_ENABLED);
+    }
+    else
+    {
+        if (stateFiledvalue == uint8_t(SlotEnableEffecterState::REPLACE))
+        {
+            sensorOpState = uint8_t(SlotEnableSensorState::SLOT_STATE_UNKOWN);
+        }
+        else
+        {
+            sensorOpState = uint8_t(SlotEnableSensorState::SLOT_STATE_DISABLED);
+        }
+    }
+    // set the sensor state based on the stateFieldValue
+    this->sendStateSensorEvent(
+        sensorId, PLDM_STATE_SENSOR_STATE, 0, sensorOpState,
+        uint8_t(SlotEnableSensorState::SLOT_STATE_UNKOWN));
+}
+
+pldm_entity SlotHandler::getEntityIDfromEffecterID(uint16_t effecterId)
+{
+    pldm_entity parentfruentity{};
+    uint8_t* pdrData = nullptr;
+    uint32_t pdrSize{};
+    const pldm_pdr_record* record{};
+    do
+    {
+        record = pldm_pdr_find_record_by_type(pdrRepo, PLDM_STATE_EFFECTER_PDR,
+                                              record, &pdrData, &pdrSize);
+        if (record && (true ^ pldm_pdr_record_is_remote(record)))
+        {
+            auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(pdrData);
+            auto compositeEffecterCount = pdr->composite_effecter_count;
+            auto possible_states_start = pdr->possible_states;
+
+            for (auto effecters = 0x00; effecters < compositeEffecterCount;
+                 effecters++)
+            {
+
+                auto possibleStates =
+                    reinterpret_cast<state_effecter_possible_states*>(
+                        possible_states_start);
+
+                if (possibleStates->state_set_id ==
+                        PLDM_OEM_IBM_SLOT_ENABLE_EFFECTER_STATE &&
+                    effecterId == pdr->effecter_id)
+                {
+                    parentfruentity.entity_type = pdr->entity_type;
+                    parentfruentity.entity_instance_num = pdr->entity_instance;
+                    parentfruentity.entity_container_id = pdr->container_id;
+
+                    return parentfruentity;
+                }
+            }
+        }
+    } while (record);
+
+    return parentfruentity;
+}
+
+uint8_t SlotHandler::fetchSlotSensorState(const std::string& slotObjectPath)
+{
+    std::string adapterObjPath;
+    uint8_t sensorOpState = uint8_t(SlotEnableSensorState::SLOT_STATE_UNKOWN);
+
+    try
+    {
+        // get the adapter dbus object path from the slot dbus object path
+        adapterObjPath = getAdapterObjPath(slotObjectPath).value();
+    }
+    catch (const std::bad_optional_access& e)
+    {
+        std::cerr << e.what() << '\n';
+        return uint8_t(SlotEnableSensorState::SLOT_STATE_UNKOWN);
+    }
+
+    if (fetchSensorStateFromDbus(adapterObjPath))
+    {
+        sensorOpState = uint8_t(SlotEnableSensorState::SLOT_STATE_ENABLED);
+    }
+    else
+    {
+        sensorOpState = uint8_t(SlotEnableSensorState::SLOT_STATE_DISABLED);
+    }
+    return sensorOpState;
+}
+
+void SlotHandler::setOemPlatformHandler(
+    pldm::responder::oem_platform::Handler* handler)
+{
+    oemPlatformHandler = handler;
+}
+
+void SlotHandler::sendStateSensorEvent(
+    uint16_t sensorId, enum sensor_event_class_states sensorEventClass,
+    uint8_t sensorOffset, uint8_t eventState, uint8_t prevEventState)
+{
+    pldm::responder::oem_ibm_platform::Handler* oemIbmPlatformHandler =
+        dynamic_cast<pldm::responder::oem_ibm_platform::Handler*>(
+            oemPlatformHandler);
+    oemIbmPlatformHandler->sendStateSensorEvent(
+        sensorId, sensorEventClass, sensorOffset, eventState, prevEventState);
+}
+
+bool SlotHandler::fetchSensorStateFromDbus(const std::string& adapterObjectPath)
+{
+    std::cerr << "fetch sensor state from dbus" << std::endl;
+
+    std::variant<bool> presentProperty{};
+    auto& bus = pldm::utils::DBusHandler::getBus();
+
+    try
+    {
+        auto service = pldm::utils::DBusHandler().getService(
+            adapterObjectPath.c_str(), ItemInterface);
+        auto method =
+            bus.new_method_call(service.c_str(), adapterObjectPath.c_str(),
+                                FreedesktopInterface, GetMethod);
+        method.append(ItemInterface, PresentProperty);
+        auto reply = bus.call(method);
+        reply.read(presentProperty);
+        return std::get<bool>(presentProperty);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "failed to make a d-bus call to Inventory manager, ERROR="
+                  << e.what() << "\n";
+    }
+
+    return false;
+}
+
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/collect_slot_vpd.hpp
+++ b/oem/ibm/libpldmresponder/collect_slot_vpd.hpp
@@ -1,0 +1,177 @@
+#pragma once
+
+#include "libpldmresponder/platform.hpp"
+
+#include <libpldm/pdr.h>
+#include <libpldm/platform.h>
+
+#include <sdbusplus/bus/match.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/utility/timer.hpp>
+
+#include <memory>
+
+namespace pldm
+{
+
+using namespace sdbusplus::bus::match::rules;
+
+namespace responder
+{
+
+using ObjectPath = std::string;
+using AssociatedEntityMap = std::map<ObjectPath, pldm_entity>;
+
+static constexpr auto FreedesktopInterface = "org.freedesktop.DBus.Properties";
+static constexpr auto PresentProperty = "Present";
+static constexpr auto GetMethod = "Get";
+static constexpr auto ItemInterface = "xyz.openbmc_project.Inventory.Item";
+
+/** @class SlotHandler
+ *
+ *  @brief This class performs the necessary operation in pldm for
+ *         Slot Enable operation. That includes taking actions on the
+ *         setStateEffecterStates calls from Host and also sending
+ *         notification to inventory manager application
+ */
+class SlotHandler
+{
+  public:
+    SlotHandler() = delete;
+    ~SlotHandler() = default;
+    SlotHandler(const SlotHandler&) = delete;
+    SlotHandler& operator=(const SlotHandler&) = delete;
+    SlotHandler(SlotHandler&&) = default;
+    SlotHandler& operator=(SlotHandler&&) = default;
+
+    /** @brief Constructors the slot enable object
+     *
+     * @param[in] event - reference for the main event loop
+     * @param[in] repo - pointer to the BMC's Primary PDR repo
+     *
+     */
+    SlotHandler(const sdeventplus::Event& event, pldm_pdr* repo) :
+        timer(event,
+              std::bind(std::mem_fn(&SlotHandler::timeOutHandler), this)),
+        pdrRepo(repo)
+    {
+        fruPresenceMatch = nullptr;
+        current_on_going_slot_entity.entity_type = 0;
+        current_on_going_slot_entity.entity_instance_num = 0;
+        current_on_going_slot_entity.entity_container_id = 0;
+    }
+
+    /** @brief Method to be called when enabling a Slot for ADD/REMOVE/REPLACE
+     *  @param[in] effecterID - The effecter ID of the effecter that is set from
+     * host
+     *  @param[in] fruAssociationMap - the dbus path to pldm entity stored while
+     * creating the pldm fru records
+     *  @param[in] stateFieldValue - the current Effecter stateFieldValue
+     */
+    void enableSlot(uint16_t effecterId,
+                    const AssociatedEntityMap& fruAssociationMap,
+                    uint8_t stateFiledValue);
+
+    /** @brief Method to used for fetching the slot sensor value
+     *  @param[in] slotObjectPath - the dbus object path for slot object
+     *  @return - returns the sensor state for the respective slot sensor
+     */
+    uint8_t fetchSlotSensorState(const std::string& slotObjectPath);
+
+    /** @brief Method to set the oem platform handler in CodeUpdate class */
+    void setOemPlatformHandler(pldm::responder::oem_platform::Handler* handler);
+
+  private:
+    /** @brief call back method called when the timer is expired
+     */
+    void timeOutHandler();
+
+    /** @brief Abstracted method for obtaining the entityID from effecterID
+     *  @param[in]  effecterID - The effecterID of the BMC effeter
+     *  @return - reutrn the pldm entity ID for the given effecter ID
+     */
+    pldm_entity getEntityIDfromEffecterID(uint16_t effecterID);
+
+    /** @brief Abstracted method for processing the Slot Operations
+     *  @param[in] slotObjPath - The slot dbus object path
+     *  @param[in] entity - the current slot pldm entity under operation
+     *  @param[in] stateFieldValue - the current Effecter stateFieldValue
+     */
+    void processSlotOperations(const std::string& slotObjectPath,
+                               const pldm_entity& entity,
+                               uint8_t stateFieldValue);
+
+    /** @brief Method to obtain the Adapter dbus Object Path from Slot Adapter
+     * path
+     *  @param[in] slotObjPath - The slot dbus object path
+     *  @return - if Successfull, returns the adapter dbus object path
+     */
+    std::optional<std::string>
+        getAdapterObjPath(const std::string& slotObjPath);
+
+    /** @brief Method to call VPD collection & VPD removal API's
+     *  @param[in] adapterObjectPath - The adapter dbus object path
+     *  @param[in] stateFieldvalue - The current stateField value from set
+     * Effecter call
+     */
+    void callVPDManager(const std::string& adapterObjPath,
+                        uint8_t stateFiledValue);
+
+    /** @brief Method to create a matcher to catch the property change signal
+     *  @param[in] adapterObjectPath - The adapter dbus object path
+     *  @param[in] stateFieldvalue - The current stateField value from set
+     * Effecter call
+     *  @param[in] entity - the current slot pldm entity under operation
+     */
+    void createPresenceMatch(const std::string& adapterObjectPath,
+                             const pldm_entity& entity,
+                             uint8_t stateFieldValue);
+
+    /** @brief Method to process the Property change signal from Preset Property
+     *  @param[in] presentValue - The current value of present Value
+     *  @param[in] adapterObjectPath - The adapter dbus object path
+     *  @param[in] stateFieldvalue - The current stateField value from set
+     * Effecter call
+     *  @param[in] entity - the current slot pldm entity under operation
+     */
+    void processPropertyChangeFromVPD(bool presentValue,
+                                      const std::string& adapterObjectPath,
+                                      uint8_t stateFieldvalue,
+                                      const pldm_entity& entity);
+
+    /** @brief Method to find the Present State from DBUS
+     *  @param[in] adapterObjectPath - reference of the Adapter dbus object path
+     */
+
+    bool fetchSensorStateFromDbus(const std::string& adapterObjectPath);
+
+    /* @brief Method to send a state sensor event to Host from SlotHandler class
+     * @param[in] sensorId - sensor id for the event
+     * @param[in] sensorEventClass - sensor event class wrt DSP0248
+     * @param[in] sensorOffset - sensor offset
+     * @param[in] eventState - new event state
+     * @param[in] prevEventState - previous state
+     */
+    void sendStateSensorEvent(uint16_t sensorId,
+                              enum sensor_event_class_states sensorEventClass,
+                              uint8_t sensorOffset, uint8_t eventState,
+                              uint8_t prevEventState);
+
+    pldm::responder::oem_platform::Handler*
+        oemPlatformHandler; //!< oem platform handler
+
+    /** @brief pointer to tha matcher for Present State for adapter object*/
+    std::unique_ptr<sdbusplus::bus::match::match> fruPresenceMatch;
+
+    /** @brief Timer used for Slot VPD Collection Operetation */
+    sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
+
+    /** @brief pointer to BMC's primary PDR repo */
+    const pldm_pdr* pdrRepo;
+
+    /** @brief variable to store the current slot entity under operation */
+    pldm_entity current_on_going_slot_entity;
+};
+
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -3,6 +3,7 @@
 #include "libpldm/entity.h"
 #include "libpldm/requester/pldm.h"
 
+#include "collect_slot_vpd.hpp"
 #include "file_io_type_lid.hpp"
 #include "libpldmresponder/file_io.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
@@ -20,9 +21,11 @@ namespace oem_ibm_platform
 int pldm::responder::oem_ibm_platform::Handler::
     getOemStateSensorReadingsHandler(
         EntityType entityType, EntityInstance entityInstance,
-        StateSetId stateSetId, CompositeCount compSensorCnt,
+        ContainerID containerId, StateSetId stateSetId,
+        CompositeCount compSensorCnt, uint16_t /*sensorId*/,
         std::vector<get_sensor_state_field>& stateField)
 {
+    auto& entityAssociationMap = getAssociateEntityMap();
     int rc = PLDM_SUCCESS;
     stateField.clear();
 
@@ -33,6 +36,20 @@ int pldm::responder::oem_ibm_platform::Handler::
             stateSetId == PLDM_OEM_IBM_BOOT_STATE)
         {
             sensorOpState = fetchBootSide(entityInstance, codeUpdate);
+        }
+        else if (entityType == PLDM_ENTITY_SLOT &&
+                 stateSetId == PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE)
+        {
+            for (const auto& [key, value] : entityAssociationMap)
+            {
+                if (value.entity_type == entityType &&
+                    value.entity_instance_num == entityInstance &&
+                    value.entity_container_id == containerId)
+                {
+                    sensorOpState = slotHandler->fetchSlotSensorState(key);
+                    break;
+                }
+            }
         }
         else
         {
@@ -49,10 +66,10 @@ int pldm::responder::oem_ibm_platform::Handler::
     oemSetStateEffecterStatesHandler(
         uint16_t entityType, uint16_t entityInstance, uint16_t stateSetId,
         uint8_t compEffecterCnt,
-        std::vector<set_effecter_state_field>& stateField,
-        uint16_t /*effecterId*/)
+        std::vector<set_effecter_state_field>& stateField, uint16_t effecterId)
 {
     int rc = PLDM_SUCCESS;
+    auto& entityAssociationMap = getAssociateEntityMap();
 
     for (uint8_t currState = 0; currState < compEffecterCnt; ++currState)
     {
@@ -137,6 +154,12 @@ int pldm::responder::oem_ibm_platform::Handler::
                                       this, std::placeholders::_1));
                 }
             }
+            else if (stateSetId == PLDM_OEM_IBM_SLOT_ENABLE_EFFECTER_STATE)
+            {
+                std::cerr << "Effecter id : " << effecterId << std::endl;
+                slotHandler->enableSlot(effecterId, entityAssociationMap,
+                                        stateField[currState].effecter_state);
+            }
             else
             {
                 rc = PLDM_PLATFORM_SET_EFFECTER_UNSUPPORTED_SENSORSTATE;
@@ -201,6 +224,72 @@ void buildAllCodeUpdateEffecterPDR(oem_ibm_platform::Handler* platformHandler,
     repo.addRecord(pdrEntry);
 }
 
+void buildAllSlotEnabeEffecterPDR(oem_ibm_platform::Handler* platformHandler,
+                                  pdr_utils::Repo& repo,
+                                  const std::vector<std::string>& slotobjpaths)
+{
+    size_t pdrSize = 0;
+    pdrSize = sizeof(pldm_state_effecter_pdr) +
+              sizeof(state_effecter_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_effecter_pdr* pdr =
+        reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
+    if (!pdr)
+    {
+        std::cerr << "Failed to get record by PDR type, ERROR:"
+                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        return;
+    }
+
+    auto& associatedEntityMap = platformHandler->getAssociateEntityMap();
+    for (const auto& entity_path : slotobjpaths)
+    {
+        pdr->hdr.record_handle = 0;
+        pdr->hdr.version = 1;
+        pdr->hdr.type = PLDM_STATE_EFFECTER_PDR;
+        pdr->hdr.record_change_num = 0;
+        pdr->hdr.length =
+            sizeof(pldm_state_effecter_pdr) - sizeof(pldm_pdr_hdr);
+        pdr->terminus_handle = pdr::BmcPldmTerminusHandle;
+        pdr->effecter_id = platformHandler->getNextEffecterId();
+
+        if (entity_path != "" &&
+            associatedEntityMap.find(entity_path) != associatedEntityMap.end())
+        {
+            pdr->entity_type = associatedEntityMap.at(entity_path).entity_type;
+            pdr->entity_instance =
+                associatedEntityMap.at(entity_path).entity_instance_num;
+            pdr->container_id =
+                associatedEntityMap.at(entity_path).entity_container_id;
+            platformHandler->effecterIdToDbusMap[pdr->effecter_id] =
+                entity_path;
+        }
+        else
+        {
+            // the slots are not present, dont create the PDR
+            continue;
+        }
+        pdr->effecter_semantic_id = 0;
+        pdr->effecter_init = PLDM_NO_INIT;
+        pdr->has_description_pdr = false;
+        pdr->composite_effecter_count = 1;
+
+        auto* possibleStatesPtr = pdr->possible_states;
+        auto possibleStates = reinterpret_cast<state_effecter_possible_states*>(
+            possibleStatesPtr);
+        possibleStates->state_set_id = PLDM_OEM_IBM_SLOT_ENABLE_EFFECTER_STATE;
+        possibleStates->possible_states_size = 2;
+        auto state =
+            reinterpret_cast<state_effecter_possible_states*>(possibleStates);
+        state->states[0].byte = 7;
+        pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+        pdrEntry.data = entry.data();
+        pdrEntry.size = pdrSize;
+        repo.addRecord(pdrEntry);
+    }
+}
+
 void buildAllCodeUpdateSensorPDR(oem_ibm_platform::Handler* platformHandler,
                                  uint16_t entityType, uint16_t entityInstance,
                                  uint16_t stateSetID, pdr_utils::Repo& repo)
@@ -250,6 +339,67 @@ void buildAllCodeUpdateSensorPDR(oem_ibm_platform::Handler* platformHandler,
     repo.addRecord(pdrEntry);
 }
 
+void buildAllSlotEnableSensorPDR(oem_ibm_platform::Handler* platformHandler,
+                                 pdr_utils::Repo& repo,
+                                 const std::vector<std::string>& slotobjpaths)
+{
+    size_t pdrSize = 0;
+    pdrSize =
+        sizeof(pldm_state_sensor_pdr) + sizeof(state_sensor_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_sensor_pdr* pdr =
+        reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
+    if (!pdr)
+    {
+        std::cerr << "Failed to get record by PDR type, ERROR:"
+                  << PLDM_PLATFORM_INVALID_SENSOR_ID << std::endl;
+        return;
+    }
+    auto& associatedEntityMap = platformHandler->getAssociateEntityMap();
+    for (const auto& entity_path : slotobjpaths)
+    {
+        pdr->hdr.record_handle = 0;
+        pdr->hdr.version = 1;
+        pdr->hdr.type = PLDM_STATE_SENSOR_PDR;
+        pdr->hdr.record_change_num = 0;
+        pdr->hdr.length = sizeof(pldm_state_sensor_pdr) - sizeof(pldm_pdr_hdr);
+        pdr->terminus_handle = pdr::BmcPldmTerminusHandle;
+        pdr->sensor_id = platformHandler->getNextSensorId();
+        if (entity_path != "" &&
+            associatedEntityMap.find(entity_path) != associatedEntityMap.end())
+        {
+            pdr->entity_type = associatedEntityMap.at(entity_path).entity_type;
+            pdr->entity_instance =
+                associatedEntityMap.at(entity_path).entity_instance_num;
+            pdr->container_id =
+                associatedEntityMap.at(entity_path).entity_container_id;
+        }
+        else
+        {
+            // the slots are not present, dont create the PDR
+            continue;
+        }
+
+        pdr->sensor_init = PLDM_NO_INIT;
+        pdr->sensor_auxiliary_names_pdr = false;
+        pdr->composite_sensor_count = 1;
+
+        auto* possibleStatesPtr = pdr->possible_states;
+        auto possibleStates =
+            reinterpret_cast<state_sensor_possible_states*>(possibleStatesPtr);
+        possibleStates->state_set_id = PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE;
+        possibleStates->possible_states_size = 1;
+        auto state =
+            reinterpret_cast<state_sensor_possible_states*>(possibleStates);
+        state->states[0].byte = 15;
+        pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+        pdrEntry.data = entry.data();
+        pdrEntry.size = pdrSize;
+        repo.addRecord(pdrEntry);
+    }
+}
+
 void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     pdr_utils::Repo& repo)
 {
@@ -265,6 +415,21 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     buildAllCodeUpdateEffecterPDR(this, PLDM_ENTITY_SYSTEM_CHASSIS,
                                   ENTITY_INSTANCE_0,
                                   PLDM_OEM_IBM_SYSTEM_POWER_STATE, repo);
+    std::vector<std::string> slotobjpaths = {
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9"};
+    buildAllSlotEnabeEffecterPDR(this, repo, slotobjpaths);
+    buildAllSlotEnableSensorPDR(this, repo, slotobjpaths);
 
     buildAllCodeUpdateSensorPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
                                 ENTITY_INSTANCE_0, PLDM_OEM_IBM_BOOT_STATE,

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -2,6 +2,8 @@
 #include "libpldm/entity.h"
 #include "libpldm/platform.h"
 
+#include "collect_slot_vpd.hpp"
+#include "common/utils.hpp"
 #include "inband_code_update.hpp"
 #include "libpldmresponder/oem_handler.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
@@ -12,12 +14,16 @@ namespace pldm
 {
 namespace responder
 {
+using ObjectPath = std::string;
+using AssociatedEntityMap = std::map<ObjectPath, pldm_entity>;
 namespace oem_ibm_platform
 {
 
 #define PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE 32768
 #define PLDM_OEM_IBM_BOOT_STATE 32769
 #define PLDM_OEM_IBM_SYSTEM_POWER_STATE 32771
+#define PLDM_OEM_IBM_SLOT_ENABLE_EFFECTER_STATE 32772
+#define PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE 32773
 
 static constexpr auto PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577;
 static constexpr auto PLDM_OEM_IBM_VERIFICATION_STATE = 32770;
@@ -32,6 +38,21 @@ enum class CodeUpdateState : uint8_t
     ABORT = 0x4,
     ACCEPT = 0x5,
     REJECT = 0x6
+};
+
+enum class SlotEnableEffecterState : uint8_t
+{
+    ADD = 0x0,
+    REMOVE = 0x1,
+    REPLACE = 0x2
+};
+
+enum class SlotEnableSensorState : uint8_t
+{
+    SLOT_STATE_UNKOWN = 0x0,
+    SLOT_STATE_ENABLED = 0x1,
+    SLOT_STATE_DISABLED = 0x2,
+    SLOT_STATE_ERROR = 0x03
 };
 
 enum VerificationStateValues
@@ -51,13 +72,15 @@ class Handler : public oem_platform::Handler
 {
   public:
     Handler(const pldm::utils::DBusHandler* dBusIntf,
-            pldm::responder::CodeUpdate* codeUpdate, int mctp_fd,
+            pldm::responder::CodeUpdate* codeUpdate,
+            pldm::responder::SlotHandler* slotHandler, int mctp_fd,
             uint8_t mctp_eid, pldm::dbus_api::Requester& requester,
             sdeventplus::Event& event,
             pldm::requester::Handler<pldm::requester::Request>* handler) :
         oem_platform::Handler(dBusIntf),
-        codeUpdate(codeUpdate), platformHandler(nullptr), mctp_fd(mctp_fd),
-        mctp_eid(mctp_eid), requester(requester), event(event), handler(handler)
+        codeUpdate(codeUpdate), slotHandler(slotHandler),
+        platformHandler(nullptr), mctp_fd(mctp_fd), mctp_eid(mctp_eid),
+        requester(requester), event(event), handler(handler)
     {
         codeUpdate->setVersions();
         setEventReceiverCnt = 0;
@@ -93,9 +116,10 @@ class Handler : public oem_platform::Handler
     }
 
     int getOemStateSensorReadingsHandler(
-        EntityType entityType, pldm::pdr::EntityInstance entityInstance,
-        pldm::pdr::StateSetId stateSetId,
-        pldm::pdr::CompositeCount compSensorCnt,
+        pldm::pdr::EntityType entityType,
+        pldm::pdr::EntityInstance entityInstance,
+        pldm::pdr::ContainerID containerId, pldm::pdr::StateSetId stateSetId,
+        pldm::pdr::CompositeCount compSensorCnt, uint16_t sensorId,
         std::vector<get_sensor_state_field>& stateField);
 
     int oemSetStateEffecterStatesHandler(
@@ -127,6 +151,11 @@ class Handler : public oem_platform::Handler
     virtual uint16_t getNextSensorId()
     {
         return platformHandler->getNextSensorId();
+    }
+
+    virtual const AssociatedEntityMap& getAssociateEntityMap()
+    {
+        return platformHandler->getAssociateEntityMap();
     }
 
     /** @brief Method to Generate the OEM PDRs
@@ -204,6 +233,9 @@ class Handler : public oem_platform::Handler
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object
+
+    pldm::responder::SlotHandler* slotHandler;
+
     pldm::responder::platform::Handler*
         platformHandler; //!< pointer to PLDM platform handler
 
@@ -221,6 +253,10 @@ class Handler : public oem_platform::Handler
     std::unique_ptr<sdeventplus::source::Defer> assembleImageEvent;
     std::unique_ptr<sdeventplus::source::Defer> startUpdateEvent;
     std::unique_ptr<sdeventplus::source::Defer> systemRebootEvent;
+
+    /** @brief Effecterid to dbus object path map
+     */
+    std::unordered_map<uint16_t, std::string> effecterIdToDbusMap;
 
     /** @brief reference of main event loop of pldmd, primarily used to schedule
      *  work

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -215,14 +215,16 @@ int main(int argc, char** argv)
 #ifdef OEM_IBM
     std::unique_ptr<pldm::responder::CodeUpdate> codeUpdate =
         std::make_unique<pldm::responder::CodeUpdate>(dbusHandler.get());
+    std::unique_ptr<pldm::responder::SlotHandler> slotHandler =
+        std::make_unique<pldm::responder::SlotHandler>(event, pdrRepo.get());
     codeUpdate->clearDirPath(LID_STAGING_DIR);
     oemPlatformHandler = std::make_unique<oem_ibm_platform::Handler>(
-        dbusHandler.get(), codeUpdate.get(), sockfd, hostEID, dbusImplReq,
-        event, &reqHandler);
+        dbusHandler.get(), codeUpdate.get(), slotHandler.get(), sockfd, hostEID,
+        dbusImplReq, event, &reqHandler);
     codeUpdate->setOemPlatformHandler(oemPlatformHandler.get());
     oemFruHandler = std::make_unique<oem_ibm_fru::Handler>(dbusHandler.get(),
                                                            pdrRepo.get());
-
+    slotHandler->setOemPlatformHandler(oemPlatformHandler.get());
     invoker.registerHandler(PLDM_OEM, std::make_unique<oem_ibm::Handler>(
                                           oemPlatformHandler.get(), sockfd,
                                           hostEID, &dbusImplReq, &reqHandler));


### PR DESCRIPTION
This commit adds the necessary sensors & effecters for all
the PCIe Slots & adapters present on BMC.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
Change-Id: I51b79b75c909ddf2cc29872fec6aa01c2d56b418