### PR TITLE
bios: Remove deprecated vmi_if_count bios attribute

### DIFF
--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -1,15 +1,6 @@
 {
    "entries":[
       {
-         "attribute_name" : "vmi_if_count",
-         "lower_bound" : 0,
-         "upper_bound" : 2,
-         "scalar_increment" : 1,
-         "default_value" : 1,
-         "helpText" : "vmi_if_count",
-         "displayName" : "vmi_if_count"
-      },
-      {
          "attribute_name" : "vmi_if0_ipv4_prefix_length",
          "lower_bound" : 0,
          "upper_bound" : 32,


### PR DESCRIPTION
vmi_if_count is a deprecated attribute and is not used by
phyp, so removing it from pldm json files.

Fixes : SW542127

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>