### PR TITLE
Fix: Set PCIeConfig Information for IBM Cards

### DIFF
--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -122,15 +122,15 @@ void Handler::updateDBusProperty(
                 if (!(pldm::responder::utils::checkIfIBMCableCard(key)))
                 {
                     setFruPresence(key);
-
-                    dbus_map_update(key, "Function0VendorId", vendorId);
-                    dbus_map_update(key, "Function0DeviceId", deviceId);
-                    dbus_map_update(key, "Function0RevisionId", revisionId);
-                    dbus_map_update(key, "Function0ClassCode", classCode);
-                    dbus_map_update(key, "Function0SubsystemVendorId",
-                                    subSystemVendorId);
-                    dbus_map_update(key, "Function0SubsystemId", subSystemId);
                 }
+
+                dbus_map_update(key, "Function0VendorId", vendorId);
+                dbus_map_update(key, "Function0DeviceId", deviceId);
+                dbus_map_update(key, "Function0RevisionId", revisionId);
+                dbus_map_update(key, "Function0ClassCode", classCode);
+                dbus_map_update(key, "Function0SubsystemVendorId",
+                                subSystemVendorId);
+                dbus_map_update(key, "Function0SubsystemId", subSystemId);
             }
         }
     }


### PR DESCRIPTION
There is a bug in a code, where we ignore the PCIe Config
information that is sent by the PHYP for IBM Cable cards.

This PR would fix the issue.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>