### PR TITLE
fix for a poweron hang

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -135,6 +135,7 @@ HostPDRHandler::HostPDRHandler(
                     this->sensorMap.clear();
                     this->mergedHostParents = false;
                     this->sensorMapIndex = objPathMap.begin();
+                    this->responseReceived = false;
                 }
             }
         });


### PR DESCRIPTION
This commit fixes the hang issue caused when
booting to host runtime followed by restarting pldmd
followed by power off and power on.
The variable responseReceived is set to false when the
host powersOff.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>
Change-Id: I47d6570fffec7b5c86db102f891f7a96f66f1f39