### PR TITLE
PLDM: effecter PDRs support for Slot PowerState

### DIFF
--- a/configurations/pdr/11.json
+++ b/configurations/pdr/11.json
@@ -3585,6 +3585,226 @@
         }]
     },
     {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
+       "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11",
+       "effecters" : [{
+           "set" : {
+               "id" : 11,
+               "size" : 1,
+               "states" : [3,4]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11",
+               "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+               "property_name": "PowerState",
+               "property_type": "string",
+               "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On"
+               ]
+           }
+      }]
+    },
+    {
        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis",
        "effecters" : [{
            "set" : {


### PR DESCRIPTION
This commit contains the addition of effecter PDRs for
the slot power state. Effecters for all the slots are
mapped to the interface defined here -
https://gerrit.openbmc-project.xyz/c/openbmc/
phosphor-dbus-interfaces/+/45372

Tested:
pldmtool platform getpdr -d 184
{
  "nextRecordHandle": 185,
  "responseCount": 29,
  "recordHandle": 184,
  "PDRHeaderVersion": 1,
  "PDRType": "State Effecter PDR",
  "recordChangeNumber": 0,
  "dataLength": 19,
  "PLDMTerminusHandle": 1,
  "effecterID": 100,
  "entityType": "[Physical] Slot",
  "entityInstanceNumber": 1,
  "containerID": 3,
  "effecterSemanticID": 0,
  "effecterInit": "noInit",
  "effecterDescriptionPDR": false,
  "compositeEffecterCount": 1,
  "stateSetID[0]": "Operational Running Status(11)",
  "possibleStatesSize[0]": 1,
  "possibleStates[0]": " 3 4"
}

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>
Change-Id: Ie578c6e53d4ffdfe33a4c11a2c484d92d243bdb8