### PR TITLE
PLDM : Fix the record handles w.r.t the ranges

### DIFF
--- a/libpldm/meson.build
+++ b/libpldm/meson.build
@@ -30,13 +30,15 @@ if get_option('oem-ibm').enabled()
   headers += [
     '../oem/ibm/libpldm/file_io.h',
     '../oem/ibm/libpldm/host.h',
+    '../oem/ibm/libpldm/pdr_oem_ibm.h',
     '../oem/ibm/libpldm/platform_oem_ibm.h',
     '../oem/ibm/libpldm/state_set_oem_ibm.h'
   ]
   sources += [
     '../oem/ibm/libpldm/file_io.c',
     '../oem/ibm/libpldm/host.c',
-    '../oem/ibm/libpldm/platform_oem_ibm.c'
+    '../oem/ibm/libpldm/platform_oem_ibm.c',
+    '../oem/ibm/libpldm/pdr_oem_ibm.c'
   ]
   libpldm_headers += ['../oem/ibm']
 endif

--- a/libpldm/pdr.h
+++ b/libpldm/pdr.h
@@ -18,6 +18,13 @@ typedef struct pldm_pdr_record {
 	uint16_t terminus_handle;
 } pldm_pdr_record;
 
+typedef struct pldm_pdr {
+	uint32_t record_count;
+	uint32_t size;
+	pldm_pdr_record *first;
+	pldm_pdr_record *last;
+} pldm_pdr;
+
 /** @struct pldm_pdr
  *  opaque structure that acts as a handle to a PDR repository
  */
@@ -134,7 +141,6 @@ const pldm_pdr_record *pldm_pdr_find_record(const pldm_pdr *repo,
 					    uint8_t **data, uint32_t *size,
 					    uint32_t *next_record_handle);
 
-pldm_pdr_record *pldm_pdr_find_last_local_record(const pldm_pdr *repo);
 /** @brief Find the previous record handle of a PDR record
  *
  *  @param[in] repo - opaque pointer acting as a PDR repo handle
@@ -252,6 +258,7 @@ void pldm_change_container_id_of_effecter(const pldm_pdr *repo,
  *  @param[in] entity_instance_num - entity instance number of FRU
  *  @param[in] container_id - container id of FRU
  *  @param[in] bmc_record_handle - handle used to construct the next record
+ *  @param[in] hotplug - indicates if its a hotplug PDR or not
  *
  *  @return uint32_t - record handle assigned to PDR record
  */
