### PR TITLE
Add stateset id support for remote sensor events

### DIFF
--- a/configurations/events/stateSensorPdrs.json
+++ b/configurations/events/stateSensorPdrs.json
@@ -1,713 +1,746 @@
 {
 	"entries": [
-	  {
-		"containerID": 1,
-		"entityType": 32801,
-		"entityInstance": 0,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  2,
-		  3,
-		  5,
-		  7,
-		  9,
-		  21,
-		  22,
-		  26
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/state/host0",
-		  "interface": "xyz.openbmc_project.State.Boot.Progress",
-		  "property_name": "BootProgress",
-		  "property_type": "string",
-		  "property_values": [
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemInitComplete",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.MemoryInit",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SecondaryProcInit",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemSetup",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PCIInit",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.OSRunning",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.BusInit",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PrimaryProcInit"
-		  ]
+		{
+			"containerID": 1,
+			"entityType": 32801,
+			"entityInstance": 0,
+			"sensorOffset": 0,
+			"stateSetId": 196,
+			"event_states": [
+				1,
+				2,
+				3,
+				5,
+				7,
+				9,
+				21,
+				22,
+				26
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/state/host0",
+				"interface": "xyz.openbmc_project.State.Boot.Progress",
+				"property_name": "BootProgress",
+				"property_type": "string",
+				"property_values": [
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemInitComplete",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.MemoryInit",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SecondaryProcInit",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemSetup",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PCIInit",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.OSRunning",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.BusInit",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PrimaryProcInit"
+				]
+			}
+		},
+		{
+			"containerID": 0,
+			"entityType": 32801,
+			"entityInstance": 0,
+			"sensorOffset": 0,
+			"stateSetId": 196,
+			"event_states": [
+				1,
+				2,
+				3,
+				5,
+				7,
+				9,
+				21,
+				22,
+				26
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/state/host0",
+				"interface": "xyz.openbmc_project.State.Boot.Progress",
+				"property_name": "BootProgress",
+				"property_type": "string",
+				"property_values": [
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemInitComplete",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.MemoryInit",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SecondaryProcInit",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemSetup",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PCIInit",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.OSRunning",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.BusInit",
+					"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PrimaryProcInit"
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 0,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 1,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 2,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 3,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 4,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 5,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 6,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 7,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 8,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 9,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 10,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 11,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 12,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 13,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 14,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 15,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 16,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 17,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 18,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 19,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 20,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 21,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 22,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 23,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 24,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 25,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 26,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 27,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 28,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 29,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 30,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
+		},
+		{
+			"containerID": 3,
+			"entityType": 66,
+			"entityInstance": 31,
+			"sensorOffset": 0,
+			"stateSetId": 1,
+			"event_states": [
+				1,
+				3
+			],
+			"dbus": {
+				"object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31",
+				"interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+				"property_name": "Functional",
+				"property_type": "bool",
+				"property_values": [
+					true,
+					false
+				]
+			}
 		}
-	  },
-	  {
-		"containerID": 0,
-		"entityType": 32801,
-		"entityInstance": 0,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  2,
-		  3,
-		  5,
-		  7,
-		  9,
-		  21,
-		  22,
-		  26
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/state/host0",
-		  "interface": "xyz.openbmc_project.State.Boot.Progress",
-		  "property_name": "BootProgress",
-		  "property_type": "string",
-		  "property_values": [
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemInitComplete",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.MemoryInit",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SecondaryProcInit",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemSetup",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PCIInit",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.OSRunning",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.BusInit",
-			"xyz.openbmc_project.State.Boot.Progress.ProgressStages.PrimaryProcInit"
-		  ]
-		}
-	  },
-
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 0,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 1,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 2,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 3,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 4,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 5,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 6,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 7,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 8,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 9,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 10,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 11,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 12,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 13,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 14,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 15,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 16,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 17,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 18,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 19,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 20,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 21,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 22,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 23,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 24,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 25,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 26,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 27,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 28,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 29,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 30,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  },
-	  {
-		"containerID": 3,
-		"entityType": 66,
-		"entityInstance": 31,
-		"sensorOffset": 0,
-		"event_states": [
-		  1,
-		  3
-		],
-		"dbus": {
-		  "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31",
-		  "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-		  "property_name": "Functional",
-		  "property_type": "bool",
-		  "property_values": [
-			true,
-			false
-		  ]
-		}
-	  }
 	]
-  } 
+}

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1072,9 +1072,10 @@ void HostPDRHandler::_setHostSensorState()
                     }
                     const auto& [containerId, entityType, entityInstance] =
                         entityInfo;
