### PR TITLE
PDR: Add LCD panel and connector support for everest

### DIFF
--- a/configurations/pdr/11.json
+++ b/configurations/pdr/11.json
@@ -62,7 +62,45 @@
                  ]
              }
          }]
-     }]
+     },
+     {
+       "type" : 32813,
+       "instance" : 1,
+       "container" : 0,
+       "effecters" : [{
+           "set" : {
+               "id" : 10,
+               "size" : 1,
+               "states" : [1,2]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+               "interface": "xyz.openbmc_project.Led.Group",
+               "property_name": "Asserted",
+               "property_type": "bool",
+               "property_values" : [false, true]
+            }
+       }]
+    },
+    {
+       "type" : 32813,
+       "instance" : 2,
+       "container" : 0,
+       "effecters" : [{
+           "set" : {
+               "id" : 10,
+               "size" : 1,
+               "states" : [1,2]
+           },
+           "dbus" : {
+               "path": "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+               "interface": "xyz.openbmc_project.Led.Group",
+               "property_name": "Asserted",
+               "property_type": "bool",
+               "property_values" : [false, true]
+            }
+       }]
+    }]
   },
   {
     "pdrType" : 9,

--- a/configurations/pdr/4.json
+++ b/configurations/pdr/4.json
@@ -109,6 +109,44 @@
                 "property_values" : [false, true]
              }
         }]
+    },
+    {
+        "type" : 32813,
+        "instance" : 1,
+        "container" : 0,
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 32813,
+        "instance" : 2,
+        "container" : 0,
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
     }]
   }]
 }

--- a/oem/ibm/configurations/pdr/ibm,everest/11.json
+++ b/oem/ibm/configurations/pdr/ibm,everest/11.json
@@ -1968,7 +1968,7 @@
         }]
     },
     {
-        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/dasd_backplane/panel0",
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel0",
         "effecters" : [{
             "set" : {
                 "id" : 17,
@@ -1977,6 +1977,125 @@
             },
             "dbus" : {
                 "path": "/xyz/openbmc_project/led/groups/op_panel_base_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1",
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/op_panel_lcd_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector0",
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector0_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector1",
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector1_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector2",
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector2_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector3",
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector3_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector4",
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector4_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector5",
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector5_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -2600,7 +2719,7 @@
         }]
     },
     {
-        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot",
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1/cxp_bot",
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -2608,7 +2727,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_bot",
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1/cxp_bot",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
                 "property_name": "Functional",
                 "property_type": "bool",
@@ -2617,7 +2736,7 @@
         }]
     },
     {
-        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top",
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1/cxp_top",
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -2625,7 +2744,41 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0/cxp_top",
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1/cxp_top",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2/cxp_bot",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2/cxp_bot",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2/cxp_top",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2/cxp_top",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
                 "property_name": "Functional",
                 "property_type": "bool",
@@ -2702,6 +2855,108 @@
         }]
     },
     {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5/pcie_card5/cxp_bot",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5/pcie_card5/cxp_bot",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5/pcie_card5/cxp_top",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5/pcie_card5/cxp_top",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7/cxp_bot",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7/cxp_bot",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7/cxp_top",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7/cxp_top",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/cxp_bot",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/cxp_bot",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/cxp_top",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/cxp_top",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot",
         "effecters" : [{
             "set" : {
@@ -2728,6 +2983,40 @@
             },
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/cxp_bot",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/cxp_bot",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/cxp_top",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11/cxp_top",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
                 "property_name": "Functional",
                 "property_type": "bool",
@@ -4368,6 +4657,125 @@
             },
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel0",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector0",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector0",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector1",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector1",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector2",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector2",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector3",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector3",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector4",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector4",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values" : [true, false]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector5",
+        "effecters" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector5",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
                 "property_name": "Functional",
                 "property_type": "bool",

--- a/oem/ibm/configurations/pdr/ibm,everest/4.json
+++ b/oem/ibm/configurations/pdr/ibm,everest/4.json
@@ -1974,12 +1974,12 @@
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel0",
         "sensors" : [{
             "set" : {
-                "id" : 10,
+                "id" : 17,
                 "size" : 1,
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/op_panel_base_fault",
+                "path": "/xyz/openbmc_project/led/groups/op_panel_base_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -1987,6 +1987,125 @@
              }
         }]
     },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1",
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/op_panel_lcd_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector0",
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector0_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector1",
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector1_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector2",
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector2_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector3",
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector3_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector4",
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector4_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector5",
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector5_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },   
     {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
         "sensors" : [{
@@ -4550,7 +4669,125 @@
              }
         }]
     },
