### PR TITLE
PLDM: Hex value support for the PCIE config space data

### DIFF
--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -45,21 +45,39 @@ int pldm::responder::oem_ibm_fru::Handler::processOEMfruRecord(
             {
                 return PLDM_ERROR;
             }
-            auto vendorId = std::to_string(htole16(pcieData->vendorId));
-            auto deviceId = std::to_string(htole16(pcieData->deviceId));
-            auto revisionId = std::to_string(pcieData->revisionId);
+
+            std::stringstream vId;
+            vId << "0x" << std::setfill('0') << std::setw(4) << std::hex
+                << htole16(pcieData->vendorId);
+            auto vendorId = vId.str();
+
+            std::stringstream dId;
+            dId << "0x" << std::setfill('0') << std::setw(4) << std::hex
+                << htole16(pcieData->deviceId);
+            auto deviceId = dId.str();
+
+            std::stringstream rId;
+            rId << "0x" << std::setfill('0') << std::setw(2) << std::hex
+                << htole16(pcieData->revisionId);
+            auto revisionId = rId.str();
 
             std::stringstream ss;
-
+            ss << "0x";
             for (int ele : pcieData->classCode)
             {
                 ss << std::setfill('0') << std::setw(2) << std::hex << ele;
             }
-            std::string classCode = ss.str();
+            auto classCode = ss.str();
 
-            auto subSystemVendorId =
-                std::to_string(htole16(pcieData->subSystemVendorId));
-            auto subSystemId = std::to_string(htole16(pcieData->subSystemId));
+            std::stringstream subSysVenId;
+            subSysVenId << "0x" << std::setfill('0') << std::setw(4) << std::hex
+                        << htole16(pcieData->subSystemVendorId);
+            auto subSystemVendorId = subSysVenId.str();
+
+            std::stringstream subSysId;
+            subSysId << "0x" << std::setfill('0') << std::setw(4) << std::hex
+                     << htole16(pcieData->subSystemId);
+            auto subSystemId = subSysId.str();
 
             updateDBusProperty(fruRSI, entityAssociationMap, vendorId, deviceId,
                                revisionId, classCode, subSystemVendorId,


### PR DESCRIPTION
This commit sets the PCIE config space data sent from
host with a prefix '0x' and the hex value. This change
was needed as the Redfish validator expects the fields
to be in a particular Regex form otherwise it fails to
validate.

Tested:
By using busctl commands to set the fields with the data
sent and also ran the Redfish validator to verify.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>