### PR TITLE
OEM-IBM: PDR: Add Real SAI sensor and effecter Support

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -2,6 +2,7 @@
 
 #include "libpldm/entity.h"
 #include "libpldm/requester/pldm.h"
+#include "libpldm/state_set.h"
 
 #include "collect_slot_vpd.hpp"
 #include "file_io_type_lid.hpp"
@@ -64,10 +65,13 @@ int pldm::responder::oem_ibm_platform::Handler::
     for (size_t i = 0; i < compSensorCnt; i++)
     {
         uint8_t sensorOpState{};
+        uint8_t realSAIState{};
         if (entityType == PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE &&
             stateSetId == PLDM_OEM_IBM_BOOT_STATE)
         {
             sensorOpState = fetchBootSide(entityInstance, codeUpdate);
+            stateField.push_back({PLDM_SENSOR_ENABLED, PLDM_SENSOR_UNKNOWN,
+                                  PLDM_SENSOR_UNKNOWN, sensorOpState});
         }
         else if (entityType == PLDM_ENTITY_SLOT &&
                  stateSetId == PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE)
@@ -82,6 +86,13 @@ int pldm::responder::oem_ibm_platform::Handler::
                     break;
                 }
             }
+        }
+        else if (entityType == PLDM_OEM_IBM_ENTITY_REAL_SAI &&
+                 stateSetId == PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS)
+        {
+            realSAIState = fetchRealSAIStatus();
+            stateField.push_back({PLDM_SENSOR_ENABLED, PLDM_SENSOR_NORMAL,
+                                  PLDM_SENSOR_UNKNOWN, realSAIState});
         }
         else
         {
@@ -193,6 +204,11 @@ int pldm::responder::oem_ibm_platform::Handler::
                 {
                     codeUpdate->processRenameEvent();
                 }
+            }
+            else if (entityType == PLDM_OEM_IBM_ENTITY_REAL_SAI &&
+                     stateSetId == PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS)
+            {
+                turnOffRealSAIEffecter();
             }
             else
             {
@@ -612,6 +628,99 @@ std::filesystem::path pldm::responder::oem_ibm_platform::Handler::getConfigDir()
     return fs::path();
 }
 
