### PR TITLE
Fix object map corruption in pldm

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -178,6 +178,14 @@ HostPDRHandler::HostPDRHandler(
                     this->responseReceived = false;
                     this->mergedHostParents = false;
                     this->objMapIndex = objPathMap.begin();
+
+                    // After a power off , the remote notes will be deleted
+                    // from the entity association tree, making the nodes point
+                    // to junk values, so set them to nullptr
+                    for (const auto& element : this->objPathMap)
+                    {
+                        this->objPathMap[element.first] = nullptr;
+                    }
                 }
                 else if (propVal ==
                          "xyz.openbmc_project.State.Host.HostState.Running")

--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -112,6 +112,13 @@ void addObjectPathEntityAssociations(
             {
                 pldm::utils::DBusHandler().getService(entity_path.c_str(),
                                                       nullptr);
+                if (objPathMap.contains(entity_path))
+                {
+                    // if the object is from PLDM, them update/refresh the
+                    // object map as the map would be with junk values after a
+                    // power off
+                    objPathMap[entity_path] = entity;
+                }
             }
             catch (const std::exception& e)
             {
@@ -140,6 +147,12 @@ void addObjectPathEntityAssociations(
         try
         {
             pldm::utils::DBusHandler().getService(dbusPath.c_str(), nullptr);
+            if (objPathMap.contains(dbusPath))
+            {
+                // if the object is from PLDM, them update/refresh the object
+                // map as the map would be with junk values after a power off
+                objPathMap[dbusPath] = entity;
+            }
         }
         catch (const std::exception& e)
         {

--- a/libpldm/pdr.c
+++ b/libpldm/pdr.c
@@ -733,9 +733,12 @@ static inline uint16_t next_container_id(pldm_entity_association_tree *tree)
 
 pldm_entity pldm_entity_extract(pldm_entity_node *node)
 {
-	assert(node != NULL);
+	if (node != NULL) {
+		return node->entity;
+	}
 
-	return node->entity;
+	pldm_entity entity = {0, 0, 0};
+	return entity;
 }
 
 uint16_t pldm_extract_host_container_id(const pldm_entity_node *entity)


### PR DESCRIPTION
- The map seems to be good in the genesis boot
- But is getting corrupted due to deletion on the
  remote PDR's when host is off.

Fixes : SW542079 & SW542324

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>