### PR TITLE
PLDM Support for MEX FRU & MEX LED 

### DIFF
--- a/common/test/pldm_utils_test.cpp
+++ b/common/test/pldm_utils_test.cpp
@@ -105,7 +105,7 @@ TEST(FindStateEffecterPDR, testOneMatch)
     state->state_set_id = 196;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -139,7 +139,7 @@ TEST(FindStateEffecterPDR, testNoMatch)
     state->state_set_id = 196;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -190,7 +190,7 @@ TEST(FindStateEffecterPDR, testMoreMatch)
     state->state_set_id = 129;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -210,7 +210,7 @@ TEST(FindStateEffecterPDR, testMoreMatch)
     state_second->state_set_id = 129;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false);
+    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
 
     uint16_t entityID_ = 31;
     uint16_t stateSetId_ = 129;
@@ -248,7 +248,7 @@ TEST(FindStateEffecterPDR, testManyNoMatch)
     state->state_set_id = 198;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -268,7 +268,7 @@ TEST(FindStateEffecterPDR, testManyNoMatch)
     state_second->state_set_id = 169;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false);
+    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -301,7 +301,7 @@ TEST(FindStateEffecterPDR, testOneMatchOneNoMatch)
     state->state_set_id = 198;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -321,7 +321,7 @@ TEST(FindStateEffecterPDR, testOneMatchOneNoMatch)
     state_second->state_set_id = 192;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false);
+    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -355,7 +355,7 @@ TEST(FindStateEffecterPDR, testOneMatchManyNoMatch)
     state->state_set_id = 198;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -375,7 +375,7 @@ TEST(FindStateEffecterPDR, testOneMatchManyNoMatch)
     state_second->state_set_id = 192;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false);
+    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_third(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -439,7 +439,7 @@ TEST(FindStateEffecterPDR, testCompositeEffecter)
     state->state_set_id = 192;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -484,7 +484,7 @@ TEST(FindStateEffecterPDR, testNoMatchCompositeEffecter)
     state->state_set_id = 123;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -518,7 +518,7 @@ TEST(FindStateSensorPDR, testOneMatch)
     state->state_set_id = 1;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -552,7 +552,7 @@ TEST(FindStateSensorPDR, testNoMatch)
     state->state_set_id = 1;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -603,7 +603,7 @@ TEST(FindStateSensorPDR, testMoreMatch)
     state->state_set_id = 1;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_sensor_pdr) - sizeof(uint8_t) +
@@ -623,7 +623,7 @@ TEST(FindStateSensorPDR, testMoreMatch)
     state_second->state_set_id = 1;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false);
+    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
 
     uint16_t entityID_ = 5;
     uint16_t stateSetId_ = 1;
@@ -661,7 +661,7 @@ TEST(FindStateSensorPDR, testManyNoMatch)
     state->state_set_id = 2;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_sensor_pdr) - sizeof(uint8_t) +
@@ -681,7 +681,7 @@ TEST(FindStateSensorPDR, testManyNoMatch)
     state_second->state_set_id = 3;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false);
+    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -714,7 +714,7 @@ TEST(FindStateSensorPDR, testOneMatchOneNoMatch)
     state->state_set_id = 20;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_sensor_pdr) - sizeof(uint8_t) +
@@ -734,7 +734,7 @@ TEST(FindStateSensorPDR, testOneMatchOneNoMatch)
     state_second->state_set_id = 1;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false);
+    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -768,7 +768,7 @@ TEST(FindStateSensorPDR, testOneMatchManyNoMatch)
     state->state_set_id = 9;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_sensor_pdr) - sizeof(uint8_t) +
@@ -788,7 +788,7 @@ TEST(FindStateSensorPDR, testOneMatchManyNoMatch)
     state_second->state_set_id = 1;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false);
+    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
 
     std::vector<uint8_t> pdr_third(sizeof(struct pldm_state_sensor_pdr) -
                                    sizeof(uint8_t) +
@@ -853,7 +853,7 @@ TEST(FindStateSensorPDR, testCompositeSensor)
     state->state_set_id = 1;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -898,7 +898,7 @@ TEST(FindStateSensorPDR, testNoMatchCompositeSensor)
     state->state_set_id = 39;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false);
+    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -138,7 +138,7 @@ struct DBusMapping
 
 using PropertyValue =
     std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-                 uint64_t, double, std::string>;
+                 uint64_t, double, std::string, std::vector<uint8_t>>;
 using DbusProp = std::string;
 using DbusChangedProps = std::map<DbusProp, PropertyValue>;
 using DBusInterfaceAdded = std::vector<
@@ -382,5 +382,17 @@ std::string toString(const struct variable_field& var);
  */
 const std::string getCurrentSystemTime();
 
+/** @brief D-Bus Method call
+ *
+ *  @param[in] service - Service name for the D-Bus method
+ *  @param[in] objPath - The D-Bus object path
+ *  @param[in] dbusMethod - The Method name to be invoked
+ *  @param[in] dbusInterface - The D-Bus interface
+ *  @param[in] value - The value to be passed as argument
+ *             to D-Bus method*
+ */
+void dbusMethodCall(const char* service, const char* objPath,
+                    const char* dbusMethod, const char* dbusInterface,
+                    const PropertyValue& value);
 } // namespace utils
 } // namespace pldm

--- a/configurations/events/stateSensorPdrs.json
+++ b/configurations/events/stateSensorPdrs.json
@@ -1,6 +1,40 @@
 {
 	"entries": [
 	  {
+		"containerID": 1,
+		"entityType": 32801,
+		"entityInstance": 0,
+		"sensorOffset": 0,
+		"event_states": [
+		  1,
+		  2,
+		  3,
+		  5,
+		  7,
+		  9,
+		  21,
+		  22,
+		  26
+		],
+		"dbus": {
+		  "object_path": "/xyz/openbmc_project/state/host0",
+		  "interface": "xyz.openbmc_project.State.Boot.Progress",
+		  "property_name": "BootProgress",
+		  "property_type": "string",
+		  "property_values": [
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified",
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemInitComplete",
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.MemoryInit",
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SecondaryProcInit",
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemSetup",
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PCIInit",
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.OSRunning",
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.BusInit",
+			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PrimaryProcInit"
+		  ]
+		}
+	  },
+	  {
 		"containerID": 0,
 		"entityType": 32801,
 		"entityInstance": 0,
@@ -34,6 +68,7 @@
 		  ]
 		}
 	  },
+
 	  {
 		"containerID": 3,
 		"entityType": 66,
@@ -675,6 +710,4 @@
 		}
 	  }
 	]
-  }
-  
-  
+  } 

