### PR TITLE
oem: Fix to remove extra system dump

### DIFF
--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -113,6 +113,25 @@ void DbusToFileHandler::reportResourceDumpFailure()
 void DbusToFileHandler::processNewResourceDump(
     const std::string& vspString, const std::string& resDumpReqPass)
 {
+    try
+    {
+        std::string objPath = resDumpCurrentObjPath;
+        auto propVal = pldm::utils::DBusHandler().getDbusPropertyVariant(
+            objPath.c_str(), "Status", resDumpProgressIntf);
+        const auto& curResDumpStatus = std::get<std::string>(propVal);
+
+        if (curResDumpStatus !=
+            "xyz.openbmc_project.Common.Progress.OperationStatus.InProgress")
+        {
+            return;
+        }
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        std::cerr << "Error in getting current resource dump status \n";
+        return;
+    }
+
     namespace fs = std::filesystem;
     const fs::path resDumpDirPath = "/var/lib/pldm/resourcedump";
 


### PR DESCRIPTION
An unwanted system dump is being generated if the resource dump is
initiated from hypervisor with an empty vsp string. So the fix here
is to additionally check the resource dump progress status and block
sending the command to hyperviosr if the status is not in progress.

Tested by initiating a resource dump from hypervisor and extra system
dump is not observed anymore.

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I25c1db3510d6f44b354881e4065aa148fe618464