### PR TITLE
Fix for the container ID incorrect for processor indicator sensors/ef…

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -872,6 +872,7 @@ void HostPDRHandler::_processPDRRepoChgEvent(
     if (oemPlatformHandler != nullptr)
     {
         oemPlatformHandler->updateContainerID();
+        oemPlatformHandler->updateContainerIDofProcLed();
     }
     deferredPDRRepoChgEvent.reset();
     this->sendPDRRepositoryChgEvent(

--- a/libpldm/pdr.c
+++ b/libpldm/pdr.c
@@ -700,6 +700,82 @@ void pldm_change_container_id_of_effecter(const pldm_pdr *repo,
 				pdr->container_id = containerId;
 				break;
 			}
+		} else if (hdr->type == PLDM_STATE_EFFECTER_PDR) {
+			struct pldm_state_effecter_pdr *pdr =
+			    (struct pldm_state_effecter_pdr *)((uint8_t *)record
+								   ->data);
+			if (pdr->effecter_id == effecterId) {
+				pdr->container_id = containerId;
+				break;
+			}
+		}
+		record = record->next;
+	}
+}
+
+void pldm_change_container_id_of_sensor(const pldm_pdr *repo, uint16_t sensorId,
+					uint16_t containerId)
+{
+	assert(repo != NULL);
+
+	pldm_pdr_record *record = repo->first;
+
+	while (record != NULL) {
+		struct pldm_pdr_hdr *hdr = (struct pldm_pdr_hdr *)record->data;
+		if (hdr->type == PLDM_STATE_SENSOR_PDR) {
+			struct pldm_state_sensor_pdr *pdr =
+			    (struct pldm_state_sensor_pdr *)((uint8_t *)
+								 record->data);
+			if (pdr->sensor_id == sensorId) {
+				pdr->container_id = containerId;
+				break;
+			}
+		}
+		record = record->next;
+	}
+}
+
+void pldm_change_instance_number_of_effecter(const pldm_pdr *repo,
+					     uint16_t effecterId,
+					     uint16_t instanceNumber)
+{
+	assert(repo != NULL);
+
+	pldm_pdr_record *record = repo->first;
+
+	while (record != NULL) {
+		struct pldm_pdr_hdr *hdr = (struct pldm_pdr_hdr *)record->data;
+		if (hdr->type == PLDM_STATE_EFFECTER_PDR) {
+			struct pldm_state_effecter_pdr *pdr =
+			    (struct pldm_state_effecter_pdr *)((uint8_t *)record
+								   ->data);
+			if (pdr->effecter_id == effecterId) {
+				pdr->entity_instance = instanceNumber;
+				break;
+			}
+		}
+		record = record->next;
+	}
+}
+
+void pldm_change_instance_number_of_sensor(const pldm_pdr *repo,
+					   uint16_t sensorId,
+					   uint16_t instanceNumber)
+{
+	assert(repo != NULL);
+
+	pldm_pdr_record *record = repo->first;
+
+	while (record != NULL) {
+		struct pldm_pdr_hdr *hdr = (struct pldm_pdr_hdr *)record->data;
+		if (hdr->type == PLDM_STATE_SENSOR_PDR) {
+			struct pldm_state_sensor_pdr *pdr =
+			    (struct pldm_state_sensor_pdr *)((uint8_t *)
+								 record->data);
+			if (pdr->sensor_id == sensorId) {
+				pdr->entity_instance = instanceNumber;
+				break;
+			}
 		}
 		record = record->next;
 	}

--- a/libpldm/pdr.h
+++ b/libpldm/pdr.h
@@ -238,6 +238,35 @@ void pldm_change_container_id_of_effecter(const pldm_pdr *repo,
 					  uint16_t effecterId,
 					  uint16_t containerId);
 
+/** @brief update the container id of a sensor
+ *
+ *  @param[in] repo -  opaque pointer acting as a PDR repo handle
+ *  @param[in] sensorId - sensor ID
+ *  @param[in] containerId - conatiner ID to be updated
+ */
+void pldm_change_container_id_of_sensor(const pldm_pdr *repo, uint16_t sensorId,
+					uint16_t containerId);
+
+/** @brief update the instance number of an effecter
+ *
+ *  @param[in] repo -  opaque pointer acting as a PDR repo handle
+ *  @param[in] effecterId - effecter ID
+ *  @param[in] instanceNumber - instance number to be updated
+ */
+void pldm_change_instance_number_of_effecter(const pldm_pdr *repo,
+					     uint16_t effecterId,
+					     uint16_t instanceNumber);
+
+/** @brief update the instance number of a sensor
+ *
+ *  @param[in] repo -  opaque pointer acting as a PDR repo handle
+ *  @param[in] sensorId - sensor ID
+ *  @param[in] instanceNumber - instance number to be updated
+ */
+void pldm_change_instance_number_of_sensor(const pldm_pdr *repo,
+					   uint16_t sensorId,
+					   uint16_t instanceNumber);
+
 /* ======================= */
 /* FRU Record Set PDR APIs */
 /* ======================= */

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -140,6 +140,9 @@ class Handler : public CmdHandler
     /** @brief To handle the boot types bios attributes at shutdown*/
     virtual void handleBootTypesAtChassisOff() = 0;
 
+    /** @brief To update container ID of Proc LED PDRs */
+    virtual void updateContainerIDofProcLed() = 0;
+
     virtual ~Handler() = default;
 
   protected:

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -404,6 +404,15 @@ class Handler : public oem_platform::Handler
      */
     uint8_t fetchRealSAIStatus();
 
+    /** @brief updating the container ID of PROC LEd PDRs*/
+    void updateContainerIDofProcLed();
+
+    /** @brief update conatiner id of identify effecter and sensor LED PDRs*/
+    void updateIdentifyEffecterAndSensorPDRs();
+
+    /** @brief update conatiner id of fault effecter and sensor LED PDRs*/
+    void updateFaultEffecterAndSensorPDRs();
+
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object
@@ -474,6 +483,8 @@ class Handler : public oem_platform::Handler
     /** @brief instanceMap is a lookup data structure to lookup <EffecterID,
      * InstanceInfo> */
     HostEffecterInstanceMap instanceMap;
+
+    bool update = true; // to indicate if update is done
 };
 
 /** @brief Method to encode code update event msg


### PR DESCRIPTION
Fix for the container ID of processor indicator sensors/effecters

The Proc LED effecter and sensor PDRs had incorrect container id
and instnace numbers assigned. We need to update the correct value
after the PDR exchange from hostboot as PROC PDRs are obtained
from the HostBoot.
Tested using pldmtool and verified the PHYP ebmcModel.
Fixes- SW541469

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>