### PR TITLE
oem_ibm : Sync power bios attribues to dbus

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -357,7 +357,17 @@
             "Disabled"
          ],
          "helpText" : "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
-         "displayName" : "Power Limit Enable (pending)"
+         "displayName" : "Power Limit Enable (pending)",
+         "helpText" : "Specifies whether the power limit is enabled.",
+         "displayName" : "Power Limit Enable",
+         "dbus":
+            {
+               "object_path" : "/xyz/openbmc_project/control/host0/power_cap",
+               "interface" : "xyz.openbmc_project.Control.Power.Cap",
+               "property_name" : "PowerCapEnable",
+               "property_type" : "bool",
+               "property_values" : [true, false]
+            }
       },
       {
          "attribute_name":"hb_power_limit_enable_current",

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -79,7 +79,13 @@
          "scalar_increment" : 1,
          "default_value" : 0,
          "helpText" : "Specifies the power limit in watts.",
-         "displayName" : "Power Limit In Watts"
+         "displayName" : "Power Limit In Watts",
+         "dbus":{
+            "object_path" : "/xyz/openbmc_project/control/host0/power_cap",
+            "interface" : "xyz.openbmc_project.Control.Power.Cap",
+            "property_type" : "uint32_t",
+            "property_name" : "PowerCap"
+         }
       },
       {
          "attribute_name" : "hb_max_number_huge_pages",


### PR DESCRIPTION
1. Map PowerCapEnable dbus property to hb_power_limit_enable
2. Map PowerCap dbus property to hb_power_limit_in_watts

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
Change-Id: I99dbc067c743c7b9a9a73c92e72975af05310dac