### PR TITLE
Allow OEM Effecters & Sensors to take json path

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -323,7 +323,8 @@ Response Handler::setStateEffecterStates(const pldm_msg* request,
 
     if (isOemStateEffecter(*this, effecterId, compEffecterCnt, entityType,
                            entityInstance, stateSetId) &&
-        oemPlatformHandler != nullptr)
+        oemPlatformHandler != nullptr &&
+        !effecterDbusObjMaps.contains(effecterId))
     {
         rc = oemPlatformHandler->oemSetStateEffecterStatesHandler(
             entityType, entityInstance, stateSetId, compEffecterCnt, stateField,
@@ -674,7 +675,8 @@ Response Handler::setNumericEffecterValue(const pldm_msg* request,
     if (isOemNumericEffecter(*this, effecterId, entityType, entityInstance,
                              effecterDataSize, effecterSemanticId,
                              effecterOffset, effecterResolution) &&
-        oemPlatformHandler != nullptr)
+        oemPlatformHandler != nullptr &&
+        !effecterDbusObjMaps.contains(effecterId))
     {
         rc = oemPlatformHandler->oemSetNumericEffecterValueHandler(
             entityType, entityInstance, effecterSemanticId, effecterDataSize,
@@ -758,7 +760,7 @@ Response Handler::getStateSensorReadings(const pldm_msg* request,
 
     if (isOemStateSensor(*this, sensorId, sensorRearmCount, comSensorCnt,
                          entityType, entityInstance, stateSetId, containerId) &&
-        oemPlatformHandler != nullptr)
+        oemPlatformHandler != nullptr && !sensorDbusObjMaps.contains(sensorId))
     {
         rc = oemPlatformHandler->getOemStateSensorReadingsHandler(
             entityType, entityInstance, containerId, stateSetId, comSensorCnt,


### PR DESCRIPTION
In the current flow, if the entity type is in the OEM range,
then in both the getStateSensorReadings & setStateEffecter handler
flow, we would trigger the oem functions rather than the generic
functions (which handles the PDR's in json format) - while this gives
a seperated infrastructure, this would also limit us from using the
json infrastructure for OEM entities.

This fix would basically allow defining the OEM entities in the standard
PDR json files, and also allow us to seperate out a new 11.json & 4.json
into the oem/<vendor> configuration folders.

Tested By :

Running macro: iocmnm -dumppdrindicatorstates
       Ident             Fault         |=Pdr Entity=|
repo  SensorId  ident  SensorId  fault Type Inst Cont Location code
==== ========== ===== ========== ===== ==== ==== ==== ==========================================
eBMC 038(0x026)  off  137(0x089)  off  002D 0001 0001 U78DA.ND0.WZS004K
eBMC 132(0x084)  off  231(0x0E7)  off  0040 0001 0002 U78DA.ND0.WZS004K-P0
eBMC 121(0x079)  off  220(0x0DC)  off  00BA 0001 0003 U78DA.ND0.WZS004K-P0-C0
eBMC 122(0x07A)  off  221(0x0DD)  off  00BA 0002 0003 U78DA.ND0.WZS004K-P0-C1
eBMC 123(0x07B)  off  222(0x0DE)  off  00BA 0005 0003 U78DA.ND0.WZS004K-P0-C2
eBMC 124(0x07C)  off  223(0x0DF)  off  00BA 0006 0003 U78DA.ND0.WZS004K-P0-C3
eBMC 125(0x07D)  off  224(0x0E0)  off  00BA 0007 0003 U78DA.ND0.WZS004K-P0-C4
eBMC 040(0x028)  off  139(0x08B)  off  0089 0001 0003 U78DA.ND0.WZS004K-P0-C5
eBMC 126(0x07E)  off  225(0x0E1)  off  00BA 0008 0003 U78DA.ND0.WZS004K-P0-C6
eBMC 127(0x07F)  off  226(0x0E2)  off  00BA 0009 0003 U78DA.ND0.WZS004K-P0-C7
eBMC 128(0x080)  off  227(0x0E3)  off  00BA 000A 0003 U78DA.ND0.WZS004K-P0-C8
eBMC 129(0x081)  off  228(0x0E4)  off  00BA 000B 0003 U78DA.ND0.WZS004K-P0-C9
eBMC 130(0x082)  off  229(0x0E5)  off  00BA 0003 0003 U78DA.ND0.WZS004K-P0-C10
eBMC 048(0x030)  off  147(0x093)  off  00B9 0002 0009 U78DA.ND0.WZS004K-P0-C10-T0
eBMC 047(0x02F)  off  146(0x092)  off  00B9 0001 0009 U78DA.ND0.WZS004K-P0-C10-T1
eBMC 131(0x083)  off  230(0x0E6)  off  00BA 0004 0003 U78DA.ND0.WZS004K-P0-C11
eBMC 053(0x035)  off  152(0x098)  off  007B 0001 0003 U78DA.ND0.WZS004K-P0-C14
eBMC 136(0x088)  off  235(0x0EB)  off  6000 0001 0003 U78DA.ND0.WZS004K-P0-C22
eBMC 054(0x036)  off  153(0x099)  off  007B 0002 0003 U78DA.ND0.WZS004K-P0-C23
eBMC 135(0x087)  off  234(0x0EA)  off  0079 0001 0003 U78DA.ND0.WZS004K-P0-E0
eBMC 055(0x037)  off  154(0x09A)  off  0049 0001 0003 U78DA.ND0.WZS004K-P1
eBMC 097(0x061)  off  196(0x0C4)  off  00BA 0001 0004 U78DA.ND0.WZS004K-P1-C0
eBMC 098(0x062)  off  197(0x0C5)  off  00BA 0002 0004 U78DA.ND0.WZS004K-P1-C1
eBMC 099(0x063)  off  198(0x0C6)  off  00BA 0003 0004 U78DA.ND0.WZS004K-P1-C2
eBMC 100(0x064)  off  199(0x0C7)  off  00BA 0004 0004 U78DA.ND0.WZS004K-P1-C3
eBMC 101(0x065)  off  200(0x0C8)  off  00BA 0005 0004 U78DA.ND0.WZS004K-P1-C4
eBMC 102(0x066)  off  201(0x0C9)  off  00BA 0006 0004 U78DA.ND0.WZS004K-P1-C5
eBMC 103(0x067)  off  202(0x0CA)  off  00BA 0007 0004 U78DA.ND0.WZS004K-P1-C6
eBMC 104(0x068)  off  203(0x0CB)  off  00BA 0008 0004 U78DA.ND0.WZS004K-P1-C7
eBMC 039(0x027)  off  138(0x08A)  off  0045 0001 0003 U78DA.ND0.WZS004K-D0
eBMC 096(0x060)  off  195(0x0C3)  off  0045 0002 0003 U78DA.ND0.WZS004K-D1
eBMC 133(0x085)  off  232(0x0E8)  off  0078 0001 0003 U78DA.ND0.WZS004K-E0
eBMC 134(0x086)  off  233(0x0E9)  off  0078 0002 0003 U78DA.ND0.WZS004K-E1
eBMC 090(0x05A)  off  189(0x0BD)  off  005D 0001 0003 U78DA.ND0.WZS004K-A0
eBMC 091(0x05B)  off  190(0x0BE)  off  005D 0002 0003 U78DA.ND0.WZS004K-A1
eBMC 092(0x05C)  off  191(0x0BF)  off  005D 0003 0003 U78DA.ND0.WZS004K-A2
eBMC 093(0x05D)  off  192(0x0C0)  off  005D 0004 0003 U78DA.ND0.WZS004K-A3
eBMC 094(0x05E)  off  193(0x0C1)  off  005D 0005 0003 U78DA.ND0.WZS004K-A4
eBMC 095(0x05F)  off  194(0x0C2)  off  005D 0006 0003 U78DA.ND0.WZS004K-A5
PHYP 030(0x01E)  off  031(0x01F)  off  002D 3C03 0001 U78CD.001.FZHCD44
PHYP 050(0x032)  off  051(0x033)  off  0050 0001 8011 U78CD.001.FZHCD44-P1
PHYP 056(0x038)  off  057(0x039)  off  00BA 0001 8012 U78CD.001.FZHCD44-P1-C1
PHYP 058(0x03A)  off  059(0x03B)  off  00BA 0002 8012 U78CD.001.FZHCD44-P1-C2
PHYP 060(0x03C)  off  061(0x03D)  off  00BA 0003 8012 U78CD.001.FZHCD44-P1-C3
PHYP 062(0x03E)  off  063(0x03F)  off  00BA 0004 8012 U78CD.001.FZHCD44-P1-C4
PHYP 064(0x040)  off  065(0x041)  off  00BA 0005 8012 U78CD.001.FZHCD44-P1-C5
PHYP 066(0x042)  off  067(0x043)  off  00BA 0006 8012 U78CD.001.FZHCD44-P1-C6
PHYP 068(0x044)  off  069(0x045)  off  00B9 0001 8012 U78CD.001.FZHCD44-P1-T1
PHYP 070(0x046)  off  071(0x047)  off  00B9 0002 8012 U78CD.001.FZHCD44-P1-T2
PHYP 032(0x020)  off  033(0x021)  off  007B 0001 8012 U78CD.001.FZHCD44-P1-E1
PHYP 052(0x034)  off  053(0x035)  off  0050 0002 8011 U78CD.001.FZHCD44-P2
PHYP 072(0x048)  off  073(0x049)  off  00BA 0001 8013 U78CD.001.FZHCD44-P2-C1
PHYP 074(0x04A)  off  075(0x04B)  off  00BA 0002 8013 U78CD.001.FZHCD44-P2-C2
PHYP 076(0x04C)  off  077(0x04D)  off  00BA 0003 8013 U78CD.001.FZHCD44-P2-C3
PHYP 078(0x04E)  off  079(0x04F)  off  00BA 0004 8013 U78CD.001.FZHCD44-P2-C4
PHYP 080(0x050)  off  081(0x051)  off  00BA 0005 8013 U78CD.001.FZHCD44-P2-C5
PHYP 082(0x052)  off  083(0x053)  off  00BA 0006 8013 U78CD.001.FZHCD44-P2-C6
PHYP 084(0x054)  off  085(0x055)  off  00B9 0001 8013 U78CD.001.FZHCD44-P2-T1
PHYP 086(0x056)  off  087(0x057)  off  00B9 0002 8013 U78CD.001.FZHCD44-P2-T2
PHYP 034(0x022)  off  035(0x023)  off  007B 0001 8013 U78CD.001.FZHCD44-P2-E1
PHYP 048(0x030)  off  049(0x031)  off  0040 0003 8011 U78CD.001.FZHCD44-P3
PHYP 054(0x036)  off  055(0x037)  off  003E 0001 8014 U78CD.001.FZHCD44-P3-C1
PHYP 036(0x024)  off  037(0x025)  off  0078 0001 8011 U78CD.001.FZHCD44-E1
PHYP 038(0x026)  off  039(0x027)  off  0078 0002 8011 U78CD.001.FZHCD44-E2
PHYP 040(0x028)  off  041(0x029)  off  005D 0001 8011 U78CD.001.FZHCD44-A1
PHYP 042(0x02A)  off  043(0x02B)  off  005D 0002 8011 U78CD.001.FZHCD44-A2
PHYP 044(0x02C)  off  045(0x02D)  off  005D 0003 8011 U78CD.001.FZHCD44-A3
PHYP 046(0x02E)  off  047(0x02F)  off  005D 0004 8011 U78CD.001.FZHCD44-A4

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>