### PR TITLE
PLDM: Support for LID type running in constructLidpath

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -86,8 +86,9 @@ class LidHandler : public FileHandler
             {
                 dir = LID_ALTERNATE_PATCH_DIR;
             }
-            if (oemIbmPlatformHandler->codeUpdate->fetchCurrentBootSide() ==
-                sideToRead)
+            if ((oemIbmPlatformHandler->codeUpdate->fetchCurrentBootSide() ==
+                 sideToRead) ||
+                (lidType == PLDM_FILE_TYPE_LID_RUNNING))
             {
                 if (isPatchDir)
                 {


### PR DESCRIPTION
To add support for the new filetype PLDM_FILE_TYPE_LID_RUNNING
in constructLidpath for host to request the running side lids.

Defect: SW544140

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>