### PR TITLE
Add composite UPS state sensor to JSON file

### DIFF
--- a/configurations/pdr/4.json
+++ b/configurations/pdr/4.json
@@ -3,6 +3,54 @@
     {
     "pdrType" : 4,
     "entries" : [{
+        "type" : 121,
+        "instance" : 1,
+        "container" : 1,
+        "parent_entity_path" : "/xyz/openbmc_project/inventory/system",
+        "sensors" : [{
+            "set" : {
+                "id" : 259,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/org/freedesktop/UPower/devices/ups_hiddev0",
+                "interface": "org.freedesktop.UPower.Device",
+                "property_name": "IsPresent",
+                "property_type": "bool",
+                "property_values" : [false, true]
+            }
+        },
+        {
+            "set" : {
+                "id" : 261,
+                "size" : 1,
+                "states" : [1,4,5]
+            },
+            "dbus" : {
+                "path": "/org/freedesktop/UPower/devices/ups_hiddev0",
+                "interface": "org.freedesktop.UPower.Device",
+                "property_name": "State",
+                "property_type": "uint32_t",
+                "property_values" : [4, 1, 2]
+            }
+        },
+        {
+            "set" : {
+                "id" : 262,
+                "size" : 1,
+                "states" : [1,3]
+            },
+            "dbus" : {
+                "path": "/org/freedesktop/UPower/devices/ups_hiddev0",
+                "interface": "org.freedesktop.UPower.Device",
+                "property_name": "BatteryLevel",
+                "property_type": "uint32_t",
+                "property_values" : [8, 3]
+            }
+        }]
+    },
+    {
         "type" : 91,
         "instance" : 1,
         "container" : 2,


### PR DESCRIPTION
Add a new composite state sensor to the state sensors JSON file.  The
composite sensor describes the state of an Uninterruptible Power Supply
(UPS) attached to the system.

The composite sensor is contained in the "Logical System" with container
ID 1.  The sensor provides the following state sets:
* 259 - Backup Power Source
* 261 - Battery Activity
* 262 - Battery State

This sensor is not system-specific, so it was added to the common
(non-OEM) state sensors JSON file.

Testing:
* Copied the modified 4.json file to the /usr/share/pldm/pdr directory
  on the BMC and re-started the pldmd.service.
* Ran 'pldmtool platform GetPDR -t stateSensor' and verified the new
  composite sensor exists in the output with the correct field values.
* Ran 'pldmtool platform GetStateSensorReadings' for the new composite
  sensor and verified the output field values.
* Ran 'pldmtool platform GetPDR -t EntityAssociation' and verified that
  one UPS/battery entity is contained in container ID 1.
* Modified the value of the 3 D-Bus interface properties that are mapped
  to the state sets.  Verified that PLDM sends an event notification by
  viewing the PLDM journal entries.  Verified the field values of the
  events.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: I48ae691d1e3531559b5d1d2aab7a5e85a6bd3460