### PR TITLE
oen-ibm: Resource dump entry delete support

### DIFF
--- a/oem/ibm/libpldm/file_io.h
+++ b/oem/ibm/libpldm/file_io.h
@@ -36,6 +36,7 @@ enum pldm_fileio_completion_codes {
 	PLDM_INVALID_FILE_HANDLE = 0x86,
 	PLDM_DATA_OUT_OF_RANGE = 0x87,
 	PLDM_INVALID_FILE_TYPE = 0x89,
+	PLDM_ERROR_FILE_DISCARDED = 0x8A,
 };
 
 /** @brief PLDM File I/O table types

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -125,7 +125,7 @@ int DumpHandler::newFileAvailable(uint64_t length)
         auto method = bus.new_method_call(service.c_str(), notifyObjPath,
                                           dumpInterface, "Notify");
         method.append(fileHandle, length);
-        bus.call_noreply(method);
+        bus.call(method);
     }
     catch (const std::exception& e)
     {
@@ -237,8 +237,49 @@ int DumpHandler::fileAck(uint8_t fileStatus)
         return PLDM_SUCCESS;
     }
 
-    if (DumpHandler::fd >= 0 && !path.empty())
+    if (!path.empty())
     {
+        if (fileStatus == PLDM_ERROR_FILE_DISCARDED)
+        {
+            uint32_t val = 0xFFFFFFFF;
+            PropertyValue value = static_cast<uint32_t>(val);
+            DBusMapping dbusMapping{path.c_str(), "com.ibm.Dump.Entry.Resource",
+                                    "SourceDumpId", "uint32_t"};
+            try
+            {
+                pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << "Failed to make a d-bus call to DUMP "
+                             "manager to reset source dump id of "
+                          << path.c_str() << ", with ERROR=" << e.what()
+                          << "\n";
+                pldm::utils::reportError(
+                    "xyz.openbmc_project.bmc.PLDM.fileAck.SourceDumpIdResetFail");
+                return PLDM_ERROR;
+            }
+
+            auto& bus = pldm::utils::DBusHandler::getBus();
+            try
+            {
+                auto method = bus.new_method_call(
+                    "xyz.openbmc_project.Dump.Manager", path.c_str(),
+                    "xyz.openbmc_project.Object.Delete", "Delete");
+                bus.call(method);
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr
+                    << "Failed to make a d-bus method to delete the dump entry "
+                    << path.c_str() << ", with ERROR=" << e.what() << "\n";
+                pldm::utils::reportError(
+                    "xyz.openbmc_project.bmc.PLDM.fileAck.DumpEntryDeleteFail");
+                return PLDM_ERROR;
+            }
+            return PLDM_SUCCESS;
+        }
+
         if (dumpType == PLDM_FILE_TYPE_DUMP ||
             dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
         {
@@ -255,10 +296,13 @@ int DumpHandler::fileAck(uint8_t fileStatus)
                     << e.what() << "\n";
             }
 
-            close(DumpHandler::fd);
             auto socketInterface = getOffloadUri(fileHandle);
             std::remove(socketInterface.c_str());
-            DumpHandler::fd = -1;
+            if (DumpHandler::fd >= 0)
+            {
+                close(DumpHandler::fd);
+                DumpHandler::fd = -1;
+            }
         }
         return PLDM_SUCCESS;
     }
@@ -299,7 +343,8 @@ int DumpHandler::fileAckWithMetaData(uint32_t metaDataValue1,
         std::cout << "Token: " << metaDataValue1 << std::endl;
         if (fileStatus != PLDM_SUCCESS)
         {
-            std::cerr << "Failue in resource dump file ack" << std::endl;
+            std::cerr << "Failue in resource dump file ack with metadata"
+                      << std::endl;
             pldm::utils::reportError(
                 "xyz.openbmc_project.bmc.PLDM.fileAck.ResourceDumpFileAckWithMetaDataFail");
 
@@ -401,12 +446,16 @@ int DumpHandler::newFileAvailableWithMetaData(uint64_t length, uint32_t token)
         auto method = bus.new_method_call(service.c_str(), notifyObjPath,
                                           dumpInterface, "Notify");
         method.append(fileHandle, length);
-        bus.call_noreply(method);
+        bus.call(method);
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to DUMP manager, ERROR="
-                  << e.what() << "\n";
+        std::cerr
+            << "failed to make a d-bus call to notify"
+               " a new dump request using newFileAvailableWithMetaData, ERROR="
+            << e.what() << "\n";
+        pldm::utils::reportError(
+            "xyz.openbmc_project.bmc.PLDM.newFileAvailableWithMetaData.NewDumpNotifyFail");
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;


### PR DESCRIPTION
This commit includes following changes:
1. Support to delete the resource dump entry when dump after dump
   was being offloaded to OS in non-hmc managed systems
2. Changed the bus call method for not to use noreply option

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I7526cfee89361f7d51ea709c9a7162c8985ab394