### PR TITLE
PLDM: Fix for upstream component

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -487,8 +487,8 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t& length,
             auto filePath =
                 pldm::utils::DBusHandler().getDbusProperty<std::string>(
                     path.c_str(), "Path", dumpFilepathInterface);
-            auto rc = transferFileData(fs::path(filePath), false, offset,
-                                       length, address);
+            auto rc = transferFileData(fs::path(filePath), true, offset, length,
+                                       address);
             return rc;
         }
         catch (const std::exception& e)


### PR DESCRIPTION
This commit fixes the upstream component
which is passed to read the dump file which
suggests if the dump is offloaded to host or
not, in case of Dump Offload in non-HMC managed
scenario

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>