### PR TITLE
Fix support for Graceful restart effecter

### DIFF
--- a/configurations/pdr/11.json
+++ b/configurations/pdr/11.json
@@ -37,7 +37,7 @@
                 "property_name": "RequestedHostTransition",
                 "property_type": "string",
                 "property_values": [
-                        "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot"
+                        "xyz.openbmc_project.State.Host.Transition.GracefulWarmReboot"
                 ]
             }
         }]


### PR DESCRIPTION
The termination status effecter when set to Graceful restart
state should request the state manager to start the GracefulWarmReboot
NOT the ForceWarmReboot.

ForeWarmReboot target would not trigger the pldm-softoff application,
so it forcefully shuts down the host rather than waiting for it to
acknowledge.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
Change-Id: I769dfc57a34e0938f3ca317db0eca8d6b85e7566