### PR TITLE
Fix the fru record table size

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1223,13 +1223,12 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records,
         uint32_t next_data_transfer_handle = 0;
         uint8_t transfer_flag = 0;
         size_t fru_record_table_length = 0;
-        std::vector<uint8_t> fru_record_table_data(respMsgLen -
-                                                   sizeof(pldm_msg_hdr));
+        std::vector<uint8_t> fru_record_table_data(respMsgLen);
         auto responsePtr = reinterpret_cast<const struct pldm_msg*>(response);
         auto rc = decode_get_fru_record_table_resp(
-            responsePtr, respMsgLen - sizeof(pldm_msg_hdr), &cc,
-            &next_data_transfer_handle, &transfer_flag,
-            fru_record_table_data.data(), &fru_record_table_length);
+            responsePtr, respMsgLen, &cc, &next_data_transfer_handle,
+            &transfer_flag, fru_record_table_data.data(),
+            &fru_record_table_length);
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {


### PR DESCRIPTION
There is a bug in pldm where we reduce the fru record table
twice , This is leading to the last few bytes being chopped
off at the end of the fru record table.

Fixes SW542325

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>