### PR TITLE
oem_ibm: Non-disruptive system dump delete support

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -212,7 +212,7 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
         return rc < 0 ? PLDM_ERROR : PLDM_SUCCESS;
     }
 
-    if (socketWriteStatus == Error) 
+    if (socketWriteStatus == Error)
     {
         std::cerr
             << "DumpHandler::writeFromMemory: Error while writing to Unix socket"
@@ -324,8 +324,15 @@ int DumpHandler::fileAck(uint8_t fileStatus)
         {
             uint32_t val = 0xFFFFFFFF;
             PropertyValue value = static_cast<uint32_t>(val);
-            DBusMapping dbusMapping{path.c_str(), "com.ibm.Dump.Entry.Resource",
-                                    "SourceDumpId", "uint32_t"};
+            auto dumpIntf = resDumpEntry;
+
+            if (dumpType == PLDM_FILE_TYPE_DUMP)
+            {
+                dumpIntf = systemDumpEntry;
+            }
+
+            DBusMapping dbusMapping{path.c_str(), dumpIntf, "SourceDumpId",
+                                    "uint32_t"};
             try
             {
                 pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -5,6 +5,7 @@
 #include "common/utils.hpp"
 #include "host-bmc/custom_dbus.hpp"
 
+#include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
@@ -15,7 +16,6 @@
 #include <exception>
 #include <fstream>
 #include <iostream>
-#include <sys/mman.h>
 #include <mutex>
 
 namespace pldm
@@ -114,15 +114,16 @@ int setupUnixSocket(const std::string& socketInterface)
     return fd;
 }
 
-void writeToUnixSocket(const int sock, const char* buf, const uint64_t blockSize)
+void writeToUnixSocket(const int sock, const char* buf,
+                       const uint64_t blockSize)
 {
 
     const std::lock_guard<std::mutex> lock(lockMutex);
-    if (socketWriteStatus==Error)
+    if (socketWriteStatus == Error)
     {
-       return;
+        return;
     }
-    socketWriteStatus=InProgress;
+    socketWriteStatus = InProgress;
     uint64_t i;
     int nwrite = 0;
 
@@ -166,9 +167,10 @@ void writeToUnixSocket(const int sock, const char* buf, const uint64_t blockSize
                     nwrite = 0;
                     continue;
                 }
-                std::cerr << "writeToUnixSocket: Failed to write " << errno << std::endl;
+                std::cerr << "writeToUnixSocket: Failed to write " << errno
+                          << std::endl;
                 close(sock);
-                socketWriteStatus =Error;
+                socketWriteStatus = Error;
                 return;
             }
         }
@@ -179,7 +181,7 @@ void writeToUnixSocket(const int sock, const char* buf, const uint64_t blockSize
     }
 
     munmap((void*)buf, blockSize);
-    socketWriteStatus=Completed;
+    socketWriteStatus = Completed;
     return;
 }
 


### PR DESCRIPTION
This commit is to support the delete of non-disruptive system
dump entry in non-hmc managed scenario after a successful offload
of the dump to OS.

Tested by triggering a non-disruptive system dump using an empty
vsp string.

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I2a60e3ac4a2fb7c318dbbecd0e10634f4ad8d06d