--- a/configurations/host/dbus_to_host_effecter.json
+++ b/configurations/host/dbus_to_host_effecter.json
@@ -3,6 +3,36 @@
         {
             "mctp_eid": 9,
             "effecter_info": {
+                "containerID": 1,
+                "entityType": 32801,
+                "entityInstance": 0,
+                "compositeEffecterCount": 1
+            },
+            "effecters": [
+                {
+                    "dbus_info": {
+                        "object_path": "/xyz/openbmc_project/state/hypervisor0",
+                        "interface": "xyz.openbmc_project.State.Host",
+                        "property_name": "RequestedHostTransition",
+                        "property_type": "string",
+                        "property_values": [
+                            "xyz.openbmc_project.State.Host.Transition.On"
+                        ]
+                    },
+                    "state" : {
+                        "id" : 196,
+                        "state_values": [
+                            2
+                            ]
+                    }
+                }
+
+            ]
+
+        },
+        {
+            "mctp_eid": 9,
+            "effecter_info": {
                 "containerID": 0,
                 "entityType": 32801,
                 "entityInstance": 0,

--- a/configurations/host/host_fru_associations.json
+++ b/configurations/host/host_fru_associations.json
@@ -1,0 +1,287 @@
+{
+	"associations":
+	[
+		{
+			"entity_type": 45,
+			"entity_instance": 15363,
+			"entity_container_id": 1,
+			"associate": 
+			[
+				{
+					"entity_type": 123,
+					"entity_instance": 1,
+					"entity_container_id": 32786,
+					"association_details": [
+						"assembly",
+						"inventory"
+					]
+				},
+				{
+					"entity_type": 123,
+					"entity_instance": 1,
+					"entity_container_id": 32787,
+					"association_details": [
+						"assembly",
+						"inventory"
+					]
+				},
+				{
+					"entity_type": 93,
+					"entity_instance": 1,
+					"entity_container_id": 32785,
+					"association_details": [
+						"all_sensors",
+						"chassis"
+					]
+				},
+				{
+					"entity_type": 93,
+					"entity_instance": 2,
+					"entity_container_id": 32785,
+					"association_details": [
+						"all_sensors",
+						"chassis"
+					]
+				},
+				{
+					"entity_type": 93,
+					"entity_instance": 3,
+					"entity_container_id": 32785,
+					"association_details": [
+						"all_sensors",
+						"chassis"
+					]
+				},
+				{
+					"entity_type": 93,
+					"entity_instance": 4,
+					"entity_container_id": 32785,
+					"association_details": [
+						"all_sensors",
+						"chassis"
+					]
+				},
+				{
+					"entity_type": 80,
+					"entity_instance": 1,
+					"entity_container_id": 32785,
+					"association_details": [
+						"assembly",
+						"chassis"
+					]
+				},
+				{
+					"entity_type": 80,
+					"entity_instance": 2,
+					"entity_container_id": 32785,
+					"association_details": [
+						"assembly",
+						"chassis"
+					]
+				},
+				{
+					"entity_type": 64,
+					"entity_instance": 3,
+					"entity_container_id": 32785,
+					"association_details": [
+						"assembly",
+						"chassis"
+					]
+				},
+				{
+					"entity_type": 62,
+					"entity_instance": 1,
+					"entity_container_id": 32788,
+					"association_details": [
+						"assembly",
+						"chassis"
+					]
+				}
+			]
+		},
+		{
+			"entity_type": 120,
+			"entity_instance": 1,
+			"entity_container_id": 32785,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		},
+		{
+			"entity_type": 120,
+			"entity_instance": 2,
+			"entity_container_id": 32785,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 1,
+			"entity_container_id": 32786,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 2,
+			"entity_container_id": 32786,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 3,
+			"entity_container_id": 32786,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 4,
+			"entity_container_id": 32786,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 5,
+			"entity_container_id": 32786,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 6,
+			"entity_container_id": 32786,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 1,
+			"entity_container_id": 32787,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 2,
+			"entity_container_id": 32787,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 3,
+			"entity_container_id": 32787,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 4,
+			"entity_container_id": 32787,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 5,
+			"entity_container_id": 32787,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}, {
+			"entity_type": 186,
+			"entity_instance": 6,
+			"entity_container_id": 32787,
+			"associate": [{
+				"entity_type": 45,
+				"entity_instance": 15363,
+				"entity_container_id": 1,
+				"association_details": [
+					"chassis",
+					"inventory"
+				]
+			}]
+		}
+	]
+}

--- a/host-bmc/custom_dbus.hpp
+++ b/host-bmc/custom_dbus.hpp
@@ -1,12 +1,28 @@
 #pragma once
 
+#include "libpldm/pdr.h"
+
 #include "com/ibm/License/Entry/LicenseEntry/server.hpp"
 #include "common/utils.hpp"
+#include "dbus_to_host_effecters.hpp"
 
+#include <sdbusplus/bus.hpp>
 #include <sdbusplus/server.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <xyz/openbmc_project/Association/Definitions/server.hpp>
 #include <xyz/openbmc_project/Inventory/Decorator/LocationCode/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/Board/Motherboard/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/Board/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/Chassis/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/Connector/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/CpuCore/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/FabricAdapter/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/Fan/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/PCIeSlot/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/PowerSupply/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/Vrm/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/server.hpp>
+#include <xyz/openbmc_project/Led/Group/server.hpp>
 #include <xyz/openbmc_project/Object/Enable/server.hpp>
 #include <xyz/openbmc_project/State/Decorator/Availability/server.hpp>
 #include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
@@ -34,10 +50,85 @@ using CoreIntf = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Inventory::Item::server::CpuCore>;
 using EnableIface = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Object::server::Enable>;
+
+using AssertedIntf = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Led::server::Group>;
+using AssociationsIntf =
+    sdbusplus::xyz::openbmc_project::Association::server::Definitions;
+using ItemChassis = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Chassis>;
+using ItemFan = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Fan>;
+using ItemConnector = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Connector>;
+using ItemVRM = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Vrm>;
+using ItemSlot = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::PCIeSlot>;
+using ItemMotherboard = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::Board::server::
+        Motherboard>;
+using ItemPowerSupply = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::PowerSupply>;
+using ItemFabricAdapter = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::FabricAdapter>;
+using ItemBoard = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Board>;
+
 using LicIntf = sdbusplus::server::object::object<
     sdbusplus::com::ibm::License::Entry::server::LicenseEntry>;
 using AvailabilityIntf = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::State::Decorator::server::Availability>;
+using Associations =
+    std::vector<std::tuple<std::string, std::string, std::string>>;
+
+class Group : public AssertedIntf
+{
+  public:
+    Group() = delete;
+    ~Group() = default;
+    Group(const Group&) = delete;
+    Group& operator=(const Group&) = delete;
+    Group(Group&&) = default;
+    Group& operator=(Group&&) = default;
+
+    Group(sdbusplus::bus::bus& bus, const std::string& objPath,
+          pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+          const pldm_entity entity, uint8_t mctpEid) :
+        AssertedIntf(bus, objPath.c_str(), true),
+        hostEffecterParser(hostEffecterParser), entity(entity), mctpEid(mctpEid)
+    {
+        // Emit deferred signal.
+        emit_object_added();
+    }
+
+    /** @brief Property SET Override function
+     *
+     *  @param[in]  value   -  True or False
+     *  @return             -  Success or exception thrown
+     */
+    bool asserted(bool value) override;
+
+    bool asserted() const override;
+
+    inline void setStateEffecterStatesFlag(bool value)
+    {
+        isTriggerStateEffecterStates = value;
+    }
+
+  private:
+    bool updateAsserted(bool value);
+
+  private:
+    /** @brief Pointer to host effecter parser */
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser;
+
+    const pldm_entity entity;
+
+    uint8_t mctpEid;
+
+    bool isTriggerStateEffecterStates = false;
+};
 
 /** @class CustomDBus
  *  @brief This is a custom D-Bus object, used to add D-Bus interface and
@@ -85,7 +176,7 @@ class CustomDBus
      *
      *  @param[in] status - PLDM operational fault status
      */
-    void setOperationalStatus(const std::string& path, uint8_t status);
+    void setOperationalStatus(const std::string& path, bool status);
 
     /** @brief Get the Functional property
      *
@@ -112,12 +203,73 @@ class CustomDBus
      */
     void implementCpuCoreInterface(const std::string& path);
 
+    /** @brief Implement Chassis Interface
+     *  @param[in] path - the object path
+     */
+    void implementChassisInterface(const std::string& path);
+
+    void implementPCIeSlotInterface(const std::string& path);
+
+    void implementPowerSupplyInterface(const std::string& path);
+
+    void implementFanInterface(const std::string& path);
+
+    void implementConnecterInterface(const std::string& path);
+
+    void implementVRMInterface(const std::string& path);
+
+    void implementMotherboardInterface(const std::string& path);
+
+    void implementFabricAdapter(const std::string& path);
+
+    void implementBoard(const std::string& path);
     /**
      * @brief Implement the xyz.openbmc_project.Object.Enable interface
      *
      * @param[in] path - The object path to implement Enable interface
      */
     void implementObjectEnableIface(const std::string& path);
+    /** @brief Set the Asserted property
+     *
+     *  @param[in] path     - The object path
+     *  @param[in] entity   - pldm entity
+     *  @param[in] value    - To assert a group, set to True. To de-assert a
+     *                        group, set to False.
+     *  @param[in] hostEffecterParser    - Pointer to host effecter parser
+     *  @param[in] instanceId - instance Id
+     *  @param[in] isTriggerStateEffecterStates - Trigger stateEffecterStates
+     *                                            command flag, true: trigger
+     */
+    void setAsserted(
+        const std::string& path, const pldm_entity& entity, bool value,
+        pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+        uint8_t instanceId, bool isTriggerStateEffecterStates = false);
+
+    /** @brief Get the Asserted property
+     *
+     *  @param[in] path   - The object path
+     *
+     *  @return asserted  - Asserted property
+     */
+    bool getAsserted(const std::string& path) const;
+
+    /** @brief Set the Associations property
+     *
+     *  @param[in] path     - The object path
+     *
+     *  @param[in] value    - An array of forward, reverse, endpoint tuples
+     */
+    void setAssociations(const std::string& path, Associations assoc);
+
+    /** @brief Get the current Associations property
+     *
+     *  @param[in] path     - The object path
+     *
+     *  @return current Associations -  An array of forward, reverse, endpoint
+     * tuples
+     */
+    const std::vector<std::tuple<std::string, std::string, std::string>>
+        getAssociations(const std::string& path);
 
     /** @brief Implement the license interface properties
      *
@@ -161,6 +313,10 @@ class CustomDBus
 
     std::map<ObjectPath, std::unique_ptr<OperationalStatusIntf>>
         operationalStatus;
+    std::unordered_map<ObjectPath, std::unique_ptr<Group>> ledGroup;
+
+    std::unordered_map<ObjectPath, std::unique_ptr<AssociationsIntf>>
+        associations;
     std::map<ObjectPath, std::unique_ptr<AvailabilityIntf>> availabilityState;
 
     std::unordered_map<ObjectPath, std::unique_ptr<ItemIntf>> presentStatus;
@@ -169,6 +325,18 @@ class CustomDBus
 
     /** @brief Used to hold the objects which will contain EnableIface */
     std::unordered_map<ObjectPath, std::unique_ptr<EnableIface>> _enabledStatus;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemChassis>> chassis;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemConnector>> connector;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemFan>> fan;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemVRM>> vrm;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemMotherboard>>
+        motherboard;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemSlot>> pcieSlot;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemPowerSupply>>
+        powersupply;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemFabricAdapter>>
+        fabricAdapter;
+    std::unordered_map<ObjectPath, std::unique_ptr<ItemBoard>> board;
 };
 
 } // namespace dbus

--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -245,12 +245,11 @@ uint8_t
     return newState;
 }
 