+void buildAllRealSAIEffecterPDR(oem_ibm_platform::Handler* platformHandler,
+                                uint16_t entityType, uint16_t entityInstance,
+                                pdr_utils::Repo& repo)
+
+{
+    size_t pdrSize = 0;
+    pdrSize = sizeof(pldm_state_effecter_pdr) +
+              sizeof(state_effecter_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_effecter_pdr* pdr =
+        reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
+    if (!pdr)
+    {
+        std::cerr << "Failed to get record by PDR type, ERROR:"
+                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        return;
+    }
+    pdr->hdr.record_handle = 0;
+    pdr->hdr.version = 1;
+    pdr->hdr.type = PLDM_STATE_EFFECTER_PDR;
+    pdr->hdr.record_change_num = 0;
+    pdr->hdr.length = sizeof(pldm_state_effecter_pdr) - sizeof(pldm_pdr_hdr);
+    pdr->terminus_handle = TERMINUS_HANDLE;
+    pdr->effecter_id = platformHandler->getNextEffecterId();
+    pdr->entity_type = entityType;
+    pdr->entity_instance = entityInstance;
+    pdr->container_id = 1;
+    pdr->effecter_semantic_id = 0;
+    pdr->effecter_init = PLDM_NO_INIT;
+    pdr->has_description_pdr = false;
+    pdr->composite_effecter_count = 1;
+
+    auto* possibleStatesPtr = pdr->possible_states;
+    auto possibleStates =
+        reinterpret_cast<state_effecter_possible_states*>(possibleStatesPtr);
+    possibleStates->state_set_id = 10;
+    possibleStates->possible_states_size = 1;
+    auto state =
+        reinterpret_cast<state_effecter_possible_states*>(possibleStates);
+    state->states[0].byte = 2;
+    pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+    pdrEntry.data = entry.data();
+    pdrEntry.size = pdrSize;
+    repo.addRecord(pdrEntry);
+}
+
+void buildAllRealSAISensorPDR(oem_ibm_platform::Handler* platformHandler,
+                              uint16_t entityType, uint16_t entityInstance,
+                              pdr_utils::Repo& repo)
+
+{
+    size_t pdrSize = 0;
+    pdrSize =
+        sizeof(pldm_state_sensor_pdr) + sizeof(state_sensor_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_sensor_pdr* pdr =
+        reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
+    if (!pdr)
+    {
+        std::cerr << "Failed to get record by PDR type, ERROR:"
+                  << PLDM_PLATFORM_INVALID_SENSOR_ID << std::endl;
+        return;
+    }
+    pdr->hdr.record_handle = 0;
+    pdr->hdr.version = 1;
+    pdr->hdr.type = PLDM_STATE_SENSOR_PDR;
+    pdr->hdr.record_change_num = 0;
+    pdr->hdr.length = sizeof(pldm_state_sensor_pdr) - sizeof(pldm_pdr_hdr);
+    pdr->terminus_handle = TERMINUS_HANDLE;
+    pdr->sensor_id = platformHandler->getNextSensorId();
+    pdr->entity_type = entityType;
+    pdr->entity_instance = entityInstance;
+    pdr->container_id = 1;
+    pdr->sensor_init = PLDM_NO_INIT;
+    pdr->sensor_auxiliary_names_pdr = false;
+    pdr->composite_sensor_count = 1;
+
+    auto* possibleStatesPtr = pdr->possible_states;
+    auto possibleStates =
+        reinterpret_cast<state_sensor_possible_states*>(possibleStatesPtr);
+    possibleStates->state_set_id = 10;
+    possibleStates->possible_states_size = 2;
+    auto state =
+        reinterpret_cast<state_sensor_possible_states*>(possibleStates);
+    state->states[0].byte = 6;
+    pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+    pdrEntry.data = entry.data();
+    pdrEntry.size = pdrSize;
+    repo.addRecord(pdrEntry);
+}
+
 void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     pdr_utils::Repo& repo)
 {
@@ -624,6 +733,11 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
 
     buildAllSlotEnabeEffecterPDR(this, repo, getslotPaths());
     buildAllSlotEnableSensorPDR(this, repo, getslotPaths());
+
+    buildAllRealSAIEffecterPDR(this, PLDM_OEM_IBM_ENTITY_REAL_SAI,
+                               ENTITY_INSTANCE_1, repo);
+    buildAllRealSAISensorPDR(this, PLDM_OEM_IBM_ENTITY_REAL_SAI,
+                             ENTITY_INSTANCE_1, repo);
 
     buildAllCodeUpdateEffecterPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
                                   ENTITY_INSTANCE_0,
@@ -645,6 +759,10 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     attachOemEntityToEntityAssociationPDR(
         this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,
         fwUpEntity);
+    pldm_entity saiEntity = {PLDM_OEM_IBM_ENTITY_REAL_SAI, 1, 1};
+    attachOemEntityToEntityAssociationPDR(
+        this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,
+        saiEntity);
 
     auto sensorId = findStateSensorId(
         repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
@@ -1227,7 +1345,8 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtPowerOn()
         }
         catch (const std::exception& e)
         {
-            return;
+            std::cerr << "Failed to fetch the restartCause, ERROR=" << e.what()
+                      << "\n";
         }
     }
 }
@@ -1299,6 +1418,65 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtChassisOff()
         biosAttrList.push_back(std::make_pair("pvm_boot_type", "IPL"));
         setBiosAttr(biosAttrList);
     }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::turnOffRealSAIEffecter()
