### PR TITLE
Spawn a new thread for the PDR Generation

### DIFF
--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <iostream>
 #include <string>
+#include <thread>
 #include <variant>
 #include <vector>
 
@@ -187,7 +188,7 @@ class DBusHandler : public DBusHandlerInterface
     /** @brief Get the bus connection. */
     static auto& getBus()
     {
-        static auto bus = sdbusplus::bus::new_default();
+        static thread_local auto bus = sdbusplus::bus::new_default();
         return bus;
     }
 

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -4,7 +4,8 @@ deps = [
   sdbusplus,
   sdeventplus,
   libpldm_dep,
-  libpldmutils
+  libpldmutils,
+  thread_dep
 ]
 
 sources = [

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -123,7 +123,7 @@ class Handler : public CmdHandler
     virtual void countSetEventReceiver() = 0;
 
     /** @brief Interface to check the BMC state */
-    virtual int checkBMCState() = 0;
+    virtual bool getBMCState() = 0;
 
     /** @brief update the dbus object paths */
     virtual void upadteOemDbusPaths(std::string& dbusPath) = 0;

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,8 @@ configure_file(output: 'config.h',
   configuration: conf_data
 )
 
+thread_dep = dependency('threads')
+
 phosphor_dbus_interfaces = dependency(
   'phosphor-dbus-interfaces',
   fallback: ['phosphor-dbus-interfaces', 'phosphor_dbus_interfaces_dep'],

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1009,6 +1009,11 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
         });
 }
 
+bool pldm::responder::oem_ibm_platform::Handler::getBMCState()
+{
+    return isBMCReady;
+}
+
 void pldm::responder::oem_ibm_platform::Handler::checkAndDisableWatchDog()
 {
     if (!hostOff && setEventReceiverCnt == SET_EVENT_RECEIVER_SENT)
@@ -1091,30 +1096,6 @@ void pldm::responder::oem_ibm_platform::Handler::disableWatchDogTimer()
         std::cerr << "Failed To disable watchdog timer"
                   << "ERROR=" << e.what() << "\n";
     }
-}
-int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
-{
-    try
-    {
-        pldm::utils::PropertyValue propertyValue =
-            pldm::utils::DBusHandler().getDbusPropertyVariant(
-                "/xyz/openbmc_project/state/bmc0", "CurrentBMCState",
-                "xyz.openbmc_project.State.BMC");
-
-        if (std::get<std::string>(propertyValue) ==
-            "xyz.openbmc_project.State.BMC.BMCState.NotReady")
-        {
-            std::cerr << "GetPDR : PLDM stack is not ready for PDR exchange"
-                      << std::endl;
-            return PLDM_ERROR_NOT_READY;
-        }
-    }
-    catch (const std::exception& e)
-    {
-        std::cerr << "Error getting the current BMC state" << std::endl;
-        return PLDM_ERROR;
-    }
-    return PLDM_SUCCESS;
 }
 
 void pldm::responder::oem_ibm_platform::Handler::setBitmapMethodCall(


### PR DESCRIPTION
PDR generation process is quite dbus intensive & in the systems
with more dbus latency , it is observed that PLDM is blocked
while doing these dbus calls & as these are blocking calls pldm
is blocked & was not responding to host which untimately led to
the PHYP initiating the BMC reboot.

Although this does not completely fix the issue, as this only
unblocks the pldm daemon just for the PDR generation process,
This is just a temperory fix, the more concrete and future proof
solution is to switch to sdbusplus::asio infrastructure.

Tested By:

1. Power off & power on in loop - PASS
https://sys-openbmc-dev-jenkins.swg-devops.com/job/OpenBMC-Dev/job/test/job/continuous-integration/job/ebmc/job/power_on_off_loop/5/console

Suggested-by: Andrew Jeffery <andrew@aj.id.au>
Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>