### PR TITLE
Add orphan entities to the Entity Association PDR's

### DIFF
--- a/configurations/pdr/4.json
+++ b/configurations/pdr/4.json
@@ -4,8 +4,9 @@
     "pdrType" : 4,
     "entries" : [{
         "type" : 91,
-        "instance" : 0,
-        "container" : 1,
+        "instance" : 1,
+        "container" : 2,
+        "parent_entity_path" : "/xyz/openbmc_project/inventory/system/chassis",
         "sensors" : [{
             "set" : {
                 "id" : 21,
@@ -23,8 +24,9 @@
     },
     {
         "type" : 5,
-        "instance" : 0,
-        "container" : 1,
+        "instance" : 1,
+        "container" : 2,
+        "parent_entity_path" : "/xyz/openbmc_project/inventory/system/chassis",
         "sensors" : [{
             "set" : {
                 "id" : 1,
@@ -42,8 +44,9 @@
     },
     {
         "type" : 5,
-        "instance" : 0,
-        "container" : 1,
+        "instance" : 2,
+        "container" : 2,
+        "parent_entity_path" : "/xyz/openbmc_project/inventory/system/chassis",
         "sensors" : [{
             "set" : {
                 "id" : 1,

--- a/libpldmresponder/pdr_numeric_effecter.hpp
+++ b/libpldmresponder/pdr_numeric_effecter.hpp
@@ -27,7 +27,8 @@ static const Json empty{};
 template <class DBusInterface, class Handler>
 void generateNumericEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
                                 Handler& handler,
-                                pdr_utils::RepoInterface& repo)
+                                pdr_utils::RepoInterface& repo,
+                                pldm_entity_association_tree* /*bmcEntityTree*/)
 {
     static const std::vector<Json> emptyList{};
     auto entries = json.value("entries", emptyList);

--- a/libpldmresponder/pdr_state_effecter.hpp
+++ b/libpldmresponder/pdr_state_effecter.hpp
@@ -29,7 +29,8 @@ static const Json empty{};
  */
 template <class DBusInterface, class Handler>
 void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
-                              Handler& handler, pdr_utils::RepoInterface& repo)
+                              Handler& handler, pdr_utils::RepoInterface& repo,
+                              pldm_entity_association_tree* /*bmcEntityTree*/)
 {
     static const std::vector<Json> emptyList{};
     auto entries = json.value("entries", emptyList);

--- a/libpldmresponder/pdr_state_sensor.hpp
+++ b/libpldmresponder/pdr_state_sensor.hpp
@@ -26,7 +26,8 @@ static const Json empty{};
  */
 template <class DBusInterface, class Handler>
 void generateStateSensorPDR(const DBusInterface& dBusIntf, const Json& json,
-                            Handler& handler, pdr_utils::RepoInterface& repo)
+                            Handler& handler, pdr_utils::RepoInterface& repo,
+                            pldm_entity_association_tree* bmcEntityTree)
 {
     static const std::vector<Json> emptyList{};
     auto entries = json.value("entries", emptyList);
@@ -73,11 +74,11 @@ void generateStateSensorPDR(const DBusInterface& dBusIntf, const Json& json,
 
         pdr->terminus_handle = TERMINUS_HANDLE;
         pdr->sensor_id = handler.getNextSensorId();
-
         try
         {
-            std::string entity_path = e.value("entity_path", "");
             auto& associatedEntityMap = handler.getAssociateEntityMap();
+            std::string entity_path = e.value("entity_path", "");
+
             if (entity_path != "" && associatedEntityMap.find(entity_path) !=
                                          associatedEntityMap.end())
             {
@@ -93,6 +94,42 @@ void generateStateSensorPDR(const DBusInterface& dBusIntf, const Json& json,
                 pdr->entity_type = e.value("type", 0);
                 pdr->entity_instance = e.value("instance", 0);
                 pdr->container_id = e.value("container", 0);
+                // now attach this entity to the container that was
+                // mentioned in the json, and add this entity to the
+                // parents entity assocation PDR
+
+                std::string parent_entity_path =
+                    e.value("parent_entity_path", "");
+                if (parent_entity_path != "" &&
+                    associatedEntityMap.contains(parent_entity_path))
+                {
+                    // find the parent node in the tree
+                    pldm_entity parent_entity =
+                        associatedEntityMap.at(parent_entity_path);
+                    pldm_entity child_entity = {pdr->entity_type,
+                                                pdr->entity_instance,
+                                                pdr->container_id};
+                    uint8_t bmcEventDataOps = PLDM_INVALID_OP;
+                    auto parent_node = pldm_entity_association_tree_find(
+                        bmcEntityTree, &parent_entity, false);
+                    if (!parent_node)
+                    {
+                        // parent node not found in the entity association tree,
+                        // this should not be possible
+                        std::cerr
+                            << "Parent Entity of type "
+                            << parent_entity.entity_type
+                            << " not found in the BMC Entity Association tree\n";
+                        return;
+                    }
+                    pldm_entity_association_tree_add(
+                        bmcEntityTree, &child_entity, pdr->entity_instance,
+                        parent_node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false,
+                        false);
+                    pldm_entity_association_pdr_add_contained_entity(
+                        repo.getPdr(), child_entity, parent_entity,
+                        &bmcEventDataOps, false);
+                }
             }
         }
         catch (const std::exception& ex)

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -62,7 +62,8 @@ const std::tuple<pdr_utils::DbusMappings, pdr_utils::DbusValMaps>&
 }
 
 void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
-                       const std::string& dir, Repo& repo)
+                       const std::string& dir, Repo& repo,
+                       pldm_entity_association_tree* bmcEntityTree)
 {
     if (!fs::exists(dir))
     {
@@ -77,23 +78,27 @@ void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
     const std::map<Type, generatePDR> generateHandlers = {
         {PLDM_STATE_EFFECTER_PDR,
          [this](const DBusHandler& dBusIntf, const auto& json,
-                RepoInterface& repo) {
+                RepoInterface& repo,
+                pldm_entity_association_tree* bmcEntityTree) {
              pdr_state_effecter::generateStateEffecterPDR<
-                 pldm::utils::DBusHandler, Handler>(dBusIntf, json, *this,
-                                                    repo);
+                 pldm::utils::DBusHandler, Handler>(dBusIntf, json, *this, repo,
+                                                    bmcEntityTree);
          }},
         {PLDM_NUMERIC_EFFECTER_PDR,
          [this](const DBusHandler& dBusIntf, const auto& json,
-                RepoInterface& repo) {
+                RepoInterface& repo,
+                pldm_entity_association_tree* bmcEntityTree) {
              pdr_numeric_effecter::generateNumericEffecterPDR<
-                 pldm::utils::DBusHandler, Handler>(dBusIntf, json, *this,
-                                                    repo);
+                 pldm::utils::DBusHandler, Handler>(dBusIntf, json, *this, repo,
+                                                    bmcEntityTree);
          }},
-        {PLDM_STATE_SENSOR_PDR, [this](const DBusHandler& dBusIntf,
-                                       const auto& json, RepoInterface& repo) {
+        {PLDM_STATE_SENSOR_PDR,
+         [this](const DBusHandler& dBusIntf, const auto& json,
+                RepoInterface& repo,
+                pldm_entity_association_tree* bmcEntityTree) {
              pdr_state_sensor::generateStateSensorPDR<pldm::utils::DBusHandler,
-                                                      Handler>(dBusIntf, json,
-                                                               *this, repo);
+                                                      Handler>(
+                 dBusIntf, json, *this, repo, bmcEntityTree);
          }}};
 
     Type pdrType{};
@@ -108,14 +113,16 @@ void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
                 for (const auto& effecter : effecterPDRs)
                 {
                     pdrType = effecter.value("pdrType", 0);
-                    generateHandlers.at(pdrType)(dBusIntf, effecter, repo);
+                    generateHandlers.at(pdrType)(dBusIntf, effecter, repo,
+                                                 bmcEntityTree);
                 }
 
                 auto sensorPDRs = json.value("sensorPDRs", empty);
                 for (const auto& sensor : sensorPDRs)
                 {
                     pdrType = sensor.value("pdrType", 0);
-                    generateHandlers.at(pdrType)(dBusIntf, sensor, repo);
+                    generateHandlers.at(pdrType)(dBusIntf, sensor, repo,
+                                                 bmcEntityTree);
                 }
             }
         }
@@ -173,7 +180,7 @@ Response Handler::getPDR(const pldm_msg* request, size_t payloadLength)
     if (!pdrCreated)
     {
         generateTerminusLocatorPDR(pdrRepo);
-        generate(*dBusIntf, pdrJsonsDir, pdrRepo);
+        generate(*dBusIntf, pdrJsonsDir, pdrRepo, bmcEntityTree);
         if (oemPlatformHandler != nullptr)
         {
             oemPlatformHandler->buildOEMPDR(pdrRepo);

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -27,9 +27,10 @@ namespace responder
 namespace platform
 {
 
-using generatePDR = std::function<void(const pldm::utils::DBusHandler& dBusIntf,
-                                       const pldm::utils::Json& json,
-                                       pdr_utils::RepoInterface& repo)>;
+using generatePDR = std::function<void(
+    const pldm::utils::DBusHandler& dBusIntf, const pldm::utils::Json& json,
+    pdr_utils::RepoInterface& repo,
+    pldm_entity_association_tree* bmcEntityTree)>;
 
 /*using EffecterId = uint16_t;
 using DbusObjMaps =
@@ -53,19 +54,21 @@ class Handler : public CmdHandler
             HostPDRHandler* hostPDRHandler,
             pldm::state_sensor::DbusToPLDMEvent* dbusToPLDMEventHandler,
             fru::Handler* fruHandler,
+            pldm_entity_association_tree* bmcEntityTree,
             pldm::responder::oem_platform::Handler* oemPlatformHandler,
             sdeventplus::Event& event, bool buildPDRLazily = false,
             const std::optional<EventMap>& addOnHandlersMap = std::nullopt) :
         pdrRepo(repo),
         hostPDRHandler(hostPDRHandler),
         dbusToPLDMEventHandler(dbusToPLDMEventHandler), fruHandler(fruHandler),
-        dBusIntf(dBusIntf), oemPlatformHandler(oemPlatformHandler),
-        event(event), pdrJsonsDir(pdrJsonsDir), pdrCreated(false)
+        bmcEntityTree(bmcEntityTree), dBusIntf(dBusIntf),
+        oemPlatformHandler(oemPlatformHandler), event(event),
+        pdrJsonsDir(pdrJsonsDir), pdrCreated(false)
     {
         if (!buildPDRLazily)
         {
             generateTerminusLocatorPDR(pdrRepo);
-            generate(*dBusIntf, pdrJsonsDir, pdrRepo);
+            generate(*dBusIntf, pdrJsonsDir, pdrRepo, bmcEntityTree);
             pdrCreated = true;
         }
 
@@ -185,7 +188,8 @@ class Handler : public CmdHandler
      */
     void generate(const pldm::utils::DBusHandler& dBusIntf,
                   const std::string& dir,
-                  pldm::responder::pdr_utils::Repo& repo);
+                  pldm::responder::pdr_utils::Repo& repo,
+                  pldm_entity_association_tree* bmcEntityTree);
 
     /** @brief Parse PDR JSONs and build state effecter PDR repository
      *
@@ -193,7 +197,8 @@ class Handler : public CmdHandler
      *  @param[in] repo - instance of state effecter implementation of Repo
      */
     void generateStateEffecterRepo(const pldm::utils::Json& json,
-                                   pldm::responder::pdr_utils::Repo& repo);
+                                   pldm::responder::pdr_utils::Repo& repo,
+                                   pldm_entity_association_tree* bmcEntityTree);
 
     /** @brief map of PLDM event type to EventHandlers
      *
@@ -455,6 +460,7 @@ class Handler : public CmdHandler
     HostPDRHandler* hostPDRHandler;
     pldm::state_sensor::DbusToPLDMEvent* dbusToPLDMEventHandler;
     fru::Handler* fruHandler;
+    pldm_entity_association_tree* bmcEntityTree;
     const pldm::utils::DBusHandler* dBusIntf;
     pldm::responder::oem_platform::Handler* oemPlatformHandler;
     sdeventplus::Event& event;

--- a/libpldmresponder/test/libpldmresponder_pdr_effecter_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_pdr_effecter_test.cpp
@@ -31,7 +31,7 @@ TEST(GeneratePDRByStateEffecter, testGoodJson)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_EFFECTER_PDR);
 
@@ -131,7 +131,7 @@ TEST(GeneratePDRByNumericEffecter, testGoodJson)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_NUMERIC_EFFECTER_PDR);
 
@@ -178,7 +178,7 @@ TEST(GeneratePDR, testMalformedJson)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_EFFECTER_PDR);
 
@@ -200,7 +200,7 @@ TEST(findStateEffecterId, goodJson)
     auto inPDRRepo = pldm_pdr_init();
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     uint16_t entityType = 33;
     uint16_t entityInstance = 0;
     uint16_t containerId = 0;

--- a/libpldmresponder/test/libpldmresponder_pdr_sensor_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_pdr_sensor_test.cpp
@@ -35,7 +35,7 @@ TEST(GeneratePDRByStateSensor, testGoodJson)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_sensor/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     handler.getPDR(req, requestPayloadLength);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_SENSOR_PDR);
@@ -86,7 +86,7 @@ TEST(GeneratePDR, testMalformedJson)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_sensor/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     handler.getPDR(req, requestPayloadLength);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_SENSOR_PDR);

--- a/libpldmresponder/test/libpldmresponder_platform_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_platform_test.cpp
@@ -43,7 +43,7 @@ TEST(getPDR, testGoodPath)
     auto pdrRepo = pldm_pdr_init();
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", pdrRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -81,7 +81,7 @@ TEST(getPDR, testShortRead)
     auto pdrRepo = pldm_pdr_init();
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", pdrRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -113,7 +113,7 @@ TEST(getPDR, testBadRecordHandle)
     auto pdrRepo = pldm_pdr_init();
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", pdrRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -143,7 +143,7 @@ TEST(getPDR, testNoNextRecord)
     auto pdrRepo = pldm_pdr_init();
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", pdrRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -175,7 +175,7 @@ TEST(getPDR, testFindPDR)
     auto pdrRepo = pldm_pdr_init();
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", pdrRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -238,7 +238,7 @@ TEST(setStateEffecterStatesHandler, testGoodRequest)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     handler.getPDR(req, requestPayloadLength);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_EFFECTER_PDR);
@@ -285,7 +285,7 @@ TEST(setStateEffecterStatesHandler, testBadRequest)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     handler.getPDR(req, requestPayloadLength);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_EFFECTER_PDR);
@@ -331,7 +331,7 @@ TEST(setNumericEffecterValueHandler, testGoodRequest)
     Repo numericEffecterPDRs(numericEffecterPdrRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, numericEffecterPDRs, PLDM_NUMERIC_EFFECTER_PDR);
 
@@ -374,7 +374,7 @@ TEST(setNumericEffecterValueHandler, testBadRequest)
     Repo numericEffecterPDRs(numericEffecterPdrRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_effecter/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, numericEffecterPDRs, PLDM_NUMERIC_EFFECTER_PDR);
 
@@ -548,7 +548,7 @@ TEST(TerminusLocatorPDR, BMCTerminusLocatorPDR)
     MockdBusHandler mockedUtils;
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "", inPDRRepo, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_TERMINUS_LOCATOR_PDR);
 
@@ -593,7 +593,7 @@ TEST(getStateSensorReadingsHandler, testGoodRequest)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_sensor/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_SENSOR_PDR);
     pdr_utils::PdrEntry e;
@@ -640,7 +640,7 @@ TEST(getStateSensorReadingsHandler, testBadRequest)
     Repo outRepo(outPDRRepo);
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, "./pdr_jsons/state_sensor/good", inPDRRepo,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_SENSOR_PDR);
     pdr_utils::PdrEntry e;

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -525,6 +525,50 @@ void buildAllNumericEffecterPDR(oem_ibm_platform::Handler* platformHandler,
     }
 }
 
+std::vector<std::string> getslotPaths()
+{
+    static constexpr auto searchpath = "/xyz/openbmc_project/inventory/system";
+    int depth = 0;
+    pldm::utils::MapperGetSubTreeResponse response =
+        pldm::utils::DBusHandler().getSubtree(
+            searchpath, depth, {"xyz.openbmc_project.Inventory.Item.PCIeSlot"});
+    std::vector<std::string> slotPaths;
+    std::transform(response.begin(), response.end(),
+                   std::back_inserter(slotPaths),
+                   [](const auto& kv) { return kv.first; });
+    return slotPaths;
+}
+
+void attachOemEntityToEntityAssociationPDR(
+    oem_ibm_platform::Handler* platformHandler,
+    pldm_entity_association_tree* bmcEntityTree,
+    const std::string& parentEntityPath, pdr_utils::Repo& repo,
+    pldm_entity childEntity)
+{
+    auto& associatedEntityMap = platformHandler->getAssociateEntityMap();
+    if (associatedEntityMap.contains(parentEntityPath))
+    {
+        // Parent is present in the entity association PDR
+        pldm_entity parent_entity = associatedEntityMap.at(parentEntityPath);
+        auto parent_node = pldm_entity_association_tree_find(
+            bmcEntityTree, &parent_entity, false);
+        if (!parent_node)
+        {
+            // parent node not found in the entity association tree,
+            // this should not be possible
+            std::cerr << "Parent Entity of type " << parent_entity.entity_type
+                      << " not found in the BMC Entity Association tree\n";
+            return;
+        }
+        pldm_entity_association_tree_add(
+            bmcEntityTree, &childEntity, 0xFFFF, parent_node,
+            PLDM_ENTITY_ASSOCIAION_PHYSICAL, false, false);
+        uint8_t bmcEventDataOps = PLDM_INVALID_OP;
+        pldm_entity_association_pdr_add_contained_entity(
+            repo.getPdr(), childEntity, parent_entity, &bmcEventDataOps, false);
+    }
+}
+
 void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     pdr_utils::Repo& repo)
 {
@@ -534,21 +578,9 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     buildAllCodeUpdateEffecterPDR(this, PLDM_ENTITY_SYSTEM_CHASSIS,
                                   ENTITY_INSTANCE_1,
                                   PLDM_OEM_IBM_SYSTEM_POWER_STATE, repo);
-    std::vector<std::string> slotobjpaths = {
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
-        "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9"};
-    buildAllSlotEnabeEffecterPDR(this, repo, slotobjpaths);
-    buildAllSlotEnableSensorPDR(this, repo, slotobjpaths);
+
+    buildAllSlotEnabeEffecterPDR(this, repo, getslotPaths());
+    buildAllSlotEnableSensorPDR(this, repo, getslotPaths());
 
     buildAllCodeUpdateEffecterPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
                                   ENTITY_INSTANCE_0,
@@ -565,6 +597,12 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
                                 PLDM_OEM_IBM_BOOT_SIDE_RENAME, repo);
     buildAllNumericEffecterPDR(this, PLDM_ENTITY_PROC, ENTITY_INSTANCE_0,
                                PLDM_OEM_IBM_SBE_SEMANTIC_ID, repo, instanceMap);
+
+    pldm_entity fwUpEntity = {PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE, 0, 1};
+    attachOemEntityToEntityAssociationPDR(
+        this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,
+        fwUpEntity);
+
     auto sensorId = findStateSensorId(
         repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
         ENTITY_INSTANCE_0, 1, PLDM_OEM_IBM_VERIFICATION_STATE);

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -66,11 +66,13 @@ class Handler : public oem_platform::Handler
             pldm::responder::SlotHandler* slotHandler, int mctp_fd,
             uint8_t mctp_eid, pldm::dbus_api::Requester& requester,
             sdeventplus::Event& event, pldm_pdr* repo,
-            pldm::requester::Handler<pldm::requester::Request>* handler) :
+            pldm::requester::Handler<pldm::requester::Request>* handler,
+            pldm_entity_association_tree* bmcEntityTree) :
         oem_platform::Handler(dBusIntf),
         codeUpdate(codeUpdate), slotHandler(slotHandler),
         platformHandler(nullptr), mctp_fd(mctp_fd), mctp_eid(mctp_eid),
-        requester(requester), event(event), pdrRepo(repo), handler(handler)
+        requester(requester), event(event), pdrRepo(repo), handler(handler),
+        bmcEntityTree(bmcEntityTree)
     {
         codeUpdate->setVersions();
         pldm::responder::utils::clearLicenseStatus();
@@ -361,6 +363,9 @@ class Handler : public oem_platform::Handler
 
     /** @brief PLDM request handler */
     pldm::requester::Handler<pldm::requester::Request>* handler;
+
+    /** @brief Pointer to BMC's entity association tree */
+    pldm_entity_association_tree* bmcEntityTree;
 
     /** @brief D-Bus property changed signal match */
     std::unique_ptr<sdbusplus::bus::match::match> hostOffMatch;

--- a/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
+++ b/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
@@ -48,7 +48,8 @@ class MockOemPlatformHandler : public oem_ibm_platform::Handler
                            int mctp_fd, uint8_t mctp_eid, Requester& requester,
                            sdeventplus::Event& event) :
         oem_ibm_platform::Handler(dBusIntf, codeUpdate, slotHandler, mctp_fd,
-                                  mctp_eid, requester, event, nullptr)
+                                  mctp_eid, requester, event, nullptr, nullptr,
+                                  nullptr)
     {}
     MOCK_METHOD(uint16_t, getNextEffecterId, ());
     MOCK_METHOD(uint16_t, getNextSensorId, ());
@@ -75,7 +76,7 @@ TEST(OemSetStateEffecterStatesHandler, testGoodRequest)
 
     oemPlatformHandler = std::make_unique<oem_ibm_platform::Handler>(
         mockDbusHandler.get(), mockCodeUpdate.get(), nullptr, 0x1, 0x9,
-        requester, event, nullptr);
+        requester, event, nullptr, nullptr, nullptr);
 
     auto rc = oemPlatformHandler->getOemStateSensorReadingsHandler(
         entityID_, entityInstance_, containerId_, stateSetId_, compSensorCnt_,

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -243,7 +243,7 @@ int main(int argc, char** argv)
     codeUpdate->clearDirPath(LID_STAGING_DIR);
     oemPlatformHandler = std::make_unique<oem_ibm_platform::Handler>(
         &dbusHandler, codeUpdate.get(), slotHandler.get(), sockfd, hostEID,
-        dbusImplReq, event, pdrRepo.get(), &reqHandler);
+        dbusImplReq, event, pdrRepo.get(), &reqHandler, bmcEntityTree.get());
     oemFruHandler =
         std::make_unique<oem_ibm_fru::Handler>(&dbusHandler, pdrRepo.get());
     codeUpdate->setOemPlatformHandler(oemPlatformHandler.get());
@@ -286,7 +286,7 @@ int main(int argc, char** argv)
     // Platform handler.
     auto platformHandler = std::make_unique<platform::Handler>(
         &dbusHandler, PDR_JSONS_DIR, pdrRepo.get(), hostPDRHandler.get(),
-        dbusToPLDMEventHandler.get(), fruHandler.get(),
+        dbusToPLDMEventHandler.get(), fruHandler.get(), bmcEntityTree.get(),
         oemPlatformHandler.get(), event, true);
 #ifdef OEM_IBM
     pldm::responder::oem_ibm_platform::Handler* oemIbmPlatformHandler =


### PR DESCRIPTION
It is not always a standard condition that we should have
a fru record set PDR, we can also have sensors/effecters
without having an associated FRU record set PDR.

This commit would help add these orphan sensors/effecters
entities into the entity association PDR's.

Fixes : SW536590 & SW536589

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>