-int HostEffecterParser::setHostStateEffecter(
-    size_t effecterInfoIndex, std::vector<set_effecter_state_field>& stateField,
-    uint16_t effecterId)
+int HostEffecterParser::sendSetStateEffecterStates(
+    uint8_t mctpEid, uint16_t effecterId, uint8_t compEffCnt,
+    std::vector<set_effecter_state_field>& stateField,
+    std::function<bool(bool)> callBack, bool value)
 {
-    uint8_t& mctpEid = hostEffecterInfo[effecterInfoIndex].mctpEid;
-    uint8_t& compEffCnt = hostEffecterInfo[effecterInfoIndex].compEffecterCnt;
     auto instanceId = requester->getInstanceId(mctpEid);
 
     std::vector<uint8_t> requestMsg(
@@ -263,14 +262,15 @@ int HostEffecterParser::setHostStateEffecter(
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message encode failure. PLDM error code = " << std::hex
-                  << std::showbase << rc << "\n";
+        std::cerr
+            << "Message encode SetStateEffecterStates failure. PLDM error code = "
+            << std::hex << std::showbase << rc << "\n";
         requester->markFree(mctpEid, instanceId);
         return rc;
     }
 
     auto setStateEffecterStatesRespHandler =
-        [](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
+        [=](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
             if (response == nullptr || !respMsgLen)
             {
                 std::cerr << "Failed to receive response for "
@@ -295,6 +295,13 @@ int HostEffecterParser::setHostStateEffecter(
                 pldm::utils::reportError(
                     "xyz.openbmc_project.bmc.pldm.SetHostEffecterFailed");
             }
+            else
+            {
+                if (callBack)
+                {
+                    callBack(value);
+                }
+            }
         };
 
     rc = handler->registerRequest(
@@ -305,6 +312,17 @@ int HostEffecterParser::setHostStateEffecter(
         std::cerr << "Failed to send request to set an effecter on Host \n";
     }
     return rc;
+}
+
+int HostEffecterParser::setHostStateEffecter(
+    size_t effecterInfoIndex, std::vector<set_effecter_state_field>& stateField,
+    uint16_t effecterId)
+{
+    uint8_t& mctpEid = hostEffecterInfo[effecterInfoIndex].mctpEid;
+    uint8_t& compEffCnt = hostEffecterInfo[effecterInfoIndex].compEffecterCnt;
+
+    return sendSetStateEffecterStates(mctpEid, effecterId, compEffCnt,
+                                      stateField);
 }
 
 void HostEffecterParser::createHostEffecterMatch(const std::string& objectPath,
@@ -326,6 +344,11 @@ void HostEffecterParser::createHostEffecterMatch(const std::string& objectPath,
                 processHostEffecterChangeNotification(
                     props, effecterInfoIndex, dbusInfoIndex, effecterId);
             }));
+}
+
+const pldm_pdr* HostEffecterParser::getPldmPDR()
+{
+    return pdrRepo;
 }
 
 } // namespace host_effecters

--- a/host-bmc/dbus_to_host_effecters.hpp
+++ b/host-bmc/dbus_to_host_effecters.hpp
@@ -167,6 +167,13 @@ class HostEffecterParser
                                          size_t dbusInfoIndex,
                                          uint16_t effecterId);
 
+    const pldm_pdr* getPldmPDR();
+
+    int sendSetStateEffecterStates(
+        uint8_t mctpEid, uint16_t effecterId, uint8_t compEffCnt,
+        std::vector<set_effecter_state_field>& stateField,
+        std::function<bool(bool)> callBack = nullptr, bool value = false);
+
   protected:
     pldm::dbus_api::Requester*
         requester;           //!< Reference to Requester to obtain instance id

--- a/host-bmc/host_associations_parser.cpp
+++ b/host-bmc/host_associations_parser.cpp
@@ -1,0 +1,78 @@
+#include "host_associations_parser.hpp"
+
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <fstream>
+#include <iostream>
+
+using namespace pldm::utils;
+
+namespace pldm
+{
+namespace host_associations
+{
+using InternalFailure =
+    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+constexpr auto hostfruAssociationsJson = "host_fru_associations.json";
+
+void HostAssociationsParser::parseHostAssociations(const std::string& jsonPath)
+{
+    fs::path jsonDir(jsonPath);
+    if (!fs::exists(jsonDir) || fs::is_empty(jsonDir))
+    {
+        std::cerr << "Host Associations json path does not exist, DIR="
+                  << jsonPath << "\n";
+        return;
+    }
+
+    fs::path jsonFilePath = jsonDir / hostfruAssociationsJson;
+
+    if (!fs::exists(jsonFilePath))
+    {
+        std::cerr << "json does not exist, PATH=" << jsonFilePath << "\n";
+        throw InternalFailure();
+    }
+
+    std::ifstream jsonFile(jsonFilePath);
+    auto data = Json::parse(jsonFile, nullptr, false);
+    if (data.is_discarded())
+    {
+        std::cerr << "Parsing json file failed, FILE=" << jsonFilePath << "\n";
+        throw InternalFailure();
+    }
+    const Json empty{};
+    const std::vector<Json> emptyList{};
+
+    auto entries = data.value("associations", emptyList);
+    for (const auto& entry : entries)
+    {
+        entity p{};
+        p.entity_type = entry.value("entity_type", 0);
+        p.entity_instance_num = entry.value("entity_instance", 0);
+        p.entity_container_id = entry.value("entity_container_id", 0);
+        auto child_node = entry.value("associate", empty);
+        std::vector<std::tuple<entity, std::string, std::string>> cvector;
+        for (const auto& child_entity : child_node)
+        {
+            entity c{};
+            std::tuple<entity, std::string, std::string> ctuple;
+            c.entity_type = child_entity.value("entity_type", 0);
+            c.entity_instance_num = child_entity.value("entity_instance", 0);
+            c.entity_container_id =
+                child_entity.value("entity_container_id", 0);
+            auto association_details_arr =
+                child_entity.value("association_details", emptyList);
+            std::string forward = association_details_arr[0];
+            std::string reverse = association_details_arr[1];
+            std::get<0>(ctuple) = c;
+            std::get<1>(ctuple) = forward;
+            std::get<2>(ctuple) = reverse;
+            cvector.push_back(ctuple);
+        }
+        associationsInfoMap.emplace(std::move(p), std::move(cvector));
+    }
+}
+
+} // namespace host_associations
+} // namespace pldm

--- a/host-bmc/host_associations_parser.hpp
+++ b/host-bmc/host_associations_parser.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "common/utils.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace pldm
+{
+
+namespace host_associations
+{
+
+struct entity
+{
+    uint16_t entity_type;
+    uint16_t entity_instance_num;
+    uint16_t entity_container_id;
+
+    bool operator==(const entity& e) const
+    {
+        return ((entity_type == e.entity_type) &&
+                (entity_instance_num == e.entity_instance_num) &&
+                (entity_container_id == e.entity_container_id));
+    }
+
+    bool operator<(const entity& e) const
+    {
+        return ((entity_type < e.entity_type) ||
+                ((entity_type == e.entity_type) &&
+                 (entity_instance_num < e.entity_instance_num)) ||
+                ((entity_type == e.entity_type) &&
+                 (entity_instance_num == e.entity_instance_num) &&
+                 (entity_container_id < e.entity_container_id)));
+    }
+};
+
+/** @class HostAssociationsParser
+ *
+ *  @brief This class parses the Host Effecter json file and monitors for the
+ *         D-Bus changes for the effecters. Upon change, calls the corresponding
+ *         setStateEffecterStates on the host
+ */
+class HostAssociationsParser
+{
+  public:
+    HostAssociationsParser() = delete;
+    HostAssociationsParser(const HostAssociationsParser&) = delete;
+    HostAssociationsParser& operator=(const HostAssociationsParser&) = delete;
+    HostAssociationsParser(HostAssociationsParser&&) = delete;
+    HostAssociationsParser& operator=(HostAssociationsParser&&) = delete;
+    virtual ~HostAssociationsParser() = default;
+
+    /** @brief Constructor to create a HostAssociationsParser object.
+     *  @param[in] jsonPath - path for the json file
+     */
+    HostAssociationsParser(const std::string& jsonPath)
+    {
+        try
+        {
+            parseHostAssociations(jsonPath);
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "The json file does not exist or malformed, ERROR="
+                      << e.what() << "\n";
+        }
+    }
+
+    /* @brief Parses the host effecter json
+     *
+     * @param[in] jsonPath - path for the json file
+     */
+    void parseHostAssociations(const std::string& jsonPath);
+
+    std::map<entity, std::vector<std::tuple<entity, std::string, std::string>>>
+        associationsInfoMap;
+};
+
+} // namespace host_associations
+} // namespace pldm