+                    auto stateSetId = stateSetIds[sensorOffset];
                     pldm::responder::events::StateSensorEntry stateSensorEntry{
-                        containerId, entityType, entityInstance, sensorOffset,
-                        false};
+                        containerId,  entityType, entityInstance,
+                        sensorOffset, false,      stateSetId};
                     handleStateSensorEvent(stateSetIds, stateSensorEntry,
                                            eventState);
                 }

--- a/libpldmresponder/event_parser.cpp
+++ b/libpldmresponder/event_parser.cpp
@@ -56,6 +56,8 @@ StateSensorHandler::StateSensorHandler(const std::string& dirPath)
                 static_cast<uint16_t>(entry.value("entityInstance", 0));
             stateSensorEntry.sensorOffset =
                 static_cast<uint8_t>(entry.value("sensorOffset", 0));
+            stateSensorEntry.stateSetid =
+                static_cast<uint16_t>(entry.value("stateSetId", 0));
 
             // container id is not found in the json
             stateSensorEntry.skipContainerCheck =

--- a/libpldmresponder/event_parser.hpp
+++ b/libpldmresponder/event_parser.hpp
@@ -28,6 +28,7 @@ struct StateSensorEntry
     pdr::EntityInstance entityInstance;
     pdr::SensorOffset sensorOffset;
     bool skipContainerCheck;
+    pdr::StateSetId stateSetid;
 
     bool operator==(const StateSensorEntry& e) const
     {
@@ -36,13 +37,15 @@ struct StateSensorEntry
             return ((containerId == e.containerId) &&
                     (entityType == e.entityType) &&
                     (entityInstance == e.entityInstance) &&
-                    (sensorOffset == e.sensorOffset));
+                    (sensorOffset == e.sensorOffset) &&
+                    (stateSetid == e.stateSetid));
         }
         else
         {
             return ((entityType == e.entityType) &&
                     (entityInstance == e.entityInstance) &&
-                    (sensorOffset == e.sensorOffset));
+                    (sensorOffset == e.sensorOffset) &&
+                    (stateSetid == e.stateSetid));
         }
     }
 
@@ -59,7 +62,12 @@ struct StateSensorEntry
                     ((containerId == e.containerId) &&
                      (entityType == e.entityType) &&
                      (entityInstance == e.entityInstance) &&
-                     (sensorOffset < e.sensorOffset)));
+                     (sensorOffset < e.sensorOffset)) ||
+                    ((containerId == e.containerId) &&
+                     (entityType == e.entityType) &&
+                     (entityInstance == e.entityInstance) &&
+                     (sensorOffset == e.sensorOffset) &&
+                     (stateSetid < e.stateSetid)));
         }
         else
         {
@@ -68,7 +76,11 @@ struct StateSensorEntry
                      (entityInstance < e.entityInstance)) ||
                     ((entityType == e.entityType) &&
                      (entityInstance == e.entityInstance) &&
-                     (sensorOffset < e.sensorOffset)));
+                     (sensorOffset < e.sensorOffset)) ||
+                    ((entityType == e.entityType) &&
+                     (entityInstance == e.entityInstance) &&
+                     (sensorOffset == e.sensorOffset) &&
+                     (stateSetid < e.stateSetid)));
         }
     }
 };

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -499,7 +499,8 @@ int Handler::sensorEvent(const pldm_msg* request, size_t payloadLength,
 
         const auto& [containerId, entityType, entityInstance] = entityInfo;
         events::StateSensorEntry stateSensorEntry{
-            containerId, entityType, entityInstance, sensorOffset, false};
+            containerId,  entityType, entityInstance,
+            sensorOffset, false,      stateSetIds[sensorOffset]};
         return hostPDRHandler->handleStateSensorEvent(
             stateSetIds, stateSensorEntry, eventState);
     }

