### PR TITLE
oem: ibm: Fix BootSide string values

### DIFF
--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -75,9 +75,10 @@ int CodeUpdate::setNextBootSide(const std::string& nextSide)
 {
     std::cout << "setNextBootSide, nextSide=" << nextSide << std::endl;
     pldm_boot_side_data pldmBootSideData = readBootSideFile();
-    currBootSide = pldmBootSideData.current_boot_side;
+    currBootSide =
+        (pldmBootSideData.current_boot_side == "Perm" ? Pside : Tside);
     nextBootSide = nextSide;
-    pldmBootSideData.next_boot_side = nextSide;
+    pldmBootSideData.next_boot_side = (nextSide == Pside ? "Perm" : "Temp");
     std::string objPath{};
     if (nextBootSide == currBootSide)
     {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -135,8 +135,10 @@ class Handler : public oem_platform::Handler
                     if (it.first == "fw_boot_side")
                     {
                         auto& [attributeType, attributevalue] = it.second;
-                        std::string nextBootSide =
+                        std::string nextBootSideAttr =
                             std::get<std::string>(attributevalue);
+                        std::string nextBootSide =
+                            (nextBootSideAttr == "Perm" ? Pside : Tside);
                         codeUpdate->setNextBootSide(nextBootSide);
                     }
                 }


### PR DESCRIPTION
The nextBootSide and currBootSide should have a value of "T" or "P", but
the side bios attributes have values of "Temp" or "Perm". There were a
couple places where the value of the attributes were being assigned to
the boot side variables without making the translation. Fixed by
converting "Temp/Perm" into "T/P".

Tested: Verified pldm returned the correct lid data from the requested
side after a code update.

Change-Id: I95f4087bfe382cf468a294fb18fdc8309b5b0bbc
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>