### PR TITLE
Lamptest & Mex critical associations support

### DIFF
--- a/host-bmc/custom_dbus.cpp
+++ b/host-bmc/custom_dbus.cpp
@@ -29,8 +29,17 @@ std::string CustomDBus::getLocationCode(const std::string& path) const
     return {};
 }
 
-void CustomDBus::setOperationalStatus(const std::string& path, bool status)
+void CustomDBus::setOperationalStatus(const std::string& path, bool status,
+                                      const std::string& parentChassis)
 {
+    if (!status && parentChassis != "")
+    {
+        // If we get operational status as false for any FRU, then set
+        // the critical association for it.
+        std::vector<std::tuple<std::string, std::string, std::string>>
+            associations{{"health_rollup", "critical", parentChassis}};
+        setAssociations(path, associations);
+    }
     if (operationalStatus.find(path) == operationalStatus.end())
     {
         operationalStatus.emplace(

--- a/host-bmc/custom_dbus.hpp
+++ b/host-bmc/custom_dbus.hpp
@@ -178,8 +178,11 @@ class CustomDBus
      *  @param[in] path   - The object path
      *
      *  @param[in] status - PLDM operational fault status
+     *  @param [in] parentChassis - The parent chassis of the FRU
+     *
      */
-    void setOperationalStatus(const std::string& path, bool status);
+    void setOperationalStatus(const std::string& path, bool status,
+                              const std::string& parentChassis);
 
     /** @brief Get the Functional property
      *

--- a/host-bmc/dbus_to_event_handler.cpp
+++ b/host-bmc/dbus_to_event_handler.cpp
@@ -84,7 +84,11 @@ void DbusToPLDMEvent::sendStateSensorEvent(SensorId sensorId,
     // DSP0248_1.2.0 Table 19
     if (!dbusMaps.contains(sensorId))
     {
-        std::cerr << "Invalid sensor ID : " << sensorId << std::endl;
+        // this is not an error condition, if we end up here
+        // that means that the sensor with the sensor id has
+        // custom behaviour(or probably an oem sensor) in
+        // sending events that cannot be captured via standard
+        // dbus-json infastructure
         return;
     }
 

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -191,6 +191,10 @@ class HostPDRHandler
      */
     void setPresenceFrus();
 
+    /* @brief get the Parent chassis object path for a fru
+     */
+    std::string getParentChassis(const std::string& fruPath);
+
     /** @brief set the presence of the fru from record handle
      *  @param[in] recorHandle - record handle of the PDR
      */

--- a/host-bmc/test/custom_dbus_test.cpp
+++ b/host-bmc/test/custom_dbus_test.cpp
@@ -21,14 +21,14 @@ TEST(CustomDBus, OperationalStatus)
     bool status = false;
     bool retStatus = false;
 
-    CustomDBus::getCustomDBus().setOperationalStatus(tmpPath, status);
+    CustomDBus::getCustomDBus().setOperationalStatus(tmpPath, status, "");
     retStatus = CustomDBus::getCustomDBus().getOperationalStatus(tmpPath);
 
     EXPECT_EQ(status, false);
     EXPECT_EQ(retStatus, false);
 
     status = true;
-    CustomDBus::getCustomDBus().setOperationalStatus(tmpPath, status);
+    CustomDBus::getCustomDBus().setOperationalStatus(tmpPath, status, "");
     retStatus = CustomDBus::getCustomDBus().getOperationalStatus(tmpPath);
 
     EXPECT_EQ(status, true);

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -48,6 +48,7 @@ if get_option('oem-ibm').enabled()
     '../oem/ibm/requester/dbus_to_file_handler.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_progress_src.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_lic.cpp',
+    '../oem/ibm/host-bmc/host_lamp_test.cpp',
   ]
 endif
 

--- a/libpldmresponder/test/meson.build
+++ b/libpldmresponder/test/meson.build
@@ -16,7 +16,8 @@ tests = [
 if get_option('oem-ibm').enabled()
   tests += [
     '../../oem/ibm/test/libpldmresponder_fileio_test',
-    '../../oem/ibm/test/libpldmresponder_oem_platform_test'
+    '../../oem/ibm/test/libpldmresponder_oem_platform_test',
+    '../../oem/ibm/test/host_bmc_lamp_test',
   ]
 endif
 

--- a/oem/ibm/host-bmc/host_lamp_test.cpp
+++ b/oem/ibm/host-bmc/host_lamp_test.cpp
@@ -1,0 +1,170 @@
+
+#include "host_lamp_test.hpp"
+
+#include "entity.h"
+#include "platform.h"
+#include "pldm.h"
+#include "state_set.h"
+
+#include "common/types.hpp"
+#include "common/utils.hpp"
+
+#include <iostream>
+
+namespace pldm
+{
+namespace led
+{
+
+bool HostLampTest::asserted() const
+{
+    return sdbusplus::xyz::openbmc_project::Led::server::Group::asserted();
+}
+
+bool HostLampTest::asserted(bool value)
+{
+    // When setting the asserted property to true, need to notify the PHYP to
+    // start lamp test.
+    // When setting the asserted property to true again, need to notify the PHYP
+    // and PHYP will restart the lamp test.
+    // When setting the asserted property to false, just update the asserted
+    // property, do not need to notify the PHYP to stop lamp test, PHYP will
+    // wait for timeout to stop.
+    if (!value &&
+        value ==
+            sdbusplus::xyz::openbmc_project::Led::server::Group::asserted())
+    {
+        return value;
+    }
+
+    if (value)
+    {
+        if (effecterID == 0)
+        {
+            effecterID = getEffecterID();
+        }
+
+        if (effecterID != 0)
+        {
+            // Call setHostStateEffecter method to notify PHYP to start lamp
+            // test. If user set Asserted to true again, need to notify PHYP to
+            // start lamptest again.
+            uint8_t rc = 0;
+            setHostStateEffecter(effecterID, rc);
+            if (rc)
+            {
+                throw sdbusplus::exception::SdBusError(
+                    static_cast<int>(std::errc::invalid_argument),
+                    "Set Host State Effector to start lamp test failed");
+            }
+            else
+            {
+                return sdbusplus::xyz::openbmc_project::Led::server::Group::
+                    asserted(value);
+            }
+        }
+        else
+        {
+            throw sdbusplus::exception::SdBusError(
+                static_cast<int>(std::errc::invalid_argument),
+                "Get Effecter ID failed, effecter = 0");
+        }
+    }
+
+    return value;
+}
+
+uint16_t HostLampTest::getEffecterID()
+{
+    uint16_t effecterID = 0;
+
+    if (!pdrRepo)
+    {
+        return effecterID;
+    }
+
+    // INDICATOR is a logical entity, so the bit 15 in entity type is set.
+    pdr::EntityType entityType = PLDM_ENTITY_INDICATOR | 0x8000;
+
+    auto stateEffecterPDRs = pldm::utils::findStateEffecterPDR(
+        mctp_eid, entityType,
+        static_cast<uint16_t>(PLDM_STATE_SET_IDENTIFY_STATE), pdrRepo);
+
+    if (stateEffecterPDRs.empty())
+    {
+        std::cerr
+            << "Lamp Test: The state set PDR can not be found, entityType = "
+            << entityType << std::endl;
+        return effecterID;
+    }
+
+    for (auto& rep : stateEffecterPDRs)
+    {
+        auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(rep.data());
+        effecterID = pdr->effecter_id;
+        break;
+    }
+
+    return effecterID;
+}
+
+void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
+{
+    constexpr uint8_t effecterCount = 1;
+    auto instanceId = requester.getInstanceId(mctp_eid);
+
+    std::vector<uint8_t> requestMsg(sizeof(pldm_msg_hdr) + sizeof(effecterID) +
+                                    sizeof(effecterCount) +
+                                    sizeof(set_effecter_state_field));
+    auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
+    set_effecter_state_field stateField{PLDM_REQUEST_SET,
+                                        PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED};
+    rc = encode_set_state_effecter_states_req(
+        instanceId, effecterID, effecterCount, &stateField, request);
+    if (rc != PLDM_SUCCESS)
+    {
+        requester.markFree(mctp_eid, instanceId);
+        std::cerr << "Failed to encode_set_state_effecter_states_req, rc = "
+                  << rc << std::endl;
+        return;
+    }
+
+    auto setStateEffecterStatesResponseHandler = [&rc](mctp_eid_t /*eid*/,
+                                                       const pldm_msg* response,
+                                                       size_t respMsgLen) {
+        if (response == nullptr || !respMsgLen)
+        {
+            std::cerr << "Failed to receive response for the Set State "
+                         "Effecter States\n";
+            return;
+        }
+
+        uint8_t completionCode{};
+        auto responsePtr = reinterpret_cast<const struct pldm_msg*>(response);
+        rc = decode_set_state_effecter_states_resp(
+            responsePtr, respMsgLen - sizeof(pldm_msg_hdr), &completionCode);
+
+        if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
+        {
+            std::cerr << "Failed to decode_set_state_effecter_states_resp: "
+                      << "rc=" << rc
+                      << ", cc=" << static_cast<unsigned>(completionCode)
+                      << std::endl;
+        }
+    };
+
+    rc = handler.registerRequest(
+        mctp_eid, instanceId, PLDM_PLATFORM, PLDM_SET_STATE_EFFECTER_STATES,
+        std::move(requestMsg),
+        std::move(setStateEffecterStatesResponseHandler));
+    if (rc != PLDM_SUCCESS)
+    {
+        std::cerr
+            << "Failed to send the the Set State Effecter States request\n";
+    }
+
+    return;
+}
+
+} // namespace led
+} // namespace pldm

--- a/oem/ibm/host-bmc/host_lamp_test.hpp
+++ b/oem/ibm/host-bmc/host_lamp_test.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "pldmd/dbus_impl_pdr.hpp"
+#include "pldmd/dbus_impl_requester.hpp"
+#include "requester/handler.hpp"
+
+#include <sdbusplus/server/object.hpp>
+#include <xyz/openbmc_project/Led/Group/server.hpp>
+
+#include <string>
+
+using namespace pldm::dbus_api;
+
+namespace pldm
+{
+namespace led
+{
+
+using LEDGroupObj = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Led::server::Group>;
+
+class HostLampTestInterfaces
+{
+  public:
+    virtual ~HostLampTestInterfaces()
+    {}
+
+    virtual uint16_t getEffecterID() = 0;
+    virtual void setHostStateEffecter(uint16_t effecterID, uint8_t& rc) = 0;
+};
+
+/** @class HostLampTest
+ *  @brief Manages group of Host lamp test LEDs
+ */
+class HostLampTest : public HostLampTestInterfaces, public LEDGroupObj
+{
+  public:
+    HostLampTest() = delete;
+    ~HostLampTest() = default;
+    HostLampTest(const HostLampTest&) = delete;
+    HostLampTest& operator=(const HostLampTest&) = delete;
+    HostLampTest(HostLampTest&&) = default;
+    HostLampTest& operator=(HostLampTest&&) = default;
+
+    /** @brief Constructs LED Group
+     *
+     * @param[in] bus       - Handle to system dbus
+     * @param[in] objPath   - The D-Bus path that hosts LED group
+     * @param[in] mctp_fd   - MCTP file descriptor
+     * @param[in] mctp_eid  - MCTP EID
+     * @param[in] requester - Reference to Requester object
+     * @param[in] repo      - pointer to BMC's primary PDR repo
+     * @param[in] handler   - PLDM request handler
+     */
+    HostLampTest(sdbusplus::bus::bus& bus, const std::string& objPath,
+                 int mctp_fd, uint8_t mctp_eid, Requester& requester,
+                 pldm_pdr* repo,
+                 pldm::requester::Handler<pldm::requester::Request>& handler) :
+        LEDGroupObj(bus, objPath.c_str()),
+        path(objPath), mctp_fd(mctp_fd), mctp_eid(mctp_eid),
+        requester(requester), pdrRepo(repo), handler(handler)
+    {}
+
+    /** @brief Property SET Override function
+     *
+     *  @param[in]  value   -  True or False
+     *  @return             -  Success or exception thrown
+     */
+    bool asserted(bool value) override;
+
+    /** @brief Property GET Override function
+     *
+     *  @return             -  True or False
+     */
+    bool asserted() const override;
+
+    /** @brief Get effecterID from PDRs.
+     *
+     *  @return effecterID
+     */
+    uint16_t getEffecterID() override;
+
+    /** @brief Set state effecter states to PHYP.
+     *
+     *  @param[in]  effecterID   -  effecterID
+     *  @param[out] rc           -  PLDM completion codes
+     */
+    void setHostStateEffecter(uint16_t effecterID, uint8_t& rc) override;
+
+  private:
+    /** @brief Path of the group instance */
+    std::string path;
+
+    /** @brief fd of MCTP communications socket */
+    int mctp_fd;
+
+    /** @brief MCTP EID of host firmware */
+    uint8_t mctp_eid;
+
+    /** @brief reference to Requester object, primarily used to access API to
+     *  obtain PLDM instance id.
+     */
+    Requester& requester;
+
+    /** @brief pointer to BMC's primary PDR repo */
+    const pldm_pdr* pdrRepo;
+
+    /** @brief Effecter ID */
+    uint16_t effecterID = 0;
+
+    /** @brief PLDM request handler */
+    pldm::requester::Handler<pldm::requester::Request>& handler;
+};
+
+} // namespace led
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -310,7 +310,7 @@ int createOrUpdateLicenseDbusPaths(const uint8_t& flag)
             licAvailState = true;
         }
 
-        CustomDBus::getCustomDBus().setOperationalStatus(key, licOpStatus);
+        CustomDBus::getCustomDBus().setOperationalStatus(key, licOpStatus, "");
         CustomDBus::getCustomDBus().setAvailabilityState(key, licAvailState);
     }
 

--- a/oem/ibm/test/host_bmc_lamp_test.cpp
+++ b/oem/ibm/test/host_bmc_lamp_test.cpp
@@ -1,0 +1,51 @@
+#include "oem/ibm/host-bmc/host_lamp_test.hpp"
+#include "pldmd/dbus_impl_requester.hpp"
+
+#include <string.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace pldm::led;
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+class MockLampTest : public HostLampTest
+{
+  public:
+    MockLampTest(sdbusplus::bus::bus& bus, const std::string& objPath,
+                 int mctp_fd, uint8_t mctp_eid, Requester& requester,
+                 pldm_pdr* repo,
+                 pldm::requester::Handler<pldm::requester::Request>* handler) :
+        HostLampTest(bus, objPath, mctp_fd, mctp_eid, requester, repo, *handler)
+    {}
+
+    MOCK_METHOD(uint16_t, getEffecterID, (), (override));
+    MOCK_METHOD(void, setHostStateEffecter, (uint16_t effecterId, uint8_t& rc),
+                (override));
+};
+
+TEST(TestLamp, Asserted)
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    pldm::dbus_api::Requester dbusImplReq(bus, "/abc/def/pldm");
+
+    MockLampTest lampTest(bus, "/xyz/openbmc_project/led/groups/host_lamp_test",
+                          0, 0, dbusImplReq, nullptr, nullptr);
+
+    EXPECT_CALL(lampTest, getEffecterID())
+        .Times(2)
+        .WillOnce(Return(0))
+        .WillOnce(Return(1));
+    EXPECT_CALL(lampTest, setHostStateEffecter(1, testing::_))
+        .WillOnce(DoAll(testing::SetArgReferee<1>(2)));
+
+    lampTest.asserted(false);
+    EXPECT_EQ(lampTest.asserted(), false);
+
+    ASSERT_THROW(lampTest.asserted(true), sdbusplus::exception::SdBusError);
+
+    lampTest.asserted(true);
+    EXPECT_EQ(lampTest.asserted(), true);
+}

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -56,6 +56,7 @@
 #include "libpldmresponder/file_io.hpp"
 #include "libpldmresponder/fru_oem_ibm.hpp"
 #include "libpldmresponder/oem_ibm_handler.hpp"
+#include "oem/ibm/host-bmc/host_lamp_test.hpp"
 #endif
 
 constexpr uint8_t MCTP_MSG_TYPE_PLDM = 1;
@@ -252,6 +253,12 @@ int main(int argc, char** argv)
     invoker.registerHandler(PLDM_OEM, std::make_unique<oem_ibm::Handler>(
                                           oemPlatformHandler.get(), sockfd,
                                           hostEID, &dbusImplReq, &reqHandler));
+
+    // host lamp test
+    std::unique_ptr<pldm::led::HostLampTest> hostLampTest =
+        std::make_unique<pldm::led::HostLampTest>(
+            bus, "/xyz/openbmc_project/led/groups/host_lamp_test", sockfd,
+            hostEID, dbusImplReq, pdrRepo.get(), reqHandler);
 #endif
     if (hostEID)
     {


### PR DESCRIPTION
This PR would add
1.Lamp test support from pldm
2. Mex critical associations for health rollup function.
3.Also removes some unwanted trace