--- a/libpldmresponder/test/event_jsons/good/event_state_sensor.json
+++ b/libpldmresponder/test/event_jsons/good/event_state_sensor.json
@@ -5,6 +5,7 @@
             "entityType": 64,
             "entityInstance": 1,
             "sensorOffset": 0,
+            "stateSetId":1,
             "event_states": [
                 0,
                 1,
@@ -27,6 +28,7 @@
             "entityType": 64,
             "entityInstance": 1,
             "sensorOffset": 1,
+            "stateSetId":1,
             "event_states": [
                 2,
                 3
@@ -47,6 +49,7 @@
             "entityType": 67,
             "entityInstance": 2,
             "sensorOffset": 0,
+            "stateSetId":1,
             "event_states": [
                 0,
                 1

--- a/libpldmresponder/test/libpldmresponder_platform_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_platform_test.cpp
@@ -478,7 +478,7 @@ TEST(StateSensorHandler, allScenarios)
 
     // Event Entry 1
     {
-        StateSensorEntry entry{1, 64, 1, 0, false};
+        StateSensorEntry entry{1, 64, 1, 0, false, 1};
         const auto& [dbusMapping, eventStateMap] = handler.getEventInfo(entry);
         DBusMapping mapping{"/xyz/abc/def",
                             "xyz.openbmc_project.example1.value", "value1",
@@ -501,7 +501,7 @@ TEST(StateSensorHandler, allScenarios)
 
     // Event Entry 2
     {
-        StateSensorEntry entry{1, 64, 1, 1, false};
+        StateSensorEntry entry{1, 64, 1, 1, false, 1};
         const auto& [dbusMapping, eventStateMap] = handler.getEventInfo(entry);
         DBusMapping mapping{"/xyz/abc/def",
                             "xyz.openbmc_project.example2.value", "value2",
@@ -518,7 +518,7 @@ TEST(StateSensorHandler, allScenarios)
 
     // Event Entry 3
     {
-        StateSensorEntry entry{2, 67, 2, 0, false};
+        StateSensorEntry entry{2, 67, 2, 0, false, 1};
         const auto& [dbusMapping, eventStateMap] = handler.getEventInfo(entry);
         DBusMapping mapping{"/xyz/abc/ghi",
                             "xyz.openbmc_project.example3.value", "value3",
@@ -535,7 +535,7 @@ TEST(StateSensorHandler, allScenarios)
 
     // Invalid Entry
     {
-        StateSensorEntry entry{0, 0, 0, 0, false};
+        StateSensorEntry entry{0, 0, 0, 0, false, 1};
         ASSERT_THROW(handler.getEventInfo(entry), std::out_of_range);
     }
 }

--- a/oem/ibm/configurations/events/oem_ibm_event_state_sensor.json
+++ b/oem/ibm/configurations/events/oem_ibm_event_state_sensor.json
@@ -4,6 +4,7 @@
             "entityType": 57346,
             "entityInstance": 0,
             "sensorOffset": 1,
+            "stateSetId": 15,
             "event_states": [
                 1,
                 2,
@@ -25,6 +26,7 @@
             "entityType": 57346,
             "entityInstance": 1,
             "sensorOffset": 1,
+            "stateSetId": 15,
             "event_states": [
                 1,
                 2,
@@ -42,5 +44,5 @@
                 ]
             }
         }
-     ]
+    ]
 }


### PR DESCRIPTION
In the current state pldm does not support having state setid
field in the event jsons, this PR would add that support in PLDM
there by allowing hosts to have multiple sensors with the same
entity instance number, type & container id but with different
state sets.

Fix for : SW542285

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>