--- a/host-bmc/test/utils_test.cpp
+++ b/host-bmc/test/utils_test.cpp
@@ -13,227 +13,73 @@ using namespace pldm::hostbmc::utils;
 TEST(EntityAssociation, addObjectPathEntityAssociations1)
 {
 
-    pldm_entity entities[41]{};
+    pldm_entity entities[8]{};
 
-    entities[0].entity_type = 64;
+    entities[0].entity_type = 45;
     entities[0].entity_container_id = 0;
-    entities[1].entity_type = 67;
+
+    entities[1].entity_type = 64;
     entities[1].entity_container_id = 1;
+
     entities[2].entity_type = 67;
-    entities[2].entity_container_id = 1;
-    entities[3].entity_type = 66;
-    entities[3].entity_container_id = 1;
-    entities[4].entity_type = 66;
-    entities[4].entity_container_id = 1;
-    entities[5].entity_type = 66;
-    entities[5].entity_container_id = 1;
-    entities[6].entity_type = 66;
-    entities[6].entity_container_id = 1;
+    entities[2].entity_container_id = 2;
+    entities[3].entity_type = 67;
+    entities[3].entity_container_id = 2;
 
+    entities[4].entity_type = 135;
+    entities[4].entity_container_id = 3;
+    entities[5].entity_type = 135;
+    entities[5].entity_container_id = 3;
+    entities[6].entity_type = 135;
+    entities[6].entity_container_id = 3;
     entities[7].entity_type = 135;
-    entities[7].entity_container_id = 2;
-    entities[8].entity_type = 135;
-    entities[8].entity_container_id = 2;
-
-    entities[9].entity_type = 135;
-    entities[9].entity_container_id = 5;
-    entities[10].entity_type = 135;
-    entities[10].entity_container_id = 5;
-
-    entities[11].entity_type = 32903;
-    entities[11].entity_container_id = 6;
-    entities[12].entity_type = 32903;
-    entities[12].entity_container_id = 6;
-    entities[13].entity_type = 32903;
-    entities[13].entity_container_id = 6;
-    entities[14].entity_type = 32903;
-    entities[14].entity_container_id = 6;
-    entities[15].entity_type = 32903;
-    entities[15].entity_container_id = 6;
-    entities[16].entity_type = 32903;
-    entities[16].entity_container_id = 6;
-    entities[17].entity_type = 32903;
-    entities[17].entity_container_id = 6;
-    entities[18].entity_type = 32903;
-    entities[18].entity_container_id = 6;
-    entities[19].entity_type = 32903;
-    entities[19].entity_container_id = 6;
-
-    entities[20].entity_type = 32903;
-    entities[20].entity_container_id = 7;
-    entities[21].entity_type = 32903;
-    entities[21].entity_container_id = 7;
-    entities[22].entity_type = 32903;
-    entities[22].entity_container_id = 7;
-    entities[23].entity_type = 32903;
-    entities[23].entity_container_id = 7;
-    entities[24].entity_type = 32903;
-    entities[24].entity_container_id = 7;
-    entities[25].entity_type = 32903;
-    entities[25].entity_container_id = 7;
-
-    entities[26].entity_type = 32903;
-    entities[26].entity_container_id = 3;
-    entities[27].entity_type = 32903;
-    entities[27].entity_container_id = 3;
-    entities[28].entity_type = 32903;
-    entities[28].entity_container_id = 3;
-    entities[29].entity_type = 32903;
-    entities[29].entity_container_id = 3;
-    entities[30].entity_type = 32903;
-    entities[30].entity_container_id = 3;
-    entities[31].entity_type = 32903;
-    entities[31].entity_container_id = 3;
-    entities[32].entity_type = 32903;
-    entities[32].entity_container_id = 3;
-    entities[33].entity_type = 32903;
-    entities[33].entity_container_id = 3;
-
-    entities[34].entity_type = 32903;
-    entities[34].entity_container_id = 4;
-    entities[35].entity_type = 32903;
-    entities[35].entity_container_id = 4;
-    entities[36].entity_type = 32903;
-    entities[36].entity_container_id = 4;
-    entities[37].entity_type = 32903;
-    entities[37].entity_container_id = 4;
-    entities[38].entity_type = 32903;
-    entities[38].entity_container_id = 4;
-    entities[39].entity_type = 32903;
-    entities[39].entity_container_id = 4;
-    entities[40].entity_type = 32903;
-    entities[40].entity_container_id = 4;
+    entities[7].entity_container_id = 3;
 
     auto tree = pldm_entity_association_tree_init();
 
-    auto l1 = pldm_entity_association_tree_add(
-        tree, &entities[0], 1, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    auto l1 = pldm_entity_association_tree_add(tree, &entities[0], 1, nullptr,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               true, true);
 
-    auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l2b = pldm_entity_association_tree_add(
-        tree, &entities[2], 1, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    auto l2 = pldm_entity_association_tree_add(
+        tree, &entities[1], 1, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true, true);
 
     auto l3a = pldm_entity_association_tree_add(
-        tree, &entities[7], 0, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+        tree, &entities[2], 0, l2, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true, true);
     auto l3b = pldm_entity_association_tree_add(
-        tree, &entities[8], 1, l2a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+        tree, &entities[3], 1, l2, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true, true);
 
-    auto l4a = pldm_entity_association_tree_add(
-        tree, &entities[9], 0, l2b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l4b = pldm_entity_association_tree_add(
-        tree, &entities[10], 1, l2b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    auto l4a = pldm_entity_association_tree_add(tree, &entities[4], 0, l3a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true);
+    auto l4b = pldm_entity_association_tree_add(tree, &entities[5], 1, l3a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true);
 
-    auto l5a = pldm_entity_association_tree_add(
-        tree, &entities[11], 0, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l5b = pldm_entity_association_tree_add(
-        tree, &entities[12], 2, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l5c = pldm_entity_association_tree_add(
-        tree, &entities[13], 3, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l5d = pldm_entity_association_tree_add(
-        tree, &entities[14], 5, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l5e = pldm_entity_association_tree_add(
-        tree, &entities[15], 6, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l5f = pldm_entity_association_tree_add(
-        tree, &entities[16], 7, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l5g = pldm_entity_association_tree_add(
-        tree, &entities[17], 8, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l5h = pldm_entity_association_tree_add(
-        tree, &entities[18], 9, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l5i = pldm_entity_association_tree_add(
-        tree, &entities[19], 15, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-
-    auto l6a = pldm_entity_association_tree_add(
-        tree, &entities[20], 1, l4b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l6b = pldm_entity_association_tree_add(
-        tree, &entities[21], 2, l4b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l6c = pldm_entity_association_tree_add(
-        tree, &entities[22], 4, l4b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l6d = pldm_entity_association_tree_add(
-        tree, &entities[23], 8, l4b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l6e = pldm_entity_association_tree_add(
-        tree, &entities[24], 10, l4b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l6f = pldm_entity_association_tree_add(
-        tree, &entities[25], 14, l4b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-
-    auto l7a = pldm_entity_association_tree_add(
-        tree, &entities[26], 5, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l7b = pldm_entity_association_tree_add(
-        tree, &entities[27], 6, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l7c = pldm_entity_association_tree_add(
-        tree, &entities[28], 8, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l7d = pldm_entity_association_tree_add(
-        tree, &entities[29], 9, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l7e = pldm_entity_association_tree_add(
-        tree, &entities[30], 11, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l7f = pldm_entity_association_tree_add(
-        tree, &entities[31], 12, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l7g = pldm_entity_association_tree_add(
-        tree, &entities[32], 13, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l7h = pldm_entity_association_tree_add(
-        tree, &entities[33], 14, l3a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-
-    auto l8a = pldm_entity_association_tree_add(
-        tree, &entities[34], 1, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l8b = pldm_entity_association_tree_add(
-        tree, &entities[35], 2, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l8c = pldm_entity_association_tree_add(
-        tree, &entities[36], 4, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l8d = pldm_entity_association_tree_add(
-        tree, &entities[37], 10, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l8e = pldm_entity_association_tree_add(
-        tree, &entities[38], 12, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l8f = pldm_entity_association_tree_add(
-        tree, &entities[39], 13, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
-    auto l8g = pldm_entity_association_tree_add(
-        tree, &entities[40], 14, l3b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    auto l5a = pldm_entity_association_tree_add(tree, &entities[6], 0, l3b,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true);
+    auto l5b = pldm_entity_association_tree_add(tree, &entities[7], 1, l3b,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true);
 
     EntityAssociations entityAssociations = {
-        {l1, l2a, l2b},
-        {l2a, l3a, l3b},
-        {l2b, l4a, l4b},
-        {l4a, l5a, l5b, l5c, l5d, l5e, l5f, l5g, l5h, l5i},
-        {l4b, l6a, l6b, l6c, l6d, l6e, l6f},
-        {l3a, l7a, l7b, l7c, l7d, l7e, l7f, l7g, l7h},
-        {l3b, l8a, l8b, l8c, l8d, l8e, l8f, l8g}};
+        {l1, l2}, {l2, l3a, l3b}, {l3a, l4a, l4b}, {l3b, l5a, l5b}};
 
     ObjectPathMaps retObjectMaps = {
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu0/core5", l7a},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu0/core6", l7b},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu0/core8", l7c},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu0/core9", l7d},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu0/core11", l7e},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu0/core12", l7f},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu0/core13", l7g},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu0/core14", l7h},
-
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu1/core1", l8a},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu1/core2", l8b},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu1/core4", l8c},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu1/core10", l8d},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu1/core12", l8e},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu1/core13", l8f},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm0/cpu1/core14", l8g},
-
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core0", l5a},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core2", l5b},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core3", l5c},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core5", l5d},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core6", l5e},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core7", l5f},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core8", l5g},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core9", l5h},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu0/core15", l5i},
-
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu1/core1", l6a},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu1/core2", l6b},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu1/core4", l6c},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu1/core8", l6d},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu1/core10", l6e},
-        {"/xyz/openbmc_project/inventory/motherboard1/dcm1/cpu1/core14", l6f}};
+        {"/xyz/openbmc_project/inventory/chassis1", l1},
+        {"/xyz/openbmc_project/inventory/chassis1/motherboard1", l2},
+        {"/xyz/openbmc_project/inventory/chassis1/motherboard1/dcm0", l3a},
+        {"/xyz/openbmc_project/inventory/chassis1/motherboard1/dcm0/cpu0", l4a},
+        {"/xyz/openbmc_project/inventory/chassis1/motherboard1/dcm0/cpu1", l4b},
+        {"/xyz/openbmc_project/inventory/chassis1/motherboard1/dcm1", l3b},
+        {"/xyz/openbmc_project/inventory/chassis1/motherboard1/dcm1/cpu0", l5a},
+        {"/xyz/openbmc_project/inventory/chassis1/motherboard1/dcm1/cpu1",
+         l5b}};
 
     ObjectPathMaps objPathMap;
-    updateEntityAssociation(entityAssociations, tree, objPathMap, nullptr);
+    pldm::hostbmc::utils::updateEntityAssociation(entityAssociations, tree,
+                                                  objPathMap, nullptr);
 
     EXPECT_EQ(objPathMap.size(), retObjectMaps.size());
 

--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -2,6 +2,7 @@
 
 #include "libpldm/entity.h"
 
+#include "common/utils.hpp"
 #include "utils.hpp"
 
 #include <iostream>
@@ -102,6 +103,20 @@ void addObjectPathEntityAssociations(
                 path /
                 fs::path{entityName +
                          std::to_string(node_entity.entity_instance_num)};
+            std::string entity_path = p.string();
+            if (oemPlatformHandler != nullptr)
+            {
+                oemPlatformHandler->upadteOemDbusPaths(entity_path);
+            }
+            try
+            {
+                pldm::utils::DBusHandler().getService(entity_path.c_str(),
+                                                      nullptr);
+            }
+            catch (const std::exception& e)
+            {
+                objPathMap[entity_path] = entity;
+            }
 
             for (size_t i = 1; i < ev.size(); i++)
             {
@@ -122,7 +137,14 @@ void addObjectPathEntityAssociations(
         {
             oemPlatformHandler->upadteOemDbusPaths(dbusPath);
         }
-        objPathMap[dbusPath] = entity;
+        try
+        {
+            pldm::utils::DBusHandler().getService(dbusPath.c_str(), nullptr);
+        }
+        catch (const std::exception& e)
+        {
+            objPathMap[dbusPath] = entity;
+        }
     }
 }
 

--- a/host-bmc/utils.hpp
+++ b/host-bmc/utils.hpp
@@ -31,7 +31,13 @@ const std::map<EntityType, EntityName> entityMaps = {
     {PLDM_ENTITY_PROC, "cpu"},
     {PLDM_ENTITY_SYSTEM_LOGICAL, "system"},
     {PLDM_ENTITY_PROC_MODULE, "dcm"},
-    {PLDM_ENTITY_PROC | 0x8000, "core"}};
+    {PLDM_ENTITY_PROC | 0x8000, "core"},
+    {PLDM_ENTITY_IO_MODULE, "io_module"},
+    {PLDM_ENTITY_FAN, "fan"},
+    {PLDM_ENTITY_SYS_MGMT_MODULE, "system_management_module"},
+    {PLDM_ENTITY_POWER_CONVERTER, "power_converter"},
+    {PLDM_ENTITY_SLOT, "slot"},
+    {PLDM_ENTITY_CONNECTOR, "connector"}};
 
 namespace hostbmc
 {

--- a/libpldm/tests/libpldm_pdr_test.cpp
+++ b/libpldm/tests/libpldm_pdr_test.cpp
@@ -18,21 +18,62 @@ TEST(PDRUpdate, testAdd)
     auto repo = pldm_pdr_init();
 
     std::array<uint8_t, 10> data{};
-    auto handle = pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    auto handle = pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     EXPECT_EQ(handle, 1u);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo), data.size());
 
-    handle = pldm_pdr_add(repo, data.data(), data.size(), 0u, false);
+    handle = pldm_pdr_add(repo, data.data(), data.size(), 0u, false, 1);
     EXPECT_EQ(handle, 2u);
-    handle = pldm_pdr_add(repo, data.data(), data.size(), 0u, false);
+    handle = pldm_pdr_add(repo, data.data(), data.size(), 0u, false, 1);
     EXPECT_EQ(handle, 3u);
     handle = pldm_pdr_add(repo, data.data(), data.size(), htole32(0xdeeddeedu),
-                          false);
+                          false, 1);
     EXPECT_EQ(handle, htole32(0xdeeddeed));
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo), data.size() * 4u);
 
+    pldm_pdr_destroy(repo);
+}
+
+TEST(PDRRemoveByTerminus, testRemoveByTerminus)
+{
+    std::array<uint8_t, 10> data{};
+
+    auto repo = pldm_pdr_init();
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_remove_pdrs_by_terminus_handle(1, repo);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 0u);
+    pldm_pdr_destroy(repo);
+
+    repo = pldm_pdr_init();
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 2);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
+    pldm_pdr_remove_pdrs_by_terminus_handle(1, repo);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
+    pldm_pdr_destroy(repo);
+
+    repo = pldm_pdr_init();
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 2);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 2);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 3u);
+    pldm_pdr_remove_pdrs_by_terminus_handle(2, repo);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
+    pldm_pdr_destroy(repo);
+
+    repo = pldm_pdr_init();
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 2);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 3u);
+    pldm_pdr_remove_remote_pdrs(repo);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
+    pldm_pdr_remove_pdrs_by_terminus_handle(1, repo);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
+    pldm_pdr_remove_pdrs_by_terminus_handle(2, repo);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 0u);
     pldm_pdr_destroy(repo);
 }
 
@@ -46,161 +87,161 @@ TEST(PDRUpdate, testRemove)
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 0u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 0u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 6u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 3u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 5u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 3u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 5u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 3u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 5u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 3u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 3u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
     pldm_pdr_destroy(repo);
 
     repo = pldm_pdr_init();
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, false);
-    pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
+    pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     pldm_pdr_remove_remote_pdrs(repo);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
-    auto handle = pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    auto handle = pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     EXPECT_EQ(handle, 3u);
-    handle = pldm_pdr_add(repo, data.data(), data.size(), 0, true);
+    handle = pldm_pdr_add(repo, data.data(), data.size(), 0, true, 1);
     EXPECT_EQ(handle, 4u);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
     pldm_pdr_destroy(repo);
@@ -212,7 +253,7 @@ TEST(PDRAccess, testGet)
 
     std::array<uint32_t, 10> in{100, 345, 3, 6, 89, 0, 11, 45, 23434, 123123};
     pldm_pdr_add(repo, reinterpret_cast<uint8_t*>(in.data()), sizeof(in), 1,
-                 false);
+                 false, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo), sizeof(in));
     uint32_t size{};
@@ -244,11 +285,11 @@ TEST(PDRAccess, testGet)
     std::array<uint32_t, 10> in2{1000, 3450, 30,  60,     890,
                                  0,    110,  450, 234034, 123123};
     pldm_pdr_add(repo, reinterpret_cast<uint8_t*>(in2.data()), sizeof(in2), 2,
-                 false);
+                 false, 1);
     pldm_pdr_add(repo, reinterpret_cast<uint8_t*>(in2.data()), sizeof(in2), 3,
-                 false);
+                 false, 1);
     pldm_pdr_add(repo, reinterpret_cast<uint8_t*>(in2.data()), sizeof(in2), 4,
-                 true);
+                 true, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo), sizeof(in2) * 4);
     hdl = pldm_pdr_find_record(repo, 0, &outData, &size, &nextRecHdl);
