### PR TITLE
Host availability interface on cores & mex dbus objects

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -166,7 +166,7 @@ HostPDRHandler::HostPDRHandler(
                         }
                     }
 
-                    // when the host is powered off, set the present
+                    // when the host is powered off, set the availability
                     // state of all the dbus objects to false
                     this->setPresenceFrus();
                     pldm_pdr_remove_remote_pdrs(repo);
@@ -255,7 +255,7 @@ void HostPDRHandler::setPresenceFrus()
     // iterate over all dbus objects
     for (const auto& [path, entityId] : objPathMap)
     {
-        CustomDBus::getCustomDBus().updateItemPresentStatus(path, false);
+        CustomDBus::getCustomDBus().setAvailabilityState(path, false);
     }
 }
 
@@ -1542,6 +1542,11 @@ void HostPDRHandler::setPresentPropertyStatus(const std::string& path)
     CustomDBus::getCustomDBus().updateItemPresentStatus(path, true);
 }
 
+void HostPDRHandler::setAvailabilityState(const std::string& path)
+{
+    CustomDBus::getCustomDBus().setAvailabilityState(path, true);
+}
+
 void HostPDRHandler::createDbusObjects(const PDRList& fruRecordSetPDRs)
 {
     getFRURecordTableMetadataByHost(fruRecordSetPDRs);
@@ -1557,6 +1562,10 @@ void HostPDRHandler::createDbusObjects(const PDRList& fruRecordSetPDRs)
         pldm_entity node = pldm_entity_extract(entity.second);
         // update the Present Property
         setPresentPropertyStatus(entity.first);
+
+        // Implement & update the Availability to true
+        setAvailabilityState(entity.first);
+
         switch (node.entity_type)
         {
             case 32903:

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -302,6 +302,12 @@ class HostPDRHandler
      */
     void setPresentPropertyStatus(const std::string& path);
 
+    /** @brief Set the availabilty dbus Property
+     *  @param[in] path     - object path
+     *  @return
+     */
+    void setAvailabilityState(const std::string& path);
+
     /** @brief Update the Led Group path
      *  @param[in] path     - object path
      *  @return


### PR DESCRIPTION
When the host is off, the dbus objects for cores and mex
would be just a dummy and a user would be not able to do any
operation on those.

So, PLDM would host the Availability interface on all the
dbus object and set the availability to false when the host
is off, and set them back to true right after the PDR exchange.

There should be a corresponding change required in redfish
to look for the availability state and mark the redfish state
as Unavailable offline.

Fixes : SW542400 & partially fixes SW542325

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>