### PR TITLE
Increment max size of hb_lid_ids from 512->1024

### DIFF
--- a/oem/ibm/configurations/bios/string_attrs.json
+++ b/oem/ibm/configurations/bios/string_attrs.json
@@ -91,7 +91,7 @@
          "attribute_name" : "hb_lid_ids",
          "string_type" : "ASCII",
          "minimum_string_length" : 0,
-         "maximum_string_length" : 512,
+         "maximum_string_length" : 1024,
          "default_string_length" : 0,
          "default_string" : "",
          "helpText" : "Provides the host a mapping of the lid IDs to human readable names.",


### PR DESCRIPTION
Merged upstream: https://gerrit.openbmc-project.xyz/c/openbmc/pldm/+/48788

More lid ids are being added to map runtime lids to human readable
names so we must increment the max size to account for this.

Signed-off-by: Christian Geddes <crgeddes@us.ibm.com>
Change-Id: I3a6037ecef37b4d2768d528267018cacfaf1a58a