@@ -294,7 +335,7 @@ TEST(PDRAccess, testGetNext)
 
     std::array<uint32_t, 10> in{100, 345, 3, 6, 89, 0, 11, 45, 23434, 123123};
     pldm_pdr_add(repo, reinterpret_cast<uint8_t*>(in.data()), sizeof(in), 1,
-                 false);
+                 false, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo), sizeof(in));
     uint32_t size{};
@@ -310,11 +351,11 @@ TEST(PDRAccess, testGetNext)
     std::array<uint32_t, 10> in2{1000, 3450, 30,  60,     890,
                                  0,    110,  450, 234034, 123123};
     pldm_pdr_add(repo, reinterpret_cast<uint8_t*>(in2.data()), sizeof(in2), 2,
-                 false);
+                 false, 1);
     pldm_pdr_add(repo, reinterpret_cast<uint8_t*>(in2.data()), sizeof(in2), 3,
-                 false);
+                 false, 1);
     pldm_pdr_add(repo, reinterpret_cast<uint8_t*>(in2.data()), sizeof(in2), 4,
-                 false);
+                 false, 1);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo), sizeof(in2) * 4);
     hdl = pldm_pdr_get_next_record(repo, hdl, &outData, &size, &nextRecHdl);
@@ -346,13 +387,13 @@ TEST(PDRAccess, testFindByType)
     std::array<uint8_t, sizeof(pldm_pdr_hdr)> data{};
     pldm_pdr_hdr* hdr = reinterpret_cast<pldm_pdr_hdr*>(data.data());
     hdr->type = 1;
-    auto first = pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    auto first = pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     hdr->type = 2;
-    auto second = pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    auto second = pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     hdr->type = 3;
-    auto third = pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    auto third = pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
     hdr->type = 4;
-    auto fourth = pldm_pdr_add(repo, data.data(), data.size(), 0, false);
+    auto fourth = pldm_pdr_add(repo, data.data(), data.size(), 0, false, 1);
 
     uint8_t* outData = nullptr;
     uint32_t size{};
@@ -533,36 +574,39 @@ TEST(EntityAssociationPDR, testBuild)
 
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l1, nullptr);
-    auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2a = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2a, nullptr);
-    auto l2b = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2b, nullptr);
-    auto l2c = pldm_entity_association_tree_add(
-        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2c = pldm_entity_association_tree_add(tree, &entities[3], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2c, nullptr);
     auto l3a = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l3a, nullptr);
     auto l3b = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l3b, nullptr);
     auto l3c = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l3b, nullptr);
     auto l4a = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l3a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l4a, nullptr);
     auto l4b = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l3b,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l4b, nullptr);
 
     EXPECT_EQ(pldm_entity_is_node_parent(l1), true);
@@ -719,7 +763,7 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     auto tree = pldm_entity_association_tree_init();
     auto node = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(node, nullptr);
     size_t num{};
     pldm_entity* out = nullptr;
