### PR TITLE
Fix the fru record table size

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -178,6 +178,14 @@ HostPDRHandler::HostPDRHandler(
                     this->responseReceived = false;
                     this->mergedHostParents = false;
                     this->objMapIndex = objPathMap.begin();
+
+                    // After a power off , the remote notes will be deleted
+                    // from the entity association tree, making the nodes point
+                    // to junk values, so set them to nullptr
+                    for (const auto& element : this->objPathMap)
+                    {
+                        this->objPathMap[element.first] = nullptr;
+                    }
                 }
                 else if (propVal ==
                          "xyz.openbmc_project.State.Host.HostState.Running")

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1223,11 +1223,10 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records,
         uint32_t next_data_transfer_handle = 0;
         uint8_t transfer_flag = 0;
         size_t fru_record_table_length = 0;
-        std::vector<uint8_t> fru_record_table_data(respMsgLen -
-                                                   sizeof(pldm_msg_hdr));
+        std::vector<uint8_t> fru_record_table_data(respMsgLen);
         auto responsePtr = reinterpret_cast<const struct pldm_msg*>(response);
         auto rc = decode_get_fru_record_table_resp(
-            responsePtr, respMsgLen - sizeof(pldm_msg_hdr), &cc,
+            responsePtr, respMsgLen, &cc,
             &next_data_transfer_handle, &transfer_flag,
             fru_record_table_data.data(), &fru_record_table_length);
 

--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -112,6 +112,13 @@ void addObjectPathEntityAssociations(
             {
                 pldm::utils::DBusHandler().getService(entity_path.c_str(),
                                                       nullptr);
+                if (objPathMap.contains(entity_path))
+                {
+                    // if the object is from PLDM, them update/refresh the
+                    // object map as the map would be with junk values after a
+                    // power off
+                    objPathMap[entity_path] = entity;
+                }
             }
             catch (const std::exception& e)
             {
@@ -140,6 +147,12 @@ void addObjectPathEntityAssociations(
         try
         {
             pldm::utils::DBusHandler().getService(dbusPath.c_str(), nullptr);
+            if (objPathMap.contains(dbusPath))
+            {
+                // if the object is from PLDM, them update/refresh the object
+                // map as the map would be with junk values after a power off
+                objPathMap[dbusPath] = entity;
+            }
         }
         catch (const std::exception& e)
         {

--- a/libpldm/pdr.c
+++ b/libpldm/pdr.c
@@ -733,9 +733,12 @@ static inline uint16_t next_container_id(pldm_entity_association_tree *tree)
 
 pldm_entity pldm_entity_extract(pldm_entity_node *node)
 {
-	assert(node != NULL);
+	if (node != NULL) {
+		return node->entity;
+	}
 
-	return node->entity;
+	pldm_entity entity = {0, 0, 0};
+	return entity;
 }
 
 uint16_t pldm_extract_host_container_id(const pldm_entity_node *entity)


### PR DESCRIPTION
There is a bug in pldm where we reduce the fru record table twice , This is leading to the last few bytes being chopped
off at the end of the fru record table.

Fix : SW542325 