### PR TITLE
PLDM: Add support for pvm_fw_boot_side

### DIFF
--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -205,6 +205,8 @@ void CodeUpdate::setVersions()
             writeBootSideFile(pldmBootSideData);
             biosAttrList.push_back(std::make_pair(
                 bootSideAttrName, pldmBootSideData.current_boot_side));
+            biosAttrList.push_back(std::make_pair(
+                "pvm_fw_boot_side", pldmBootSideData.current_boot_side));
             setBiosAttr(biosAttrList);
         }
         else
@@ -224,6 +226,8 @@ void CodeUpdate::setVersions()
                 writeBootSideFile(pldmBootSideData);
                 biosAttrList.push_back(
                     std::make_pair(bootSideAttrName, current_boot_side));
+                biosAttrList.push_back(
+                    std::make_pair("pvm_fw_boot_side", current_boot_side));
                 setBiosAttr(biosAttrList);
             }
             else
@@ -231,6 +235,8 @@ void CodeUpdate::setVersions()
                 pldm_boot_side_data pldmBootSideData = readBootSideFile();
                 biosAttrList.push_back(std::make_pair(
                     bootSideAttrName, pldmBootSideData.current_boot_side));
+                biosAttrList.push_back(std::make_pair(
+                    "pvm_fw_boot_side", pldmBootSideData.current_boot_side));
                 setBiosAttr(biosAttrList);
             }
         }
@@ -392,6 +398,8 @@ void CodeUpdate::processRenameEvent()
     writeBootSideFile(pldmBootSideData);
     biosAttrList.push_back(
         std::make_pair(bootSideAttrName, pldmBootSideData.current_boot_side));
+    biosAttrList.push_back(
+        std::make_pair("pvm_fw_boot_side", pldmBootSideData.current_boot_side));
     setBiosAttr(biosAttrList);
 }
 


### PR DESCRIPTION
Add support for pvm_fw_boot_side attribute till HB starts using
fw_boot_side_current attribute

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>