@@ -735,15 +779,15 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false);
+                                            false, true);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false);
+                                            false, true);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false);
+                                            false, true);
     EXPECT_NE(node, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 3u);
@@ -767,15 +811,15 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false);
+                                            false, true);
     EXPECT_NE(node, nullptr);
     auto node1 = pldm_entity_association_tree_add(
         tree, &entities[1], 0xFFFF, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(node1, nullptr);
     auto node2 = pldm_entity_association_tree_add(
         tree, &entities[2], 0xFFFF, node1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(node2, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 3u);
@@ -797,19 +841,19 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false);
+                                            false, true);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false);
+                                            false, true);
     EXPECT_NE(node, nullptr);
     node1 = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, node,
                                              PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                             false);
+                                             false, true);
     EXPECT_NE(node1, nullptr);
     node2 = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, node,
                                              PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                             false);
+                                             false, true);
     EXPECT_NE(node2, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 4u);
@@ -868,48 +912,54 @@ TEST(EntityAssociationPDR, testPDR)
 
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l1, nullptr);
     auto l1a = pldm_entity_association_tree_add(
         tree, &entities[1], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l1a, nullptr);
 
-    auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2a = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2a, nullptr);
-    auto l2b = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
+    auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_LOGICAL,
+                                                false, true);
     EXPECT_NE(l2b, nullptr);
-    auto l2c = pldm_entity_association_tree_add(
-        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2c = pldm_entity_association_tree_add(tree, &entities[3], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2c, nullptr);
-    auto l2d = pldm_entity_association_tree_add(
-        tree, &entities[4], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
+    auto l2d = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_LOGICAL,
+                                                false, true);
     EXPECT_NE(l2d, nullptr);
 
     auto l3a = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l3a, nullptr);
     auto l3b = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l3b, nullptr);
-    auto l3c = pldm_entity_association_tree_add(
-        tree, &entities[7], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
+    auto l3c = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_LOGICAL,
+                                                false, true);
     EXPECT_NE(l3c, nullptr);
-    auto l3d = pldm_entity_association_tree_add(
-        tree, &entities[8], 0xFFFF, l2a, PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
+    auto l3d = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l2a,
+                                                PLDM_ENTITY_ASSOCIAION_LOGICAL,
+                                                false, true);
     EXPECT_NE(l3d, nullptr);
 
     auto l4a = pldm_entity_association_tree_add(tree, &entities[9], 0xFFFF, l3a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l4a, nullptr);
-    auto l4b =
-        pldm_entity_association_tree_add(tree, &entities[10], 0xFFFF, l3b,
-                                         PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
+    auto l4b = pldm_entity_association_tree_add(
+        tree, &entities[10], 0xFFFF, l3b, PLDM_ENTITY_ASSOCIAION_LOGICAL, false,
+        true);
     EXPECT_NE(l4b, nullptr);
 
     EXPECT_EQ(pldm_entity_get_num_children(l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL),
@@ -924,7 +974,7 @@ TEST(EntityAssociationPDR, testPDR)
               1);
 
     auto repo = pldm_pdr_init();
-    pldm_entity_association_pdr_add(tree, repo, false);
+    pldm_entity_association_pdr_add(tree, repo, false, 1);
 
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 6u);
 
@@ -1171,36 +1221,39 @@ TEST(EntityAssociationPDR, testFind)
 
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l1, nullptr);
-    auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2a = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2a, nullptr);
-    auto l2b = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2b, nullptr);
-    auto l2c = pldm_entity_association_tree_add(
-        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2c = pldm_entity_association_tree_add(tree, &entities[3], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2c, nullptr);
     auto l3a = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l3a, nullptr);
     auto l3b = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l3b, nullptr);
     auto l3c = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l3c, nullptr);
     auto l4a = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l3a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l4a, nullptr);
     auto l4b = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l3b,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false);
+                                                false, true);
     EXPECT_NE(l4b, nullptr);
 
     pldm_entity entity{};
@@ -1248,19 +1301,19 @@ TEST(EntityAssociationPDR, testCopyTree)
     auto newTree = pldm_entity_association_tree_init();
     auto l1 = pldm_entity_association_tree_add(
         orgTree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(
         orgTree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(
         orgTree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(
         orgTree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l2c, nullptr);
     size_t orgNum{};
     pldm_entity* orgOut = nullptr;
@@ -1358,31 +1411,37 @@ TEST(EntityAssociationPDR, testGetChildren)
     auto tree = pldm_entity_association_tree_init();
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(l1, nullptr);
-    auto l2a = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2a = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2a, nullptr);
-    auto l2b = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2b, nullptr);
-    auto l2c = pldm_entity_association_tree_add(
-        tree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2c = pldm_entity_association_tree_add(tree, &entities[3], 0xFFFF, l1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l2c, nullptr);
 
     pldm_entity et1;
     et1.entity_type = 2;
     et1.entity_instance_num = 1;
+    et1.entity_container_id = 1;
     EXPECT_EQ(true, pldm_is_current_parent_child(l1, &et1));
 
     pldm_entity et2;
     et2.entity_type = 2;
     et2.entity_instance_num = 2;
+    et2.entity_container_id = 1;
     EXPECT_EQ(true, pldm_is_current_parent_child(l1, &et2));
 
     pldm_entity et3;
     et3.entity_type = 2;
     et3.entity_instance_num = 3;
+    et3.entity_container_id = 1;
     EXPECT_EQ(false, pldm_is_current_parent_child(l1, &et3));
 
     pldm_entity_association_tree_destroy(tree);
@@ -1399,6 +1458,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     entities[4].entity_type = 2;
     entities[5].entity_type = 2;
     entities[6].entity_type = 2;
+    entities[6].entity_container_id = 1;
     entities[7].entity_type = 3;
     entities[8].entity_type = 3;
 
@@ -1412,11 +1472,12 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto node = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false);
+        false, true);
     EXPECT_NE(node, nullptr);
 
