### PR TITLE
Remove hb_power_limit_enable_current and hb_power_limit_in_watts_current

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -344,20 +344,8 @@
          "default_values":[
             "Disabled"
          ],
-         "helpText" : "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
-         "displayName" : "Power Limit Enable (pending)"
-      },
-      {
-         "attribute_name":"hb_power_limit_enable_current",
-         "possible_values":[
-            "Enabled",
-            "Disabled"
-         ],
-         "default_values":[
-            "Disabled"
-         ],
-         "helpText" : "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
-         "displayName" : "Power Limit Enable (current)"
+         "helpText" : "Specifies whether the power limit is enabled.",
+         "displayName" : "Power Limit Enable"
       },
       {
          "attribute_name":"hb_secure_ver_lockin_enabled",

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -87,17 +87,8 @@
          "upper_bound" : 65535,
          "scalar_increment" : 1,
          "default_value" : 0,
-         "helpText" : "Specifies the power limit in watts, requires a reboot for a change to be applied.",
-         "displayName" : "Power Limit In Watts (pending)"
-      },
-      {
-         "attribute_name" : "hb_power_limit_in_watts_current",
-         "lower_bound" : 0,
-         "upper_bound" : 65535,
-         "scalar_increment" : 1,
-         "default_value" : 0,
-         "helpText" : "Specifies the power limit in watts for the current IPL. Do not set this attribute directly; set hb_power_limit_in_watts instead.",
-         "displayName" : "Power Limit In Watts (current)"
+         "helpText" : "Specifies the power limit in watts.",
+         "displayName" : "Power Limit In Watts"
       },
       {
          "attribute_name" : "hb_max_number_huge_pages",


### PR DESCRIPTION
hb_power_limit_enable and hb_power_limit_in_watts were previously
defined as latched/pending attributes. This is being changed because
when these values are changed, the new value is immediately sent to
the OCCs, and firmware needs to process the latest value that the OCC
received rather than the one effective at the beginning of the IPL.

Change-Id: Ida39a3ee5e6b4b0d3255bfef95601890afd80709
Signed-off-by: Zach Clark <zach@ibm.com>