+{
+    try
+    {
+        pldm::utils::DBusMapping dbuspartitionMapping{
+            "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group", "Asserted", "bool"};
+        pldm::utils::DBusHandler().setDbusProperty(dbuspartitionMapping, false);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to turn off partition SAI effecter"
+                  << "ERROR=" << e.what() << "\n";
+    }
+    try
+    {
+        pldm::utils::DBusMapping dbusplatformMapping{
+            "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group", "Asserted", "bool"};
+        pldm::utils::DBusHandler().setDbusProperty(dbusplatformMapping, false);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to turn off platform SAI effecter"
+                  << "ERROR=" << e.what() << "\n";
+    }
+}
+
+uint8_t pldm::responder::oem_ibm_platform::Handler::fetchRealSAIStatus()
+{
+    static constexpr auto partitionSAIObjectPath =
+        "/xyz/openbmc_project/led/groups/partition_system_attention_indicator";
+    static constexpr auto platformSAIObjectPath =
+        "/xyz/openbmc_project/led/groups/platform_system_attention_indicator";
+    static constexpr auto saiInterface = "xyz.openbmc_project.Led.Group";
+    static constexpr auto saiPropertyName = "Asserted";
+    uint8_t isPartitionSAIOn = 0;
+    uint8_t isPlatformSAIOn = 0;
+
+    try
+    {
+        isPartitionSAIOn = pldm::utils::DBusHandler().getDbusProperty<bool>(
+            partitionSAIObjectPath, saiPropertyName, saiInterface);
+        isPlatformSAIOn = pldm::utils::DBusHandler().getDbusProperty<bool>(
+            platformSAIObjectPath, saiPropertyName, saiInterface);
+
+        if (isPartitionSAIOn || isPlatformSAIOn)
+        {
+            return PLDM_SENSOR_WARNING;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to fetch Real SAI sensor status"
+                  << "ERROR=" << e.what() << "\n";
+    }
+    return PLDM_SENSOR_NORMAL;
 }
 
 } // namespace oem_ibm_platform

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -43,6 +43,8 @@ using PendingObj = std::tuple<AttributeType, CurrentValue>;
 using PendingAttributes = std::map<AttributeName, PendingObj>;
 static constexpr auto PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577;
 static constexpr auto PLDM_OEM_IBM_FRONT_PANEL_TRIGGER = 32837;
+static constexpr auto PLDM_OEM_IBM_ENTITY_REAL_SAI = 24578;
+
 constexpr uint16_t ENTITY_INSTANCE_0 = 0;
 constexpr uint16_t ENTITY_INSTANCE_1 = 1;
 
@@ -391,6 +393,16 @@ class Handler : public oem_platform::Handler
 
     /** @brief To handle the boot types bios attributes at shutdown*/
     void handleBootTypesAtChassisOff();
+
+    /** @brief To turn off Real SAI effecter*/
+    void turnOffRealSAIEffecter();
+
+    /** @brief Fetch Real SAI status based on the partition SAI and platform SAI
+     *  sensor state. Real SAI is turned on if any of the partition or platform
+     *  SAI turned on else Real SAI is turned off.
+     *  @return Real SAI sensor state PLDM_SENSOR_WARNING/PLDM_SENSOR_NORMAL
+     */
+    uint8_t fetchRealSAIStatus();
 
     ~Handler() = default;
 

--- a/pldmtool/oem/ibm/oem_ibm_state_set.hpp
+++ b/pldmtool/oem/ibm/oem_ibm_state_set.hpp
@@ -55,6 +55,8 @@ extern const std::map<uint8_t, std::string> OemIBMEntityType{
      "OEM IBM Firmware Update"},
     {PLDM_OEM_ENTITY_TYPE_START, "OEM IBM Entity Type Start"},
     {PLDM_OEM_ENTITY_TYPE_END, "OEM IBM Entity Type End"},
