### PR TITLE
PLDM: Setting the slot power state to Off

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -173,6 +173,54 @@ HostPDRHandler::HostPDRHandler(
                 }
             }
         });
+
+    chassisOffMatch = std::make_unique<sdbusplus::bus::match::match>(
+        pldm::utils::DBusHandler::getBus(),
+        propertiesChanged("/xyz/openbmc_project/state/chassis0",
+                          "xyz.openbmc_project.State.Chassis"),
+        [this](sdbusplus::message::message& msg) {
+            DbusChangedProps props{};
+            std::string intf;
+            msg.read(intf, props);
+            const auto itr = props.find("CurrentPowerState");
+            if (itr != props.end())
+            {
+                PropertyValue value = itr->second;
+                auto propVal = std::get<std::string>(value);
+                if (propVal ==
+                    "xyz.openbmc_project.State.Chassis.PowerState.Off")
+                {
+                    static constexpr auto searchpath =
+                        "/xyz/openbmc_project/inventory/system/chassis/motherboard";
+                    int depth = 0;
+                    std::vector<std::string> powerInterface = {
+                        "xyz.openbmc_project.State.Decorator.PowerState"};
+                    pldm::utils::MapperGetSubTreeResponse response =
+                        pldm::utils::DBusHandler().getSubtree(searchpath, depth,
+                                                              powerInterface);
+                    for (const auto& [objPath, serviceMap] : response)
+                    {
+                        pldm::utils::DBusMapping dbusMapping{
+                            objPath,
+                            "xyz.openbmc_project.State.Decorator.PowerState",
+                            "PowerState", "string"};
+                        value =
+                            "xyz.openbmc_project.State.Decorator.PowerState.State.Off";
+                        try
+                        {
+                            pldm::utils::DBusHandler().setDbusProperty(
+                                dbusMapping, value);
+                        }
+                        catch (const std::exception& e)
+                        {
+                            std::cerr
+                                << "Unable to set the slot power state to Off "
+                                << "ERROR=" << e.what() << "\n";
+                        }
+                    }
+                }
+            }
+        });
 }
 
 void HostPDRHandler::fetchPDR(PDRRecordHandles&& recordHandles, bool isModified)

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -342,6 +342,9 @@ class HostPDRHandler
     /** @brief D-Bus property changed signal match */
     std::unique_ptr<sdbusplus::bus::match::match> hostOffMatch;
 
+    /** @brief D-Bus property changed signal match */
+    std::unique_ptr<sdbusplus::bus::match::match> chassisOffMatch;
+
     /** @brief sensorMap is a lookup data structure that is build from the
      *         hostPDR that speeds up the lookup of <TerminusID, SensorID> in
      *         PlatformEventMessage command request.


### PR DESCRIPTION
This commit sets the slot power state to off when the
host powers off. The host only powers on the slots and
the BMC needs to turn all the slots off when the host powers off.

Tested using the busctl commands.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>
Change-Id: Ie1fe384638a756f2657ea113e8f8aa5e9caace2b