@@ -259,7 +266,7 @@ uint32_t pldm_pdr_add_fru_record_set(pldm_pdr *repo, uint16_t terminus_handle,
 				     uint16_t fru_rsi, uint16_t entity_type,
 				     uint16_t entity_instance_num,
 				     uint16_t container_id,
-				     uint32_t bmc_record_handle);
+				     uint32_t bmc_record_handle, bool hotplug);
 
 /** @brief Find a FRU record set PDR by FRU record set identifier
  *

--- a/libpldm/tests/libpldm_pdr_test.cpp
+++ b/libpldm/tests/libpldm_pdr_test.cpp
@@ -438,7 +438,7 @@ TEST(PDRAccess, getPLDMEntityfromPDR)
     auto repo = pldm_pdr_init();
 
     // Test FRU Record set PDR
-    auto handle = pldm_pdr_add_fru_record_set(repo, 1, 10, 1, 0, 100, 0);
+    auto handle = pldm_pdr_add_fru_record_set(repo, 1, 10, 1, 0, 100, 0, false);
     auto entity = pldm_get_entity_from_record_handle(repo, handle);
     EXPECT_EQ(entity.entity_type, htole16(1));
     EXPECT_EQ(entity.entity_instance_num, htole16(0));
@@ -495,7 +495,7 @@ TEST(PDRUpdate, testAddFruRecordSet)
 {
     auto repo = pldm_pdr_init();
 
-    auto handle = pldm_pdr_add_fru_record_set(repo, 1, 10, 1, 0, 100, 0);
+    auto handle = pldm_pdr_add_fru_record_set(repo, 1, 10, 1, 0, 100, 0, false);
     EXPECT_EQ(handle, 1u);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo),
@@ -521,7 +521,7 @@ TEST(PDRUpdate, testAddFruRecordSet)
     EXPECT_EQ(fru->container_id, htole16(100));
     outData = nullptr;
 
-    handle = pldm_pdr_add_fru_record_set(repo, 2, 11, 2, 1, 101, 0);
+    handle = pldm_pdr_add_fru_record_set(repo, 2, 11, 2, 1, 101, 0, false);
     EXPECT_EQ(handle, 2u);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo),
@@ -573,9 +573,9 @@ TEST(PDRUpdate, tesFindtFruRecordSet)
     uint16_t entityType{};
     uint16_t entityInstanceNum{};
     uint16_t containerId{};
-    auto first = pldm_pdr_add_fru_record_set(repo, 1, 1, 1, 0, 100, 1);
-    auto second = pldm_pdr_add_fru_record_set(repo, 1, 2, 1, 1, 100, 2);
-    auto third = pldm_pdr_add_fru_record_set(repo, 1, 3, 1, 2, 100, 3);
+    auto first = pldm_pdr_add_fru_record_set(repo, 1, 1, 1, 0, 100, 1, false);
+    auto second = pldm_pdr_add_fru_record_set(repo, 1, 2, 1, 1, 100, 2, false);
+    auto third = pldm_pdr_add_fru_record_set(repo, 1, 3, 1, 2, 100, 3, false);
     EXPECT_EQ(first, pldm_pdr_get_record_handle(
                          repo, pldm_pdr_fru_record_set_find_by_rsi(
                                    repo, 1, &terminusHdl, &entityType,
@@ -1538,7 +1538,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
                                                false, true);
     auto first = pldm_pdr_add_fru_record_set(
         repo, 1, 1, entities[1].entity_type, entities[1].entity_instance_num,
-        entities[1].entity_container_id, 1);
+        entities[1].entity_container_id, 1, false);
     EXPECT_NE(l1, nullptr);
     EXPECT_EQ(entities[1].entity_instance_num, 63);
     EXPECT_EQ(first, pldm_pdr_get_record_handle(
@@ -1553,7 +1553,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
                                                false, true);
     auto second = pldm_pdr_add_fru_record_set(
         repo, 1, 2, entities[2].entity_type, entities[2].entity_instance_num,
-        entities[2].entity_container_id, 2);
+        entities[2].entity_container_id, 2, false);
     EXPECT_NE(l2, nullptr);
     EXPECT_EQ(entities[2].entity_instance_num, 37);
     EXPECT_EQ(second, pldm_pdr_get_record_handle(
@@ -1568,7 +1568,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
                                                false, true);
     auto third = pldm_pdr_add_fru_record_set(
         repo, 1, 3, entities[3].entity_type, entities[3].entity_instance_num,
-        entities[3].entity_container_id, 3);
+        entities[3].entity_container_id, 3, false);
     EXPECT_NE(l3, nullptr);
     EXPECT_EQ(entities[3].entity_instance_num, 44);
     EXPECT_EQ(third, pldm_pdr_get_record_handle(
@@ -1583,7 +1583,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
                                                false, true);
     auto fourth = pldm_pdr_add_fru_record_set(
         repo, 1, 4, entities[4].entity_type, entities[4].entity_instance_num,
-        entities[4].entity_container_id, 4);
+        entities[4].entity_container_id, 4, false);
     EXPECT_NE(l4, nullptr);
     EXPECT_EQ(entities[4].entity_instance_num, 89);
     EXPECT_EQ(fourth, pldm_pdr_get_record_handle(
@@ -1598,7 +1598,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
                                                false, true);
     auto fifth = pldm_pdr_add_fru_record_set(
         repo, 1, 5, entities[5].entity_type, entities[5].entity_instance_num,
-        entities[5].entity_container_id, 5);
+        entities[5].entity_container_id, 5, false);
     EXPECT_NE(l5, nullptr);
     EXPECT_EQ(entities[5].entity_instance_num, 90);
     EXPECT_EQ(fifth, pldm_pdr_get_record_handle(
@@ -1618,7 +1618,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
                                                false, true);
     auto seventh = pldm_pdr_add_fru_record_set(
         repo, 1, 7, entities[7].entity_type, entities[7].entity_instance_num,
-        entities[7].entity_container_id, 7);
+        entities[7].entity_container_id, 7, false);
     EXPECT_NE(l7, nullptr);
     EXPECT_EQ(entities[7].entity_instance_num, 100);
     EXPECT_EQ(seventh, pldm_pdr_get_record_handle(
@@ -1633,7 +1633,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
                                                false, true);
     auto eighth = pldm_pdr_add_fru_record_set(
         repo, 1, 8, entities[8].entity_type, entities[8].entity_instance_num,
-        entities[8].entity_container_id, 8);
+        entities[8].entity_container_id, 8, false);
     EXPECT_NE(l8, nullptr);
     EXPECT_EQ(entities[8].entity_instance_num, 100);
     EXPECT_EQ(eighth, pldm_pdr_get_record_handle(

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -6,6 +6,8 @@
 #include "common/utils.hpp"
 #include "pdr.hpp"
 #ifdef OEM_IBM
+#include "oem/ibm/libpldm/pdr_oem_ibm.h"
+
 #include "oem/ibm/libpldmresponder/utils.hpp"
 #endif
 
@@ -333,12 +335,23 @@ uint32_t FruImpl::populateRecords(
             if (numRecs == numRecsCount)
             {
                 recordSetIdentifier = nextRSI();
-                // bmc_record_handle = concurrentAdd ? 0 : nextRecordHandle();
-                bmc_record_handle = concurrentAdd ? 0xFFFF : nextRecordHandle();
+                if (concurrentAdd)
+                {
+#ifdef OEM_IBM
+                    auto lastLocalRecord =
+                        pldm_pdr_find_last_local_record(pdrRepo);
+                    bmc_record_handle = (lastLocalRecord->record_handle) + 1;
+#endif
+                }
+                else
+                {
+                    bmc_record_handle = nextRecordHandle();
+                }
                 newRcord = pldm_pdr_add_fru_record_set(
                     pdrRepo, TERMINUS_HANDLE, recordSetIdentifier,
                     entity.entity_type, entity.entity_instance_num,
-                    entity.entity_container_id, bmc_record_handle);
+                    entity.entity_container_id, bmc_record_handle,
+                    concurrentAdd);
                 objectPathToRSIMap[objectPath] = recordSetIdentifier;
             }
             auto curSize = table.size();
@@ -1256,8 +1269,11 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
 uint32_t
     FruImpl::addHotPlugRecord(pldm::responder::pdr_utils::PdrEntry pdrEntry)
 {
+    uint32_t lastHandle = 0;
+#ifdef OEM_IBM
     auto lastLocalRecord = pldm_pdr_find_last_local_record(pdrRepo);
-    auto lastHandle = lastLocalRecord->record_handle;
+    lastHandle = lastLocalRecord->record_handle;
+#endif
     pdrEntry.handle.recordHandle = lastHandle + 1;
     return pldm_pdr_add_hotplug_record(pdrRepo, pdrEntry.data, pdrEntry.size,
                                        pdrEntry.handle.recordHandle, false,

--- a/oem/ibm/libpldm/pdr_oem_ibm.c
+++ b/oem/ibm/libpldm/pdr_oem_ibm.c
@@ -1,0 +1,23 @@
+#include "pdr_oem_ibm.h"
+#include "pdr.h"
+
+pldm_pdr_record *pldm_pdr_find_last_local_record(const pldm_pdr *repo)
+{
+	assert(repo != NULL);
+	pldm_pdr_record *curr = repo->first;
+	pldm_pdr_record *prev = repo->first;
+
+	while (curr != NULL) {
+		if (curr->record_handle > 0x00000000 &&
+		    curr->record_handle < 0x00FFFFFF &&
+		    curr->next->record_handle > 0x00FFFFFF) {
+			return curr;
+		}
+		prev = curr;
+		curr = curr->next;
+	}
+	if (curr == NULL) {
+		return prev;
+	}
+	return NULL;
+}

--- a/oem/ibm/libpldm/pdr_oem_ibm.h
+++ b/oem/ibm/libpldm/pdr_oem_ibm.h
@@ -1,0 +1,26 @@
+#ifndef PDR_OEM_IBM_H
+#define PDR_OEM_IBM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "pdr.h"
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** @brief Find the last local record
+ *
+ *  @param[in] repo - opaque pointer acting as a PDR repo handle
+ *
+ *  @return opaque pointer to the PDR record,will be NULL if record was not
+ * found
+ */
+pldm_pdr_record *pldm_pdr_find_last_local_record(const pldm_pdr *repo);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PDR_OEM_IBM_H */


### PR DESCRIPTION
The record handles of the PDRs were messed up during the
normal poweron and a CM operation. This commit fixes
the record handles.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>