### PR TITLE
PLDM: fixes SW542086 and removes a trace line

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1186,7 +1186,6 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records,
 
     if (!total_table_records)
     {
-        std::cerr << "Failed to get fru record table." << std::endl;
         return;
     }
 

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -872,7 +872,7 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
         }
     };
     rc = handler->registerRequest(
-        mctp_eid, instanceId, PLDM_PLATFORM, PLDM_PDR_REPOSITORY_CHG_EVENT,
+        mctp_eid, instanceId, PLDM_PLATFORM, PLDM_PLATFORM_EVENT_MESSAGE,
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {


### PR DESCRIPTION
This fixes the Duplicate PLDM Record Handles sent
to the host on IOCM Fan Add.

This also removes a trace line in the code.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>