### PR TITLE
fix the invalid effecter and sensor PDRs

### DIFF
--- a/libpldmresponder/pdr_numeric_effecter.hpp
+++ b/libpldmresponder/pdr_numeric_effecter.hpp
@@ -73,6 +73,13 @@ void generateNumericEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
                 pdr->entity_type = e.value("type", 0);
                 pdr->entity_instance = e.value("instance", 0);
                 pdr->container_id = e.value("container", 0);
+
+                // do not create the PDR when the FRU or the entity path is not
+                // present
+                if (!pdr->entity_type)
+                {
+                    continue;
+                }
             }
         }
         catch (const std::exception& ex)

--- a/libpldmresponder/pdr_state_effecter.hpp
+++ b/libpldmresponder/pdr_state_effecter.hpp
@@ -93,6 +93,13 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
                 pdr->entity_type = e.value("type", 0);
                 pdr->entity_instance = e.value("instance", 0);
                 pdr->container_id = e.value("container", 0);
+
+                // do not create the PDR when the FRU or the entity path is not
+                // present
+                if (!pdr->entity_type)
+                {
+                    continue;
+                }
             }
         }
         catch (const std::exception& ex)

--- a/libpldmresponder/pdr_state_sensor.hpp
+++ b/libpldmresponder/pdr_state_sensor.hpp
@@ -94,6 +94,13 @@ void generateStateSensorPDR(const DBusInterface& dBusIntf, const Json& json,
                 pdr->entity_type = e.value("type", 0);
                 pdr->entity_instance = e.value("instance", 0);
                 pdr->container_id = e.value("container", 0);
+
+                // do not create the PDR when the FRU or the entity path is not
+                // present
+                if (!pdr->entity_type)
+                {
+                    continue;
+                }
                 // now attach this entity to the container that was
                 // mentioned in the json, and add this entity to the
                 // parents entity assocation PDR


### PR DESCRIPTION
The LED effecter and sensor PDRs where created even when
the FRU or the entity path was not present which puts the
entity ID in the PDR as 0. This commit fixes that issue.

Fixes:SW537409

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>