-    auto l1 = pldm_entity_association_tree_add(
-        tree, &entities[1], 63, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l1 = pldm_entity_association_tree_add(tree, &entities[1], 63, node,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     auto first = pldm_pdr_add_fru_record_set(
         repo, 1, 1, entities[1].entity_type, entities[1].entity_instance_num,
         entities[1].entity_container_id, 1);
@@ -1429,8 +1490,9 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 2);
     EXPECT_EQ(entityInstanceNum, 63);
 
-    auto l2 = pldm_entity_association_tree_add(
-        tree, &entities[2], 37, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2 = pldm_entity_association_tree_add(tree, &entities[2], 37, node,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     auto second = pldm_pdr_add_fru_record_set(
         repo, 1, 2, entities[2].entity_type, entities[2].entity_instance_num,
         entities[2].entity_container_id, 2);
@@ -1443,8 +1505,9 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 2);
     EXPECT_EQ(entityInstanceNum, 37);
 
-    auto l3 = pldm_entity_association_tree_add(
-        tree, &entities[3], 44, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l3 = pldm_entity_association_tree_add(tree, &entities[3], 44, node,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     auto third = pldm_pdr_add_fru_record_set(
         repo, 1, 3, entities[3].entity_type, entities[3].entity_instance_num,
         entities[3].entity_container_id, 3);
@@ -1457,8 +1520,9 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 2);
     EXPECT_EQ(entityInstanceNum, 44);
 
-    auto l4 = pldm_entity_association_tree_add(
-        tree, &entities[4], 89, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l4 = pldm_entity_association_tree_add(tree, &entities[4], 89, node,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     auto fourth = pldm_pdr_add_fru_record_set(
         repo, 1, 4, entities[4].entity_type, entities[4].entity_instance_num,
         entities[4].entity_container_id, 4);
@@ -1473,7 +1537,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto l5 = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, node,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false);
+                                               false, true);
     auto fifth = pldm_pdr_add_fru_record_set(
         repo, 1, 5, entities[5].entity_type, entities[5].entity_instance_num,
         entities[5].entity_container_id, 5);
@@ -1486,12 +1550,14 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 2);
     EXPECT_EQ(entityInstanceNum, 90);
 
-    auto l6 = pldm_entity_association_tree_add(
-        tree, &entities[6], 90, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l6 = pldm_entity_association_tree_add(tree, &entities[6], 90, node,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     EXPECT_EQ(l6, nullptr);
 
-    auto l7 = pldm_entity_association_tree_add(
-        tree, &entities[7], 100, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l7 = pldm_entity_association_tree_add(tree, &entities[7], 100, l1,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     auto seventh = pldm_pdr_add_fru_record_set(
         repo, 1, 7, entities[7].entity_type, entities[7].entity_instance_num,
         entities[7].entity_container_id, 7);
@@ -1504,8 +1570,9 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
     EXPECT_EQ(entityType, 3);
     EXPECT_EQ(entityInstanceNum, 100);
 
-    auto l8 = pldm_entity_association_tree_add(
-        tree, &entities[8], 100, l2, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l8 = pldm_entity_association_tree_add(tree, &entities[8], 100, l2,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     auto eighth = pldm_pdr_add_fru_record_set(
         repo, 1, 8, entities[8].entity_type, entities[8].entity_instance_num,
         entities[8].entity_container_id, 8);
@@ -1557,27 +1624,33 @@ TEST(EntityAssociationPDR, findAndAddHostPDR)
 
     auto tree = pldm_entity_association_tree_init();
 
-    auto l1 =
-        pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
-                                         PLDM_ENTITY_ASSOCIAION_LOGICAL, false);
+    auto l1 = pldm_entity_association_tree_add(
+        tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_LOGICAL,
+        false, true);
     EXPECT_NE(l1, nullptr);
-    auto l2 = pldm_entity_association_tree_add(
-        tree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l2 = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     EXPECT_NE(l2, nullptr);
-    auto l3 = pldm_entity_association_tree_add(
-        tree, &entities[2], 0xFFFF, l2, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l3 = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l2,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               false, true);
     EXPECT_NE(l3, nullptr);
-    auto l4a = pldm_entity_association_tree_add(
-        tree, &entities[3], 0, l3, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l4a = pldm_entity_association_tree_add(tree, &entities[3], 0, l3,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l4a, nullptr);
-    auto l4b = pldm_entity_association_tree_add(
-        tree, &entities[4], 1, l3, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false);
+    auto l4b = pldm_entity_association_tree_add(tree, &entities[4], 1, l3,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                false, true);
     EXPECT_NE(l4b, nullptr);
-    auto l5a = pldm_entity_association_tree_add(
-        tree, &entities[5], 0, l4a, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    auto l5a = pldm_entity_association_tree_add(tree, &entities[5], 0, l4a,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true);
     EXPECT_NE(l5a, nullptr);
-    auto l5b = pldm_entity_association_tree_add(
-        tree, &entities[6], 0, l4b, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    auto l5b = pldm_entity_association_tree_add(tree, &entities[6], 0, l4b,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true);
     EXPECT_NE(l5b, nullptr);
 
     pldm_entity entity{};
@@ -1590,8 +1663,9 @@ TEST(EntityAssociationPDR, findAndAddHostPDR)
     EXPECT_EQ(entities[5].entity_container_id, 4);
     EXPECT_EQ(pldm_extract_host_container_id(l5a), 2);
 
-    auto l6a = pldm_entity_association_tree_add(
-        tree, &entities[7], 0, result1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    auto l6a = pldm_entity_association_tree_add(tree, &entities[7], 0, result1,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true);
     EXPECT_NE(l6a, nullptr);
 
     entity.entity_type = 135;
@@ -1602,8 +1676,9 @@ TEST(EntityAssociationPDR, findAndAddHostPDR)
     EXPECT_EQ(entities[6].entity_container_id, 5);
     EXPECT_EQ(pldm_extract_host_container_id(l5b), 3);
 
-    auto l7a = pldm_entity_association_tree_add(
-        tree, &entities[8], 0, result2, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true);
+    auto l7a = pldm_entity_association_tree_add(tree, &entities[8], 0, result2,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true);
     EXPECT_NE(l7a, nullptr);
 
     pldm_entity_association_tree_destroy(tree);

--- a/libpldmresponder/bios.cpp
+++ b/libpldmresponder/bios.cpp
@@ -183,7 +183,7 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
                                 "uint64_t"};
         pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
     }
-    catch (std::exception& e)
+    catch (const std::exception& e)
     {
 
         std::cerr << "Error Setting time,PATH=" << setTimePath

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -799,7 +799,7 @@ void BIOSConfig::processBiosAttrChangeNotification(
     {
         attrNameHdl = biosStringTable.findHandle(attrName);
     }
-    catch (std::invalid_argument& e)
+    catch (const std::invalid_argument& e)
     {
         std::cerr << "Could not find handle for BIOS string, ATTRIBUTE="
                   << attrName.c_str() << "\n";

--- a/libpldmresponder/bios_table.cpp
+++ b/libpldmresponder/bios_table.cpp
@@ -23,7 +23,7 @@ bool BIOSTable::isEmpty() const noexcept
     {
         empty = fs::is_empty(filePath);
     }
-    catch (fs::filesystem_error& e)
+    catch (const fs::filesystem_error& e)
     {
         return true;
     }

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -24,6 +24,7 @@ sources = [
   '../host-bmc/host_pdr_handler.cpp',
   '../host-bmc/dbus_to_event_handler.cpp',
   '../host-bmc/dbus_to_host_effecters.cpp',
+  '../host-bmc/host_associations_parser.cpp',
   '../host-bmc/host_condition.cpp',
   '../host-bmc/utils.cpp',
   '../host-bmc/custom_dbus.cpp',

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -129,6 +129,7 @@ class Handler : public CmdHandler
     virtual void upadteOemDbusPaths(std::string& dbusPath) = 0;
     /** @brief Interface to update container ID */
     virtual void updateContainerID() = 0;
+    virtual void modifyPDROemActions(uint32_t recordHandle, pldm_pdr* repo) = 0;
 
     virtual ~Handler() = default;
 

--- a/libpldmresponder/pdr_state_effecter.hpp
+++ b/libpldmresponder/pdr_state_effecter.hpp
@@ -31,7 +31,6 @@ template <class DBusInterface, class Handler>
 void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
                               Handler& handler, pdr_utils::RepoInterface& repo)
 {
-    std::cout << "\nenter generateStateEffecterPDR" << std::endl;
     static const std::vector<Json> emptyList{};
     auto entries = json.value("entries", emptyList);
     for (const auto& e : entries)
@@ -169,7 +168,6 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
         pdrEntry.size = pdrSize;
         repo.addRecord(pdrEntry);
     }
-    std::cout << "\nexit generateStateEffecterPDR" << std::endl;
 }
 
 } // namespace pdr_state_effecter

--- a/libpldmresponder/pdr_state_sensor.hpp
+++ b/libpldmresponder/pdr_state_sensor.hpp
@@ -28,7 +28,6 @@ template <class DBusInterface, class Handler>
 void generateStateSensorPDR(const DBusInterface& dBusIntf, const Json& json,
                             Handler& handler, pdr_utils::RepoInterface& repo)
 {
-    std::cout << "\nenter generateStateSensorPDR " << std::endl;
     static const std::vector<Json> emptyList{};
     auto entries = json.value("entries", emptyList);
     for (const auto& e : entries)
@@ -181,7 +180,6 @@ void generateStateSensorPDR(const DBusInterface& dBusIntf, const Json& json,
         pdrEntry.size = pdrSize;
         repo.addRecord(pdrEntry);
     }
-    std::cout << "\nexit generateStateSensorPDR " << std::endl;
 }
 
 } // namespace pdr_state_sensor

--- a/libpldmresponder/pdr_utils.hpp
+++ b/libpldmresponder/pdr_utils.hpp
@@ -246,6 +246,14 @@ std::tuple<pldm::pdr::TerminusHandle, pldm::pdr::SensorID,
 std::vector<FruRecordDataFormat> parseFruRecordTable(const uint8_t* fruData,
                                                      size_t fruLen);
 
+/** @brief Method to fetch the bitmap of possible states from a PDR
+ *
+ *  @param[in] pdrs - The PDR to fetch the bitmap from
+ *
+ *  @return the bitmap of possible states
+ *  */
+std::vector<uint8_t> fetchBitMap(std::vector<std::vector<uint8_t>> pdrs);
+
 } // namespace pdr_utils
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/configurations/events/oem_ibm_event_state_sensor.json
+++ b/oem/ibm/configurations/events/oem_ibm_event_state_sensor.json
@@ -1,7 +1,7 @@
 {
     "entries": [
         {
-            "containerID": 0,
+            "containerID": 32784,
             "entityType": 57346,
             "entityInstance": 0,
             "sensorOffset": 1,
@@ -43,6 +43,51 @@
                     false
                 ]
             }
+        },
+        {
+            "containerID": 0,
+            "entityType": 57346,
+            "entityInstance": 0,
+            "sensorOffset": 1,
+            "event_states": [
+                1,
+                2,
+                3
+            ],
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0",
+                "interface": "xyz.openbmc_project.Object.Enable",
+                "property_name": "Enabled",
+                "property_type": "bool",
+                "property_values": [
+                    true,
+                    false,
+                    false
+                ]
+            }
+        },
+        {
+            "containerID": 32784,
+            "entityType": 57346,
+            "entityInstance": 1,
+            "sensorOffset": 1,
+            "event_states": [
+                1,
+                2,
+                3
+            ],
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0",
+                "interface": "xyz.openbmc_project.Object.Enable",
+                "property_name": "Enabled",
+                "property_type": "bool",
+                "property_values": [
+                    true,
+                    false,
+                    false
+                ]
+            }
         }
+
      ]
 }

--- a/oem/ibm/libpldm/state_set.h
+++ b/oem/ibm/libpldm/state_set.h
@@ -14,6 +14,9 @@ enum ibm_oem_pldm_state_set_ids {
 	PLDM_OEM_IBM_SBE_MAINTENANCE_STATE = 32772,
 	PLDM_OEM_IBM_BOOT_SIDE_RENAME = 32773,
 	PLDM_OEM_IBM_SBE_SEMANTIC_ID = 32775,
+	PLDM_OEM_IBM_SBE_HRESET_STATE = 32776,
+
+	PLDM_OEM_IBM_PANEL_TRIGGER_STATE = 32778,
 	PLDM_OEM_IBM_SLOT_ENABLE_EFFECTER_STATE = 32779,
 	PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE = 32780,
 };
@@ -64,6 +67,11 @@ enum ibm_oem_pldm_state_set_sbe_dump_state_values {
 enum ibm_oem_pldm_state_set_boot_side_rename_state_values {
 	PLDM_BOOT_SIDE_NOT_RENAMED = 1,
 	PLDM_BOOT_SIDE_HAS_BEEN_RENAMED = 2,
+};
+enum ibm_oem_pldm_state_set_sbe_hreset_state_values {
+	SBE_HRESET_NOT_READY = 0x1,
+	SBE_HRESET_READY = 0x2,
+	SBE_HRESET_FAILED = 0x3,
 };
 
 #ifdef __cplusplus

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -262,7 +262,7 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
     {
         value = table.at(fileHandle);
     }
-    catch (std::exception& e)
+    catch (const std::exception& e)
     {
         std::cerr << "File handle does not exist in the file table, HANDLE="
                   << fileHandle << "\n";
@@ -354,7 +354,7 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
     {
         value = table.at(fileHandle);
     }
-    catch (std::exception& e)
+    catch (const std::exception& e)
     {
         std::cerr << "File handle does not exist in the file table, HANDLE="
                   << fileHandle << "\n";
@@ -479,7 +479,7 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
     {
         value = table.at(fileHandle);
     }
-    catch (std::exception& e)
+    catch (const std::exception& e)
     {
         std::cerr << "File handle does not exist in the file table, HANDLE="
                   << fileHandle << "\n";
@@ -560,7 +560,7 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
     {
         value = table.at(fileHandle);
     }
-    catch (std::exception& e)
+    catch (const std::exception& e)
     {
         std::cerr << "File handle does not exist in the file table, HANDLE="
                   << fileHandle << "\n";

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -115,8 +115,8 @@ int PelHandler::readIntoMemory(uint32_t offset, uint32_t& length,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "GetPEL D-Bus call failed, PEL id = " << fileHandle
-                  << ", error = " << e.what() << "\n";
+        std::cerr << "GetPEL D-Bus call failed, PEL id = 0x" << std::hex
+                  << fileHandle << ", error = " << e.what() << "\n";
         return PLDM_ERROR;
     }
 
@@ -183,7 +183,8 @@ int PelHandler::read(uint32_t offset, uint32_t& length, Response& response,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "GetPEL D-Bus call failed";
+        std::cerr << "GetPEL D-Bus call failed on PEL ID 0x" << std::hex
+                  << fileHandle << ", error = " << e.what() << "\n";
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;
@@ -229,7 +230,8 @@ int PelHandler::fileAck(uint8_t /*fileStatus*/)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "HostAck D-Bus call failed";
+        std::cerr << "HostAck D-Bus call failed on PEL ID 0x" << std::hex
+                  << fileHandle << ", error = " << e.what() << "\n";
         return PLDM_ERROR;
     }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -907,6 +907,12 @@ void pldm::responder::oem_ibm_platform::Handler::upadteOemDbusPaths(
         size_t pos = dbusPath.find(toFind);
         dbusPath.replace(pos, toFind.length(), "system/chassis/motherboard");
     }
+    toFind = "system1";
+    if (dbusPath.find(toFind) != std::string::npos)
+    {
+        size_t pos = dbusPath.find(toFind);
+        dbusPath.replace(pos, toFind.length(), "system");
+    }
 }
 void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
     sdeventplus::source::EventBase& /*source */)
@@ -1089,6 +1095,23 @@ int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;
+}
+void pldm::responder::oem_ibm_platform::Handler::modifyPDROemActions(
+    uint32_t /*recordHandle*/, pldm_pdr* repo)
+{
+    // need to add a change here to compare the recordHandle before fetching the
+    // panel effecter and calling panel
+    auto pdrs = pldm::utils::findStateEffecterPDR(
+        0xD0,
+        pldm::responder::oem_ibm_platform::PLDM_OEM_IBM_FRONT_PANEL_TRIGGER,
+        PLDM_OEM_IBM_PANEL_TRIGGER_STATE, repo);
+    if (!std::empty(pdrs))
+    {
+        auto bitMap = responder::pdr_utils::fetchBitMap(pdrs);
+        pldm::utils::dbusMethodCall("com.ibm.PanelApp", "/com/ibm/panel_app",
+                                    "toggleFunctionState", "com.ibm.panel",
+                                    bitMap);
+    }
 }
 
 void pldm::responder::oem_ibm_platform::Handler::updateContainerID()

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -25,6 +25,7 @@ namespace oem_ibm_platform
 {
 
 static constexpr auto PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577;
+static constexpr auto PLDM_OEM_IBM_FRONT_PANEL_TRIGGER = 32837;
 constexpr uint16_t ENTITY_INSTANCE_0 = 0;
 constexpr uint16_t ENTITY_INSTANCE_1 = 1;
 
@@ -44,15 +45,15 @@ class Handler : public oem_platform::Handler
 {
   public:
     Handler(const pldm::utils::DBusHandler* dBusIntf,
-            pldm::responder::CodeUpdate* codeUpdate, pldm_pdr* repo,
+            pldm::responder::CodeUpdate* codeUpdate,
             pldm::responder::SlotHandler* slotHandler, int mctp_fd,
             uint8_t mctp_eid, pldm::dbus_api::Requester& requester,
-            sdeventplus::Event& event,
+            sdeventplus::Event& event, pldm_pdr* repo,
             pldm::requester::Handler<pldm::requester::Request>* handler) :
         oem_platform::Handler(dBusIntf),
-        codeUpdate(codeUpdate), pdrRepo(repo), slotHandler(slotHandler),
+        codeUpdate(codeUpdate), slotHandler(slotHandler),
         platformHandler(nullptr), mctp_fd(mctp_fd), mctp_eid(mctp_eid),
-        requester(requester), event(event), handler(handler)
+        requester(requester), event(event), pdrRepo(repo), handler(handler)
     {
         codeUpdate->setVersions();
         pldm::responder::utils::clearLicenseStatus();
@@ -84,6 +85,39 @@ class Handler : public oem_platform::Handler
                              "xyz.openbmc_project.State.Host.HostState.Running")
                     {
                         hostOff = false;
+                    }
+                }
+            });
+
+        bootProgressMatch = std::make_unique<sdbusplus::bus::match::match>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged("/xyz/openbmc_project/state/host0",
+                              "xyz.openbmc_project.State.Boot.Progress"),
+            [this](sdbusplus::message::message& msg) {
+                pldm::utils::DbusChangedProps props{};
+                std::string intf;
+                msg.read(intf, props);
+                const auto itr = props.find("BootProgress");
+                if (itr != props.end())
+                {
+                    pldm::utils::PropertyValue value = itr->second;
+                    auto propVal = std::get<std::string>(value);
+                    if (propVal == "xyz.openbmc_project.State.Boot.Progress."
+                                   "ProgressStages.SystemInitComplete")
+                    {
+                        auto pdrs = pldm::utils::findStateEffecterPDR(
+                            0xD0, PLDM_OEM_IBM_FRONT_PANEL_TRIGGER,
+                            PLDM_OEM_IBM_PANEL_TRIGGER_STATE, pdrRepo);
+
+                        if (!std::empty(pdrs))
+                        {
+                            auto bitMap =
+                                responder::pdr_utils::fetchBitMap(pdrs);
+
+                            pldm::utils::dbusMethodCall(
+                                "com.ibm.PanelApp", "/com/ibm/panel_app",
+                                "toggleFunctionState", "com.ibm.panel", bitMap);
+                        }
                     }
                 }
             });
@@ -234,12 +268,11 @@ class Handler : public oem_platform::Handler
     void updateContainerID();
 
     void setHostEffecterState(bool status);
+    void modifyPDROemActions(uint32_t recordHandle, pldm_pdr* repo);
 
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object
-
-    const pldm_pdr* pdrRepo; // the PDR repo
 
     pldm::responder::SlotHandler* slotHandler;
 
@@ -276,11 +309,16 @@ class Handler : public oem_platform::Handler
     /** @brief D-Bus property changed signal match for CurrentPowerState*/
     std::unique_ptr<sdbusplus::bus::match::match> chassisOffMatch;
 
+    const pldm_pdr* pdrRepo;
+
     /** @brief PLDM request handler */
     pldm::requester::Handler<pldm::requester::Request>* handler;
 
     /** @brief D-Bus property changed signal match */
     std::unique_ptr<sdbusplus::bus::match::match> hostOffMatch;
+
+    /** @brief D-Bus property Changed Signal match for bootProgress*/
+    std::unique_ptr<sdbusplus::bus::match::match> bootProgressMatch;
 
     bool hostOff = true;
 

--- a/softoff/softoff.cpp
+++ b/softoff/softoff.cpp
@@ -33,13 +33,13 @@ namespace sdbusRule = sdbusplus::bus::match::rules;
 SoftPowerOff::SoftPowerOff(sdbusplus::bus::bus& bus, sd_event* event) :
     bus(bus), timer(event)
 {
-    auto rc = getHostState();
+    getHostState();
     if (hasError || completed)
     {
         return;
     }
 
-    rc = getEffecterID();
+    auto rc = getEffecterID();
     if (completed)
     {
         std::cerr
@@ -254,12 +254,11 @@ int SoftPowerOff::getSensorInfo()
         for (auto& rep : Response)
         {
             pdr = reinterpret_cast<pldm_state_sensor_pdr*>(rep.data());
-        }
-
-        if (!pdr)
-        {
-            std::cerr << "Failed to get state sensor PDR.\n";
-            return PLDM_ERROR;
+            if (!pdr)
+            {
+                std::cerr << "Failed to get state sensor PDR.\n";
+                return PLDM_ERROR;
+            }
         }
 
         sensorID = pdr->sensor_id;


### PR DESCRIPTION
PLDM Support for MEX FRU & MEX LED

This PR Includes
- MEX FRU & MEX LED Support
- MEX CM Support
- Op Panel Support
- Fixes SW536877
- Additional PEL Tracing
- HRESET State Set Support
- Support for phyp new container ID changes for MEX

Tested By :

1. On a rainier system without a MEX drawer attached.
   - Power on works
   - Boot progress sensor works
   - VMI IP configuration over redfish works

2. On a rainier system with a MEX drawer attached.
   - Power on works
   - Boot progress sensor works
   - VMI IP configuration over redfish works.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>