### PR TITLE
Modified default values for bios attributes.

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -1,18 +1,6 @@
 {
     "entries" :[
       {
-         "attribute_name":"pvm_fw_boot_side",
-         "possible_values":[
-            "Perm",
-            "Temp"
-         ],
-         "default_values":[
-            "Temp"
-         ],
-         "helpText" : "pvm_fw_boot_side",
-         "displayName" : "pvm_fw_boot_side"
-      },
-      {
          "attribute_name":"fw_boot_side",
          "possible_values":[
             "Perm",
@@ -402,7 +390,7 @@
             "Enabled"
          ],
          "default_values":[
-            "Enabled"
+            "Disabled"
          ],
          "helpText" : "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
          "displayName" : "Memory Mirror Mode (pending)"
@@ -414,7 +402,7 @@
             "Enabled"
          ],
          "default_values":[
-            "Enabled"
+            "Disabled"
          ],
          "helpText" : "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
          "displayName" : "Memory Mirror Mode (current)"


### PR DESCRIPTION
Deleted pvm_fw_boot_side attribute and modified default value of hb_memory_mirror_mode and hb_memory_mirror_mode_current.

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>