### PR TITLE
Add notimeout option for pldmsoftoff

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -569,21 +569,6 @@ std::string toString(const struct variable_field& var)
     return str;
 }
 
-const std::string getCurrentSystemTime()
-{
-    struct timeval tpend;
-    gettimeofday(&tpend, NULL);
-
-    int secofday = (tpend.tv_sec + 3600 * 8) % 86400;
-    int hours = secofday / 3600;
-    int minutes = (secofday - hours * 3600) / 60;
-    int seconds = secofday % 60;
-    int milliseconds = tpend.tv_usec / 1000;
-    char buf[40];
-    sprintf(buf, "%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
-    return buf;
-}
-
 std::vector<std::string> split(std::string_view srcStr, std::string_view delim,
                                std::string_view trimStr)
 {
@@ -681,6 +666,19 @@ void setBiosAttr(const BiosAttributeList& biosAttrList)
             return;
         }
     }
+}
+std::string getCurrentSystemTime()
+{
+    using namespace std::chrono;
+    const time_point<system_clock> tp = system_clock::now();
+    std::time_t tt = system_clock::to_time_t(tp);
+    auto ms = duration_cast<microseconds>(tp.time_since_epoch()) -
+              duration_cast<seconds>(tp.time_since_epoch());
+
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&tt), "%F %Z %T.")
+       << std::to_string(ms.count());
+    return ss.str();
 }
 
 } // namespace utils

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -377,12 +377,6 @@ void printBuffer(bool isTx, const std::vector<uint8_t>& buffer);
  */
 std::string toString(const struct variable_field& var);
 
-/** @brief Get the current system time in readable format
- *
- *  @return - std::string equivalent of the system time
- */
-const std::string getCurrentSystemTime();
-
 /** @brief Split strings according to special identifiers
  *
  *  We can split the string according to the custom identifier(';', ',', '&' or
@@ -396,6 +390,11 @@ const std::string getCurrentSystemTime();
  */
 std::vector<std::string> split(std::string_view srcStr, std::string_view delim,
                                std::string_view trimStr = "");
+/** @brief Get the current system time in readable format
+ *
+ *  @return - std::string equivalent of the system time
+ */
+std::string getCurrentSystemTime();
 
 /** @brief Method to get the value from a bios attribute
  *

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ conf_data.set('PLDM_VERBOSITY',get_option('verbosity'))
 conf_data.set('NUMBER_OF_REQUEST_RETRIES', get_option('number-of-request-retries'))
 conf_data.set('INSTANCE_ID_EXPIRATION_INTERVAL',get_option('instance-id-expiration-interval'))
 conf_data.set('RESPONSE_TIME_OUT',get_option('response-time-out'))
-conf_data.set('FLIGHT_RECORDER_MAX_SIZE',get_option('flightrecorder-size'))
+conf_data.set('FLIGHT_RECORDER_MAX_ENTRIES',get_option('flightrecorder-max-entries'))
 if get_option('libpldm-only').disabled()
   conf_data.set_quoted('HOST_EID_PATH', join_paths(package_datadir, 'host_eid'))
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,4 +26,4 @@ option('terminus-id', type:'integer', min:0, max: 255, description: 'The terminu
 option('terminus-handle',type:'integer',min:0, max:65535, description: 'The terminus handle value of the device that is running this pldm stack', value:1)
 
 # Flight Recorder for PLDM Daemon
-option('flightrecorder-size', type:'integer',min:1, max:30, description: 'The max number of pldm messages that can be stored in the recorder', value: 10)
+option('flightrecorder-max-entries', type:'integer',min:0, max:30, description: 'The max number of pldm messages that can be stored in the recorder, this feature will be disabled if it is set to 0', value: 10)

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -461,7 +461,8 @@ int main(int argc, char** argv)
 #endif
 
     stdplus::signal::block(SIGUSR1);
-    Signal(event, SIGUSR1, interruptFlightRecorderCallBack).set_floating(true);
+    sdeventplus::source::Signal sigUsr1(
+        event, SIGUSR1, std::bind_front(&interruptFlightRecorderCallBack));
     returnCode = event.loop();
     if (shutdown(sockfd, SHUT_RDWR))
     {

--- a/requester/request.hpp
+++ b/requester/request.hpp
@@ -176,8 +176,7 @@ class Request final : public RequestRetryTimer
         {
             pldm::utils::printBuffer(pldm::utils::Tx, requestMsg);
         }
-        pldm::flightrecorder::FlightRecorder::GetInstance().saveRecord(
-            requestMsg, true);
+
         if (currentSendbuffSize >= 0 &&
             (size_t)currentSendbuffSize < requestMsg.size())
         {
@@ -189,6 +188,8 @@ class Request final : public RequestRetryTimer
                 std::cerr << "Requester : Error calling setsockopt. RC = "
                           << res << ", errno = " << errno << std::endl;
         }
+        pldm::flightrecorder::FlightRecorder::GetInstance().saveRecord(
+            requestMsg, true);
         auto rc = pldm_send(eid, fd, requestMsg.data(), requestMsg.size());
         if (rc < 0)
         {

--- a/softoff/main.cpp
+++ b/softoff/main.cpp
@@ -1,10 +1,30 @@
 #include "common/utils.hpp"
 #include "softoff.hpp"
 
+#include <getopt.h>
+
 #include <iostream>
 
-int main()
+int main(int argc, char* argv[])
 {
+
+    bool noTimeOut = false;
+    static struct option long_options[] = {{"notimeout", no_argument, 0, 't'},
+                                           {0, 0, 0, 0}};
+
+    auto argflag = getopt_long(argc, argv, "t", long_options, nullptr);
+    switch (argflag)
+    {
+        case 't':
+            noTimeOut = true;
+            std::cout << "Not applying any time outs\n";
+            break;
+        case -1:
+            break;
+        default:
+            exit(EXIT_FAILURE);
+    }
+
     // Get a default event loop
     auto event = sdeventplus::Event::get_default();
 
@@ -14,7 +34,7 @@ int main()
     // Attach the bus to sd_event to service user requests
     bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
 
-    pldm::SoftPowerOff softPower(bus, event.get());
+    pldm::SoftPowerOff softPower(bus, event.get(), noTimeOut);
 
     if (softPower.isError())
     {

--- a/softoff/meson.build
+++ b/softoff/meson.build
@@ -20,5 +20,11 @@ if get_option('systemd').enabled()
                    output: 'pldmSoftPowerOff.service',
                    copy: true,
                    install_dir: systemd_system_unit_dir)
+  configure_file(
+    input: 'softoff',
+    output: 'softoff',
+    copy: true,
+    install: true,
+    install_dir: join_paths(get_option('sysconfdir'), 'default'))
 endif
 

--- a/softoff/services/pldmSoftPowerOff.service
+++ b/softoff/services/pldmSoftPowerOff.service
@@ -8,5 +8,7 @@ Conflicts=obmc-host-start@0.target
 
 [Service]
 Restart=no
-ExecStart=/usr/bin/pldm-softpoweroff
+Environment=SOFTOFF_ARGS=null
+EnvironmentFile=-/etc/default/softoff
+ExecStart=/usr/bin/pldm-softpoweroff $SOFTOFF_ARGS
 Type=oneshot

--- a/softoff/softoff
+++ b/softoff/softoff
@@ -1,0 +1,1 @@
+SOFTOFF_ARGS=null

--- a/softoff/softoff.hpp
+++ b/softoff/softoff.hpp
@@ -23,8 +23,10 @@ class SoftPowerOff
      *
      *  @param[in] bus       - system D-Bus handler
      *  @param[in] event     - sd_event handler
+     *  @param[in] noTimeOut - bool variable that captures
+     *                         is there is indeed a timeout
      */
