### PR TITLE
Define the hb_inhibit_bmc_reset BIOS attribute

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -153,6 +153,19 @@
          "displayName" : "hb-debug-console"
       },
       {
+         "attribute_name":"hb_inhibit_bmc_reset",
+         "possible_values":[
+            "NoInhibit",
+            "Inhibit"
+         ],
+         "default_values":[
+            "NoInhibit"
+         ],
+         "helpText" : "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+         "displayName" : "hb-inhibit-bmc-reset",
+         "readOnly":true
+      },
+      {
          "attribute_name":"pvm_system_power_off_policy",
          "possible_values":[
             "Power Off",


### PR DESCRIPTION
This commit defines the hb_inhibit_bmc_reset BIOS attribute. When set
to the enumeration value "Inhibit", Hostboot will instruct PHYP via
HDAT to not reset/reload the BMC at runtime.

Signed-off-by: Zach Clark <zach@ibm.com>
Change-Id: Ibb5ec25649c1c0c5532ae0c93003f46213fe32b1