### PR TITLE
PLDM Power down effecter and APR support

### DIFF
--- a/libpldm/state_set.h
+++ b/libpldm/state_set.h
@@ -222,7 +222,9 @@ enum pldm_state_set_boot_progress_state_values {
 /* @brief List of states for the System Power State set (ID 260).
  */
 enum pldm_state_set_system_power_state_values {
-	PLDM_STATE_SET_SYS_POWER_STATE_OFF_SOFT_GRACEFUL = 9
+	PLDM_STATE_SET_SYS_POWER_CYCLE_OFF_SOFT_GRACEFUL = 7,
+	PLDM_STATE_SET_SYS_POWER_STATE_OFF_SOFT_GRACEFUL = 9,
+	PLDM_STATE_SET_SYS_POWER_STATE_OFF_HARD_GRACEFUL = 10,
 };
 
 /* OEM ranges */

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -233,6 +233,25 @@ int pldm::responder::oem_ibm_platform::Handler::
             {
                 turnOffRealSAIEffecter();
             }
+            else if (entityType == PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER &&
+                     stateSetId == PLDM_STATE_SET_SYSTEM_POWER_STATE)
+            {
+                if (stateField[currState].effecter_state ==
+                    PLDM_STATE_SET_SYS_POWER_CYCLE_OFF_SOFT_GRACEFUL)
+                {
+                    processPowerCycleOffSoftGraceful();
+                }
+                else if (stateField[currState].effecter_state ==
+                         PLDM_STATE_SET_SYS_POWER_STATE_OFF_SOFT_GRACEFUL)
+                {
+                    processPowerOffSoftGraceful();
+                }
+                else if (stateField[currState].effecter_state ==
+                         PLDM_STATE_SET_SYS_POWER_STATE_OFF_HARD_GRACEFUL)
+                {
+                    processPowerOffHardGraceful();
+                }
+            }
             else
             {
                 rc = PLDM_PLATFORM_SET_EFFECTER_UNSUPPORTED_SENSORSTATE;
@@ -554,6 +573,53 @@ void buildAllNumericEffecterPDR(oem_ibm_platform::Handler* platformHandler,
     }
 }
 
+void buildAllSystemPowerStateEffecterPDR(
+    oem_ibm_platform::Handler* platformHandler, uint16_t entityType,
+    uint16_t entityInstance, uint16_t stateSetID, pdr_utils::Repo& repo)
+{
+    size_t pdrSize = 0;
+    pdrSize = sizeof(pldm_state_effecter_pdr) +
+              sizeof(state_effecter_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_effecter_pdr* pdr =
+        reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
+    if (!pdr)
+    {
+        std::cerr << "Failed to get record by PDR type, ERROR:"
+                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        return;
+    }
+    pdr->hdr.record_handle = 0;
+    pdr->hdr.version = 1;
+    pdr->hdr.type = PLDM_STATE_EFFECTER_PDR;
+    pdr->hdr.record_change_num = 0;
+    pdr->hdr.length = sizeof(pldm_state_effecter_pdr) - sizeof(pldm_pdr_hdr);
+    pdr->terminus_handle = TERMINUS_HANDLE;
+    pdr->effecter_id = platformHandler->getNextEffecterId();
+    pdr->entity_type = entityType;
+    pdr->entity_instance = entityInstance;
+    pdr->container_id = 1;
+    pdr->effecter_semantic_id = 0;
+    pdr->effecter_init = PLDM_NO_INIT;
+    pdr->has_description_pdr = false;
+    pdr->composite_effecter_count = 1;
+
+    auto* possibleStatesPtr = pdr->possible_states;
+    auto possibleStates =
+        reinterpret_cast<state_effecter_possible_states*>(possibleStatesPtr);
+    possibleStates->state_set_id = stateSetID;
+    possibleStates->possible_states_size = 2;
+    auto state =
+        reinterpret_cast<state_effecter_possible_states*>(possibleStates);
+    state->states[0].byte = 128;
+    state->states[1].byte = 6;
+    pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+    pdrEntry.data = entry.data();
+    pdrEntry.size = pdrSize;
+    repo.addRecord(pdrEntry);
+}
+
 std::vector<std::string> getslotPaths()
 {
     static constexpr auto searchpath = "/xyz/openbmc_project/inventory/system";
@@ -768,6 +834,9 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
                                 PLDM_OEM_IBM_BOOT_SIDE_RENAME, repo);
     buildAllNumericEffecterPDR(this, PLDM_ENTITY_PROC, ENTITY_INSTANCE_0,
                                PLDM_OEM_IBM_SBE_SEMANTIC_ID, repo, instanceMap);
+    buildAllSystemPowerStateEffecterPDR(
+        this, PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER, ENTITY_INSTANCE_0,
+        PLDM_STATE_SET_SYSTEM_POWER_STATE, repo);
 
     pldm_entity fwUpEntity = {PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE, 0, 1};
     attachOemEntityToEntityAssociationPDR(
@@ -777,6 +846,11 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     attachOemEntityToEntityAssociationPDR(
         this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,
         saiEntity);
+    pldm_entity powerStateEntity = {PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER, 0,
+                                    1};
+    attachOemEntityToEntityAssociationPDR(
+        this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,
+        powerStateEntity);
 
     auto sensorId = findStateSensorId(
         repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
@@ -1617,6 +1691,66 @@ void pldm::responder::oem_ibm_platform::Handler::updateContainerIDofProcLed()
         update = false;
     }
 }
+
+void pldm::responder::oem_ibm_platform::Handler::
+    processPowerCycleOffSoftGraceful()
+{
+    pldm::utils::PropertyValue value =
+        "xyz.openbmc_project.State.Host.Transition.Reboot";
+    pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/host0",
+                                         "xyz.openbmc_project.State.Host",
+                                         "RequestedHostTransition", "string"};
+    try
+    {
+        dBusIntf->setDbusProperty(dbusMapping, value);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr
+            << "Error to do a graceful shutdown, cycle chassis power, and boot the host back up. Unable to set property RequestedHostTransition. ERROR="
+            << e.what() << "\n";
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::processPowerOffSoftGraceful()
+{
+    pldm::utils::PropertyValue value =
+        "xyz.openbmc_project.State.Chassis.Transition.Off";
+    pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/chassis0",
+                                         "xyz.openbmc_project.State.Chassis",
+                                         "RequestedPowerTransition", "string"};
+    try
+    {
+        dBusIntf->setDbusProperty(dbusMapping, value);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr
+            << "Error in powering down the host. Unable to set property RequestedPowerTransition. ERROR="
+            << e.what() << "\n";
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
+{
+    pldm::utils::PropertyValue value =
+        "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn";
+    pldm::utils::DBusMapping dbusMapping{
+        "/xyz/openbmc_project/control/host0/power_restore_policy/one_time",
+        "xyz.openbmc_project.Control.Power.RestorePolicy", "PowerRestorePolicy",
+        "string"};
+    try
+    {
+        dBusIntf->setDbusProperty(dbusMapping, value);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr
+            << "Setting one-time restore policy failed, Unable to set property PowerRestorePolicy. ERROR="
+            << e.what() << "\n";
+    }
+}
+
 } // namespace oem_ibm_platform
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -44,6 +44,7 @@ using PendingAttributes = std::map<AttributeName, PendingObj>;
 static constexpr auto PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577;
 static constexpr auto PLDM_OEM_IBM_FRONT_PANEL_TRIGGER = 32837;
 static constexpr auto PLDM_OEM_IBM_ENTITY_REAL_SAI = 24581;
+static constexpr auto PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER = 24580;
 
 constexpr uint16_t ENTITY_INSTANCE_0 = 0;
 constexpr uint16_t ENTITY_INSTANCE_1 = 1;
@@ -414,6 +415,16 @@ class Handler : public oem_platform::Handler
 
     /** @brief update conatiner id of fault effecter and sensor LED PDRs*/
     void updateFaultEffecterAndSensorPDRs();
+
+    /** @brief To process the graceful shutdown, cycle chassis power, and boot
+     *  the host back up*/
+    void processPowerCycleOffSoftGraceful();
+
+    /** @brief To process powering down the host*/
+    void processPowerOffSoftGraceful();
+
+    /** @brief To process auto power restore policy*/
+    void processPowerOffHardGraceful();
 
     ~Handler() = default;
 

--- a/pldmtool/oem/ibm/oem_ibm_state_set.hpp
+++ b/pldmtool/oem/ibm/oem_ibm_state_set.hpp
@@ -57,7 +57,8 @@ extern const std::map<uint8_t, std::string> OemIBMEntityType{
     {PLDM_OEM_ENTITY_TYPE_END, "OEM IBM Entity Type End"},
     {pldm::responder::oem_ibm_platform::PLDM_OEM_IBM_ENTITY_REAL_SAI,
      "OEM IBM Real SAI"},
-};
+    {pldm::responder::oem_ibm_platform::PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER,
+     "OEM IBM Chassis Power Controller"}};
 
 /** @brief Map for PLDM OEM IBM State Sets
  */

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -443,8 +443,11 @@ class GetPDR : public CommandInterface
         {PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS_STRESSED, "Stressed"}};
 
     static inline const std::map<uint8_t, std::string> setSysPowerState{
-        {PLDM_STATE_SET_SYS_POWER_STATE_OFF_SOFT_GRACEFUL,
-         "Off-Soft Graceful"}};
+        {PLDM_STATE_SET_SYS_POWER_STATE_OFF_SOFT_GRACEFUL, "Off-Soft Graceful"},
+        {PLDM_STATE_SET_SYS_POWER_CYCLE_OFF_SOFT_GRACEFUL,
+         "Power Cycle Off-Soft Graceful"},
+        {PLDM_STATE_SET_SYS_POWER_STATE_OFF_HARD_GRACEFUL,
+         "Off-Hard Graceful"}};
 
     static inline const std::map<uint8_t, std::string> setSWTerminationStatus{
         {PLDM_SW_TERM_GRACEFUL_RESTART_REQUESTED,


### PR DESCRIPTION
This commit adds a single OEM state effecter with a 
OEM entity type and with states [7,9,10] to perform 3 custom
actions ReIPL, PowerDown and ArmAPR.
fixes:SW531941

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>