### PR TITLE
oem-ibm: Remove extra bytes in resource dump request

### DIFF
--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -44,7 +44,7 @@ void DbusToFileHandler::sendNewFileAvailableCmd(uint64_t fileSize)
     }
     auto instanceId = requester->getInstanceId(mctp_eid);
     std::vector<uint8_t> requestMsg(sizeof(pldm_msg_hdr) +
-                                    PLDM_NEW_FILE_REQ_BYTES + fileSize);
+                                    PLDM_NEW_FILE_REQ_BYTES);
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
     // Need to revisit this logic at the time of multiple resource dump support
     uint32_t fileHandle = 1;


### PR DESCRIPTION
This is to remove the extra bytes in the new file available request
to hypervisor when the ACF file is fetched from the system while
initiating a resource dump.

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: Iff2143f6f76a1a1ae588891a4a14159288b3df06