### PR TITLE
oem_ibm: bios : change the default value of pvm_stop_at_standby

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -113,7 +113,7 @@
             "ManualOnly"
          ],
          "default_values":[
-            "Enabled"
+            "Disabled"
          ],
          "helpText" : "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
          "displayName" : "pvm_stop_at_standby",
@@ -134,7 +134,7 @@
             "ManualOnly"
          ],
          "default_values":[
-            "Enabled"
+            "Disabled"
          ],
          "helpText" : "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
          "displayName" : "pvm_stop_at_standby_current (current)"


### PR DESCRIPTION
IBM legacy behaviour is to boot to runtime by default, so changing
this attribute default value to align with the legacy designs.

Fixes : SW542764

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
Change-Id: I26873e3574dc37554b090fce32f047e5aebe0a6f