+    {pldm::responder::oem_ibm_platform::PLDM_OEM_IBM_ENTITY_REAL_SAI,
+     "OEM IBM Real SAI"},
 };
 
 /** @brief Map for PLDM OEM IBM State Sets


### PR DESCRIPTION
Signed-off-by: Sridevi Ramesh <sridevra@in.ibm.com>



Real SAI effecter
================

{
    "nextRecordHandle": 138,
    "responseCount": 30,
    "recordHandle": 137,
    "PDRHeaderVersion": 1,
    "PDRType": "State Effecter PDR",
    "recordChangeNumber": 0,
    "dataLength": 16,
    "PLDMTerminusHandle": 1,
    "effecterID": 24,
    "entityType": "[Physical] OEM IBM Real SAI(OEM)",
    "entityInstanceNumber": 1,
    "containerID": 1,
    "effecterSemanticID": 0,
    "effecterInit": "noInit",
    "effecterDescriptionPDR": false,
    "compositeEffecterCount": 1,
    "stateSetID[0]": "Operational Fault Status(10)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Normal(1)"
    ]
}

Real SAI sensor
===============

{
    "nextRecordHandle": 139,
    "responseCount": 28,
    "recordHandle": 138,
    "PDRHeaderVersion": 1,
    "PDRType": "State Sensor PDR",
    "recordChangeNumber": 0,
    "dataLength": 14,
    "PLDMTerminusHandle": 1,
    "sensorID": 22,
    "entityType": "[Physical] OEM IBM Real SAI(OEM)",
    "entityInstanceNumber": 1,
    "containerID": 1,
    "sensorInit": "noInit",
    "sensorAuxiliaryNamesPDR": false,
    "compositeSensorCount": 1,
    "stateSetID[0]": "Operational Fault Status(10)",
    "possibleStatesSize[0]": 2,
    "possibleStates[0]": [
        "Normal(1)",
        "Stressed(2)"
    ]
}

Entity association PDR
======================

{
    "nextRecordHandle": 77,
    "responseCount": 56,
    "recordHandle": 76,
    "PDRHeaderVersion": 1,
    "PDRType": "Entity Association PDR",
    "recordChangeNumber": 0,
    "dataLength": 46,
    "containerID": 1,
    "associationType": "Physical",
    "containerEntityType": "[Physical] System (Logical)",
    "containerEntityInstanceNumber": 1,
    "containerEntityContainerID": 0,
    "containedEntityCount": 6,
    "containedEntityType[1]": "[Physical] System chassis (main enclosure)",
    "containedEntityInstanceNumber[1]": 1,
    "containedEntityContainerID[1]": 1,
    "containedEntityType[2]": "[Physical] OEM IBM Firmware Update(OEM)",
    "containedEntityInstanceNumber[2]": 1,
    "containedEntityContainerID[2]": 1,
    "containedEntityType[3]": "[Physical] OEM IBM Real SAI(OEM)",
    "containedEntityInstanceNumber[3]": 1,
    "containedEntityContainerID[3]": 1,
    "containedEntityType[4]": "[Physical] Battery",
    "containedEntityInstanceNumber[4]": 1,
    "containedEntityContainerID[4]": 1,
    "containedEntityType[5]": "[Physical] Indicator",
    "containedEntityInstanceNumber[5]": 1,
    "containedEntityContainerID[5]": 1,
    "containedEntityType[6]": "[Physical] Indicator",
    "containedEntityInstanceNumber[6]": 2,
    "containedEntityContainerID[6]": 1
}


Verify Real Sensor and effecter
==============================

 /tmp/pldmtool platform GetStateSensorReadings -i 22 -r 0
{
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Normal"
}
 busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/platform_system_attention_indicator xyz.openbmc_project.Led.Group Asserted b true

/tmp/pldmtool platform GetStateSensorReadings -i 22 -r 0                                                            {
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Warning"
}

 /tmp/pldmtool platform SetStateEffecterStates -i 24 -c 1 -d 1 1
{
    "Response": "SUCCESS"
}
/tmp/pldmtool platform GetStateSensorReadings -i 22 -r 0
{
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Normal"
