### PR TITLE
Add support to skip container ID checks in events

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -997,7 +997,8 @@ void HostPDRHandler::_setHostSensorState()
                     const auto& [containerId, entityType, entityInstance] =
                         entityInfo;
                     pldm::responder::events::StateSensorEntry stateSensorEntry{
-                        containerId, entityType, entityInstance, sensorOffset};
+                        containerId, entityType, entityInstance, sensorOffset,
+                        false};
                     handleStateSensorEvent(stateSetIds, stateSensorEntry,
                                            eventState);
                 }

--- a/libpldmresponder/event_parser.cpp
+++ b/libpldmresponder/event_parser.cpp
@@ -49,13 +49,17 @@ StateSensorHandler::StateSensorHandler(const std::string& dirPath)
         {
             StateSensorEntry stateSensorEntry{};
             stateSensorEntry.containerId =
-                static_cast<uint16_t>(entry.value("containerID", 0));
+                static_cast<uint16_t>(entry.value("containerID", 0xFFFF));
             stateSensorEntry.entityType =
                 static_cast<uint16_t>(entry.value("entityType", 0));
             stateSensorEntry.entityInstance =
                 static_cast<uint16_t>(entry.value("entityInstance", 0));
             stateSensorEntry.sensorOffset =
                 static_cast<uint8_t>(entry.value("sensorOffset", 0));
+
+            // container id is not found in the json
+            stateSensorEntry.skipContainerCheck =
+                (stateSensorEntry.containerId == 0xFFFF) ? true : false;
 
             pldm::utils::DBusMapping dbusInfo{};
 
@@ -114,9 +118,19 @@ StateToDBusValue StateSensorHandler::mapStateToDBusVal(
     return eventStateMap;
 }
 
-int StateSensorHandler::eventAction(const StateSensorEntry& entry,
+int StateSensorHandler::eventAction(StateSensorEntry entry,
                                     pdr::EventState state)
 {
+    for (const auto& kv : eventMap)
+    {
+        if (kv.first.skipContainerCheck &&
+            kv.first.entityType == entry.entityType &&
+            kv.first.entityInstance == entry.entityInstance)
+        {
+            entry.skipContainerCheck = true;
+            break;
+        }
+    }
     try
     {
         const auto& [dbusMapping, eventStateMap] = eventMap.at(entry);

--- a/libpldmresponder/event_parser.hpp
+++ b/libpldmresponder/event_parser.hpp
@@ -27,25 +27,49 @@ struct StateSensorEntry
     pdr::EntityType entityType;
     pdr::EntityInstance entityInstance;
     pdr::SensorOffset sensorOffset;
+    bool skipContainerCheck;
 
     bool operator==(const StateSensorEntry& e) const
     {
-        return ((containerId == e.containerId) &&
-                (entityType == e.entityType) &&
-                (entityInstance == e.entityInstance) &&
-                (sensorOffset == e.sensorOffset));
+        if (!skipContainerCheck)
+        {
+            return ((containerId == e.containerId) &&
+                    (entityType == e.entityType) &&
+                    (entityInstance == e.entityInstance) &&
+                    (sensorOffset == e.sensorOffset));
+        }
+        else
+        {
+            return ((entityType == e.entityType) &&
+                    (entityInstance == e.entityInstance) &&
+                    (sensorOffset == e.sensorOffset));
+        }
     }
 
     bool operator<(const StateSensorEntry& e) const
     {
-        return (
-            (containerId < e.containerId) ||
-            ((containerId == e.containerId) && (entityType < e.entityType)) ||
-            ((containerId == e.containerId) && (entityType == e.entityType) &&
-             (entityInstance < e.entityInstance)) ||
-            ((containerId == e.containerId) && (entityType == e.entityType) &&
-             (entityInstance == e.entityInstance) &&
-             (sensorOffset < e.sensorOffset)));
+        if (!skipContainerCheck)
+        {
+            return ((containerId < e.containerId) ||
+                    ((containerId == e.containerId) &&
+                     (entityType < e.entityType)) ||
+                    ((containerId == e.containerId) &&
+                     (entityType == e.entityType) &&
+                     (entityInstance < e.entityInstance)) ||
+                    ((containerId == e.containerId) &&
+                     (entityType == e.entityType) &&
+                     (entityInstance == e.entityInstance) &&
+                     (sensorOffset < e.sensorOffset)));
+        }
+        else
+        {
+            return ((entityType < e.entityType) ||
+                    ((entityType == e.entityType) &&
+                     (entityInstance < e.entityInstance)) ||
+                    ((entityType == e.entityType) &&
+                     (entityInstance == e.entityInstance) &&
+                     (sensorOffset < e.sensorOffset)));
+        }
     }
 };
 
@@ -87,7 +111,7 @@ class StateSensorHandler
      *
      *  @return PLDM completion code
      */
-    int eventAction(const StateSensorEntry& entry, pdr::EventState state);
+    int eventAction(StateSensorEntry entry, pdr::EventState state);
 
     /** @brief Helper API to get D-Bus information for a StateSensorEntry
      *

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -463,8 +463,8 @@ int Handler::sensorEvent(const pldm_msg* request, size_t payloadLength,
         }
 
         const auto& [containerId, entityType, entityInstance] = entityInfo;
-        events::StateSensorEntry stateSensorEntry{containerId, entityType,
-                                                  entityInstance, sensorOffset};
+        events::StateSensorEntry stateSensorEntry{
+            containerId, entityType, entityInstance, sensorOffset, false};
         return hostPDRHandler->handleStateSensorEvent(
             stateSetIds, stateSensorEntry, eventState);
     }

--- a/libpldmresponder/test/libpldmresponder_platform_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_platform_test.cpp
@@ -478,7 +478,7 @@ TEST(StateSensorHandler, allScenarios)
 
     // Event Entry 1
     {
-        StateSensorEntry entry{1, 64, 1, 0};
+        StateSensorEntry entry{1, 64, 1, 0, false};
         const auto& [dbusMapping, eventStateMap] = handler.getEventInfo(entry);
         DBusMapping mapping{"/xyz/abc/def",
                             "xyz.openbmc_project.example1.value", "value1",
@@ -501,7 +501,7 @@ TEST(StateSensorHandler, allScenarios)
 
     // Event Entry 2
     {
-        StateSensorEntry entry{1, 64, 1, 1};
+        StateSensorEntry entry{1, 64, 1, 1, false};
         const auto& [dbusMapping, eventStateMap] = handler.getEventInfo(entry);
         DBusMapping mapping{"/xyz/abc/def",
                             "xyz.openbmc_project.example2.value", "value2",
@@ -518,7 +518,7 @@ TEST(StateSensorHandler, allScenarios)
 
     // Event Entry 3
     {
-        StateSensorEntry entry{2, 67, 2, 0};
+        StateSensorEntry entry{2, 67, 2, 0, false};
         const auto& [dbusMapping, eventStateMap] = handler.getEventInfo(entry);
         DBusMapping mapping{"/xyz/abc/ghi",
                             "xyz.openbmc_project.example3.value", "value3",
@@ -535,7 +535,7 @@ TEST(StateSensorHandler, allScenarios)
 
     // Invalid Entry
     {
-        StateSensorEntry entry{0, 0, 0, 0};
+        StateSensorEntry entry{0, 0, 0, 0, false};
         ASSERT_THROW(handler.getEventInfo(entry), std::out_of_range);
     }
 }

--- a/oem/ibm/configurations/events/oem_ibm_event_state_sensor.json
+++ b/oem/ibm/configurations/events/oem_ibm_event_state_sensor.json
@@ -1,7 +1,6 @@
 {
     "entries": [
         {
-            "containerID": 32784,
             "entityType": 57346,
             "entityInstance": 0,
             "sensorOffset": 1,
@@ -23,51 +22,6 @@
             }
         },
         {
-            "containerID": 0,
-            "entityType": 57346,
-            "entityInstance": 1,
-            "sensorOffset": 1,
-            "event_states": [
-                1,
-                2,
-                3
-            ],
-            "dbus": {
-                "object_path": "/xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0",
-                "interface": "xyz.openbmc_project.Object.Enable",
-                "property_name": "Enabled",
-                "property_type": "bool",
-                "property_values": [
-                    true,
-                    false,
-                    false
-                ]
-            }
-        },
-        {
-            "containerID": 0,
-            "entityType": 57346,
-            "entityInstance": 0,
-            "sensorOffset": 1,
-            "event_states": [
-                1,
-                2,
-                3
-            ],
-            "dbus": {
-                "object_path": "/xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0",
-                "interface": "xyz.openbmc_project.Object.Enable",
-                "property_name": "Enabled",
-                "property_type": "bool",
-                "property_values": [
-                    true,
-                    false,
-                    false
-                ]
-            }
-        },
-        {
-            "containerID": 32784,
             "entityType": 57346,
             "entityInstance": 1,
             "sensorOffset": 1,
@@ -88,6 +42,5 @@
                 ]
             }
         }
-
      ]
 }


### PR DESCRIPTION
Phyp currently creates the container ID's dynamically, so
we will not able to know the Id of the containers beforehand.

So this PR would be adding support to skip checking for entities
that does not have container Id's mentioned in the events json.

Fixes : SW540578 & SW540536

Tested By :

On Rainier :
type : 57346
instance : 0
conId : 32779
name : Enabled
interfacexyz.openbmc_project.Object.Enable
obj path : /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
entered the try block
value : 0 ,service :xyz.openbmc_project.Network.Hypervisor , interface : xyz.openbmc_project.Object.Enable , path : /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
type : 57346
instance : 0
conId : 32779
name : Enabled
interfacexyz.openbmc_project.Object.Enable
obj path : /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
entered the try block
value : 1 ,service :xyz.openbmc_project.Network.Hypervisor , interface : xyz.openbmc_project.Object.Enable , path : /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0

On Everest :
type : 57346
instance : 0
conId : 32790
name : Enabled
interfacexyz.openbmc_project.Object.Enable
obj path : /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
value : 0 ,service :xyz.openbmc_project.Network.Hypervisor , interface : xyz.openbmc_project.Object.Enable , path : /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
type : 57346
instance : 0
conId : 32790
name : Enabled
interfacexyz.openbmc_project.Object.Enable
obj path : /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
value : 1 ,service :xyz.openbmc_project.Network.Hypervisor , interface : xyz.openbmc_project.Object.Enable , path : /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>