-
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1",
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/op_panel_lcd_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector0",
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector0_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector1",
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector1_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector2",
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector2_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector3",
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector3_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector4",
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector4_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/connector5",
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/opencapi_connector5_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
     {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
         "sensors" : [{

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -64,10 +64,13 @@ int pldm::responder::oem_ibm_platform::Handler::
     for (size_t i = 0; i < compSensorCnt; i++)
     {
         uint8_t sensorOpState{};
+        uint8_t realSAIState{};
         if (entityType == PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE &&
             stateSetId == PLDM_OEM_IBM_BOOT_STATE)
         {
             sensorOpState = fetchBootSide(entityInstance, codeUpdate);
+            stateField.push_back({PLDM_SENSOR_ENABLED, PLDM_SENSOR_UNKNOWN,
+                                  PLDM_SENSOR_UNKNOWN, sensorOpState});
         }
         else if (entityType == PLDM_ENTITY_SLOT &&
                  stateSetId == PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE)
@@ -82,6 +85,12 @@ int pldm::responder::oem_ibm_platform::Handler::
                     break;
                 }
             }
+        }
+        else if (entityType == PLDM_OEM_IBM_ENTITY_REAL_SAI && stateSetId == 10)
+        {
+            realSAIState = fetchRealSAIStatus();
+            stateField.push_back({PLDM_SENSOR_ENABLED, PLDM_SENSOR_NORMAL,
+                                  PLDM_SENSOR_UNKNOWN, realSAIState});
         }
         else
         {
@@ -194,6 +203,11 @@ int pldm::responder::oem_ibm_platform::Handler::
                 {
                     codeUpdate->processRenameEvent();
                 }
+            }
+            else if (entityType == PLDM_OEM_IBM_ENTITY_REAL_SAI &&
+                     stateSetId == 10)
+            {
+                turnOffRealSAIEffecter();
             }
             else
             {
@@ -613,6 +627,99 @@ std::filesystem::path pldm::responder::oem_ibm_platform::Handler::getConfigDir()
     return fs::path();
 }
 
+void buildAllRealSAIEffecterPDR(oem_ibm_platform::Handler* platformHandler,
+                                uint16_t entityType, uint16_t entityInstance,
+                                pdr_utils::Repo& repo)
+
+{
+    size_t pdrSize = 0;
+    pdrSize = sizeof(pldm_state_effecter_pdr) +
+              sizeof(state_effecter_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_effecter_pdr* pdr =
+        reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
+    if (!pdr)
+    {
+        std::cerr << "Failed to get record by PDR type, ERROR:"
+                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        return;
+    }
+    pdr->hdr.record_handle = 0;
+    pdr->hdr.version = 1;
+    pdr->hdr.type = PLDM_STATE_EFFECTER_PDR;
+    pdr->hdr.record_change_num = 0;
+    pdr->hdr.length = sizeof(pldm_state_effecter_pdr) - sizeof(pldm_pdr_hdr);
+    pdr->terminus_handle = TERMINUS_HANDLE;
+    pdr->effecter_id = platformHandler->getNextEffecterId();
+    pdr->entity_type = entityType;
+    pdr->entity_instance = entityInstance;
+    pdr->container_id = 1;
+    pdr->effecter_semantic_id = 0;
+    pdr->effecter_init = PLDM_NO_INIT;
+    pdr->has_description_pdr = false;
+    pdr->composite_effecter_count = 1;
+
+    auto* possibleStatesPtr = pdr->possible_states;
+    auto possibleStates =
+        reinterpret_cast<state_effecter_possible_states*>(possibleStatesPtr);
+    possibleStates->state_set_id = 10;
+    possibleStates->possible_states_size = 1;
+    auto state =
+        reinterpret_cast<state_effecter_possible_states*>(possibleStates);
+    state->states[0].byte = 2;
+    pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+    pdrEntry.data = entry.data();
+    pdrEntry.size = pdrSize;
+    repo.addRecord(pdrEntry);
+}
+
+void buildAllRealSAISensorPDR(oem_ibm_platform::Handler* platformHandler,
+                              uint16_t entityType, uint16_t entityInstance,
+                              pdr_utils::Repo& repo)
+
+{
+    size_t pdrSize = 0;
+    pdrSize =
+        sizeof(pldm_state_sensor_pdr) + sizeof(state_sensor_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_sensor_pdr* pdr =
+        reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
+    if (!pdr)
+    {
+        std::cerr << "Failed to get record by PDR type, ERROR:"
+                  << PLDM_PLATFORM_INVALID_SENSOR_ID << std::endl;
+        return;
+    }
+    pdr->hdr.record_handle = 0;
+    pdr->hdr.version = 1;
+    pdr->hdr.type = PLDM_STATE_SENSOR_PDR;
+    pdr->hdr.record_change_num = 0;
+    pdr->hdr.length = sizeof(pldm_state_sensor_pdr) - sizeof(pldm_pdr_hdr);
+    pdr->terminus_handle = TERMINUS_HANDLE;
+    pdr->sensor_id = platformHandler->getNextSensorId();
+    pdr->entity_type = entityType;
+    pdr->entity_instance = entityInstance;
+    pdr->container_id = 1;
+    pdr->sensor_init = PLDM_NO_INIT;
+    pdr->sensor_auxiliary_names_pdr = false;
+    pdr->composite_sensor_count = 1;
+
+    auto* possibleStatesPtr = pdr->possible_states;
+    auto possibleStates =
+        reinterpret_cast<state_sensor_possible_states*>(possibleStatesPtr);
+    possibleStates->state_set_id = 10;
+    possibleStates->possible_states_size = 2;
+    auto state =
+        reinterpret_cast<state_sensor_possible_states*>(possibleStates);
+    state->states[0].byte = 6;
+    pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+    pdrEntry.data = entry.data();
+    pdrEntry.size = pdrSize;
+    repo.addRecord(pdrEntry);
+}
+
 void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     pdr_utils::Repo& repo)
 {
@@ -625,6 +732,11 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
 
     buildAllSlotEnabeEffecterPDR(this, repo, getslotPaths());
     buildAllSlotEnableSensorPDR(this, repo, getslotPaths());
+
+    buildAllRealSAIEffecterPDR(this, PLDM_OEM_IBM_ENTITY_REAL_SAI,
+                               ENTITY_INSTANCE_1, repo);
+    buildAllRealSAISensorPDR(this, PLDM_OEM_IBM_ENTITY_REAL_SAI,
+                             ENTITY_INSTANCE_1, repo);
 
     buildAllCodeUpdateEffecterPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
                                   ENTITY_INSTANCE_0,
@@ -1301,6 +1413,56 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtChassisOff()
         biosAttrList.push_back(std::make_pair("pvm_boot_type", "IPL"));
         setBiosAttr(biosAttrList);
     }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::turnOffRealSAIEffecter()
+{
+    try
+    {
+        pldm::utils::DBusMapping dbuspartitionMapping{
+            "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group", "Asserted", "bool"};
+        pldm::utils::DBusHandler().setDbusProperty(dbuspartitionMapping, false);
+
+        pldm::utils::DBusMapping dbusplatformMapping{
+            "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group", "Asserted", "bool"};
+        pldm::utils::DBusHandler().setDbusProperty(dbusplatformMapping, false);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to set the Real SAI effecter" << std::endl;
+    }
+}
+
+uint8_t pldm::responder::oem_ibm_platform::Handler::fetchRealSAIStatus()
+{
+    static constexpr auto partitionSAIObjectPath =
+        "/xyz/openbmc_project/led/groups/partition_system_attention_indicator";
+    static constexpr auto platformSAIObjectPath =
+        "/xyz/openbmc_project/led/groups/platform_system_attention_indicator";
+    static constexpr auto saiInterface = "xyz.openbmc_project.Led.Group";
+    static constexpr auto saiPropertyName = "Asserted";
+    uint8_t isPartitionSAIOn = 0;
+    uint8_t isPlatformSAIOn = 0;
+
+    try
+    {
+        isPartitionSAIOn = pldm::utils::DBusHandler().getDbusProperty<bool>(
+            partitionSAIObjectPath, saiPropertyName, saiInterface);
+        isPlatformSAIOn = pldm::utils::DBusHandler().getDbusProperty<bool>(
+            platformSAIObjectPath, saiPropertyName, saiInterface);
+
+        if (isPartitionSAIOn || isPlatformSAIOn)
+        {
+            return PLDM_SENSOR_WARNING;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to fetch Real SAI sensor status" << std::endl;
+    }
+    return PLDM_SENSOR_NORMAL;
 }
 
 } // namespace oem_ibm_platform

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -43,6 +43,8 @@ using PendingObj = std::tuple<AttributeType, CurrentValue>;
 using PendingAttributes = std::map<AttributeName, PendingObj>;
 static constexpr auto PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577;
 static constexpr auto PLDM_OEM_IBM_FRONT_PANEL_TRIGGER = 32837;
+static constexpr auto PLDM_OEM_IBM_ENTITY_REAL_SAI = 24578;
+
 constexpr uint16_t ENTITY_INSTANCE_0 = 0;
 constexpr uint16_t ENTITY_INSTANCE_1 = 1;
 
@@ -391,6 +393,17 @@ class Handler : public oem_platform::Handler
 
     /** @brief To handle the boot types bios attributes at shutdown*/
     void handleBootTypesAtChassisOff();
+
+    /** @brief To turn off Real SAI effecter*/
+    void turnOffRealSAIEffecter();
+
+    /** @brief Fetch Real SAI status based on the partition SAI and platform SAI
+     *  sensor state. Real SAI is turned on if any of the partition or platform
+     *  SAI turned on else Real SAI is turned off
+     *  @return Real SAI sensor state PLDM_SENSOR_WARNING/PLDM_SENSOR_NORMAL
+     */
+
+    uint8_t fetchRealSAIStatus();
 
     ~Handler() = default;
 

--- a/pldmtool/oem/ibm/oem_ibm_state_set.hpp
+++ b/pldmtool/oem/ibm/oem_ibm_state_set.hpp
@@ -55,6 +55,8 @@ extern const std::map<uint8_t, std::string> OemIBMEntityType{
      "OEM IBM Firmware Update"},
     {PLDM_OEM_ENTITY_TYPE_START, "OEM IBM Entity Type Start"},
     {PLDM_OEM_ENTITY_TYPE_END, "OEM IBM Entity Type End"},
+    {pldm::responder::oem_ibm_platform::PLDM_OEM_IBM_ENTITY_REAL_SAI,
+     "OEM IBM Real SAI"},
 };
 
 /** @brief Map for PLDM OEM IBM State Sets


### PR DESCRIPTION
effecter lcd panel identify
=======================

 pldmtool platform getpdr -d 266
{
    "nextRecordHandle": 267,
    "responseCount": 29,
    "recordHandle": 266,
    "PDRHeaderVersion": 1,
    "PDRType": "State Effecter PDR",
    "recordChangeNumber": 0,
    "dataLength": 19,
    "PLDMTerminusHandle": 1,
    "effecterID": 146,
    "entityType": "[Physical] Chassis front panel board(control panel)",
    "entityInstanceNumber": 2,
    "containerID": 5,
    "effecterSemanticID": 0,
    "effecterInit": "noInit",
    "effecterDescriptionPDR": false,
    "compositeEffecterCount": 1,
    "stateSetID[0]": "Identify State(17)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Identify State Unasserted(1)",
        "Identify State Asserted(2)"
    ]
}

pldmtool platform SetStateEffecterStates -i 146 -c 1 -d 1 2                                                                 {
    "Response": "SUCCESS"
}

busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/op_panel_lcd_identify xyz.openbmc_project.Led.Group Asserted
b true

effecter connector identify
===========================

    "nextRecordHandle": 268,
    "responseCount": 29,
    "recordHandle": 267,
    "PDRHeaderVersion": 1,
    "PDRType": "State Effecter PDR",
    "recordChangeNumber": 0,
    "dataLength": 19,
    "PLDMTerminusHandle": 1,
    "effecterID": 147,
    "entityType": "[Physical] Connector",
    "entityInstanceNumber": 1,
    "containerID": 3,
    "effecterSemanticID": 0,
    "effecterInit": "noInit",
    "effecterDescriptionPDR": false,
    "compositeEffecterCount": 1,
    "stateSetID[0]": "Identify State(17)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Identify State Unasserted(1)",
        "Identify State Asserted(2)"


busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/opencapi_connector0_identify xyz.openbmc_project.Led.Group Asserted
b false
 pldmtool platform SetStateEffecterStates -i 147 -c 1 -d 1 1
{
    "Response": "SUCCESS"
}
busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/opencapi_connector0_identify xyz.openbmc_project.Led.Group Asserted
b false

effecter op-panel fault


{
    "nextRecordHandle": 416,
    "responseCount": 29,
    "recordHandle": 415,
    "PDRHeaderVersion": 1,
    "PDRType": "State Effecter PDR",
    "recordChangeNumber": 0,
    "dataLength": 19,
    "PLDMTerminusHandle": 1,
    "effecterID": 295,
    "entityType": "[Physical] Chassis front panel board(control panel)",
    "entityInstanceNumber": 2,
    "containerID": 5,
    "effecterSemanticID": 0,
    "effecterInit": "noInit",
    "effecterDescriptionPDR": false,
    "compositeEffecterCount": 1,
    "stateSetID[0]": "Operational Fault Status(10)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Normal(1)",
        "Stressed(2)"
    ]
}

}
busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1 xyz.openbmc_project.State.Decorator.OperationalStatus Functional
b true
pldmtool platform SetStateEffecterStates -i 295 -c 1 -d 1 2                                                                 {
    "Response": "SUCCESS"
}
busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/panel1 xyz.openbmc_project.State.Decorator.OperationalStatus Functional
b false

Effecter connector fault
========================

{
    "nextRecordHandle": 417,
    "responseCount": 29,
    "recordHandle": 416,
    "PDRHeaderVersion": 1,
    "PDRType": "State Effecter PDR",
    "recordChangeNumber": 0,
    "dataLength": 19,
    "PLDMTerminusHandle": 1,
    "effecterID": 296,
    "entityType": "[Physical] Connector",
    "entityInstanceNumber": 1,
    "containerID": 3,
    "effecterSemanticID": 0,
    "effecterInit": "noInit",
    "effecterDescriptionPDR": false,
    "compositeEffecterCount": 1,
    "stateSetID[0]": "Operational Fault Status(10)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Normal(1)",
        "Stressed(2)"
    ]
}


 pldmtool platform SetStateEffecterStates -i 296 -c 1 -d 1 1
{
    "Response": "SUCCESS"
}
busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/connector0 xyz.openbmc_project.State.Decorator.OperationalStatus Functional
b true

sensor Identify panel
=================

{
    "nextRecordHandle": 576,
    "responseCount": 27,
    "recordHandle": 575,
    "PDRHeaderVersion": 1,
    "PDRType": "State Sensor PDR",
    "recordChangeNumber": 0,
    "dataLength": 17,
    "PLDMTerminusHandle": 1,
    "sensorID": 137,
    "entityType": "[Physical] Chassis front panel board(control panel)",
    "entityInstanceNumber": 2,
    "containerID": 5,
    "sensorInit": "noInit",
    "sensorAuxiliaryNamesPDR": false,
    "compositeSensorCount": 1,
    "stateSetID[0]": "Identify State(17)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Identify State Unasserted(1)",
        "Identify State Asserted(2)"
    ]
}


 busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/op_panel_lcd_identify xyz.openbmc_project.Led.Group Asserted b true

 pldmtool platform GetStateSensorReadings -i 137 -r 0                                                                        {
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Warning"
}

Sensor Identify connector
============================

{
    "nextRecordHandle": 577,
    "responseCount": 27,
    "recordHandle": 576,
    "PDRHeaderVersion": 1,
    "PDRType": "State Sensor PDR",
    "recordChangeNumber": 0,
    "dataLength": 17,
    "PLDMTerminusHandle": 1,
    "sensorID": 138,
    "entityType": "[Physical] Connector",
    "entityInstanceNumber": 1,
    "containerID": 3,
    "sensorInit": "noInit",
    "sensorAuxiliaryNamesPDR": false,
    "compositeSensorCount": 1,
    "stateSetID[0]": "Identify State(17)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Identify State Unasserted(1)",
        "Identify State Asserted(2)"
    ]
}


busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/opencapi_connector0_identify xyz.openbmc_project.Led.Group Asserted b true


pldmtool platform GetStateSensorReadings -i 138 -r 0
{
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Warning"
}