### PR TITLE
Support for Mex IO Enclosure version

### DIFF
--- a/host-bmc/custom_dbus.cpp
+++ b/host-bmc/custom_dbus.cpp
@@ -29,6 +29,19 @@ std::string CustomDBus::getLocationCode(const std::string& path) const
     return {};
 }
 
+void CustomDBus::setSoftwareVersion(const std::string& path, std::string value)
+{
+    if (version.find(path) == version.end())
+    {
+        version.emplace(path,
+                        std::make_unique<SoftwareVersion>(
+                            pldm::utils::DBusHandler::getBus(), path.c_str()));
+    }
+
+    version.at(path)->version(value);
+    version.at(path)->purpose(VersionPurpose::Other);
+}
+
 void CustomDBus::setOperationalStatus(const std::string& path, bool status,
                                       const std::string& parentChassis)
 {

--- a/host-bmc/custom_dbus.hpp
+++ b/host-bmc/custom_dbus.hpp
@@ -25,6 +25,7 @@
 #include <xyz/openbmc_project/Inventory/Item/server.hpp>
 #include <xyz/openbmc_project/Led/Group/server.hpp>
 #include <xyz/openbmc_project/Object/Enable/server.hpp>
+#include <xyz/openbmc_project/Software/Version/server.hpp>
 #include <xyz/openbmc_project/State/Decorator/Availability/server.hpp>
 #include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
 
@@ -77,6 +78,8 @@ using ItemBoard = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Inventory::Item::server::Board>;
 using ItemGlobal = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Inventory::Item::server::Global>;
+using SoftwareVersion = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Software::server::Version>;
 
 using LicIntf = sdbusplus::server::object::object<
     sdbusplus::com::ibm::License::Entry::server::LicenseEntry>;
@@ -84,6 +87,8 @@ using AvailabilityIntf = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::State::Decorator::server::Availability>;
 using Associations =
     std::vector<std::tuple<std::string, std::string, std::string>>;
+using VersionPurpose =
+    sdbusplus::xyz::openbmc_project::Software::server::Version::VersionPurpose;
 
 class Group : public AssertedIntf
 {
@@ -214,6 +219,8 @@ class CustomDBus
      *  @param[in] path - the object path
      */
     void implementChassisInterface(const std::string& path);
+
+    void setSoftwareVersion(const std::string& path, std::string value);
 
     void implementPCIeSlotInterface(const std::string& path);
 
@@ -347,6 +354,7 @@ class CustomDBus
         fabricAdapter;
     std::unordered_map<ObjectPath, std::unique_ptr<ItemBoard>> board;
     std::unordered_map<ObjectPath, std::unique_ptr<ItemGlobal>> global;
+    std::unordered_map<ObjectPath, std::unique_ptr<SoftwareVersion>> version;
 };
 
 } // namespace dbus

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1413,9 +1413,32 @@ void HostPDRHandler::setLocationCode(
                             std::string(reinterpret_cast<const char*>(
                                             tlv.fruFieldValue.data()),
                                         tlv.fruFieldLen));
+
+                        /* Remove this once phyp support is in place */
+                        if (node.entity_type == PLDM_ENTITY_SYSTEM_CHASSIS)
+                        {
+                            CustomDBus::getCustomDBus().setSoftwareVersion(
+                                entity.first, "sample_mex_version");
+                        }
+                        /* Remove this once phyp support is in place */
                     }
                 }
             }
+            /* Enable this once phyp support is in place
+            else
+            {
+                for(auto& tlv : data.fruTLV)
+                {
+                    if(tlv.fruFieldType == PLDM_FRU_FIELD_TYPE_VERSION &&
+            node.entity_type == PLDM_ENTITY_SYSTEM_CHASSIS)
+                    {
+                        CustomDBus::getCustomDBus().setSoftwareVersion(entity.first,
+                            std::string(reinterpret_cast<const char*>(
+                                            tlv.fruFieldValue.data()),
+                                        tlv.fruFieldLen))
+                    }
+                }
+            }*/
         }
     }
 }


### PR DESCRIPTION
PHYP sends a FRU record set PDR and send the io enclosure
version data via the frurecord table, and pldm parses that
and hosts the Version Interface on the mex chassis object.

Currently phyp does not have the support for this yet, so
hardcoded a dummy value for now, would have to remove that part
of code once the phyp change is in the driver.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>