-    SoftPowerOff(sdbusplus::bus::bus& bus, sd_event* event);
+    SoftPowerOff(sdbusplus::bus::bus& bus, sd_event* event, bool noTimeOut);
 
     /** @brief Is the pldm-softpoweroff has error.
      * if hasError is true, that means the pldm-softpoweroff failed to
@@ -39,6 +41,10 @@ class SoftPowerOff
      */
     inline bool isTimerExpired()
     {
+        if (noTimeOut)
+        {
+            return false;
+        }
         return timer.isExpired();
     }
 
@@ -137,6 +143,10 @@ class SoftPowerOff
 
     /** @brief Reference to Timer object */
     phosphor::Timer timer;
+
+    /** @brief captures if the is a timeout value
+     */
+    bool noTimeOut;
 
     /** @brief Used to subscribe to dbus pldm StateSensorEvent signal
      * When the host soft off is complete, it sends an platform event message


### PR DESCRIPTION
This PR consists of 2 changes :
1. flight recorder upstream changes 
2. --notimeout option for the pldmsoftoff app

softoff testing :

without timeouts:
==============
root@rain118bmc:~# ./pldm-softpoweroff --notimeout
Not applying any time outs
Tx: 80 02 39 03 00 01 01 06
Got the response for set effecter states command, PLDM RC = 0
Rx: 00 02 39 00
Recieved the graceful shutdown signal from host

With timeouts:
=============
root@rain118bmc:~#obmcutil poweroff
Feb 17 14:43:35 rain118bmc systemd[1]: Starting PLDM soft power off app...
Feb 17 14:43:35 rain118bmc pldm-softpoweroff[4056]: Tx: 80 02 39 03 00 01 01 05
Feb 17 14:43:35 rain118bmc pldm-softpoweroff[4056]: Got the response for set effecter states command, PLDM RC = 0
Feb 17 14:43:35 rain118bmc pldm-softpoweroff[4056]: Timer started waiting for host soft off, TIMEOUT_IN_SEC = 0x1c20
Feb 17 14:43:52 rain118bmc pldm-softpoweroff[4056]: Recieved the graceful shutdown signal from host
Feb 17 14:43:52 rain118bmc systemd[1]: pldmSoftPowerOff.service: Deactivated successfully.
Feb 17 14:43:52 rain118bmc systemd[1]: Finished PLDM soft power off app.