### PR TITLE
DumpHandler: Reset dump OffloadUri after dump offload

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -53,7 +53,7 @@ class DumpHandler : public FileHandler
 
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
-
+    void resetOffloadUri();
     /** @brief DumpHandler destructor
      */
     ~DumpHandler()


### PR DESCRIPTION
This is needed for dump manager to identify if a dump offload
in progress so that it can reject other host dump requests.

Tested by:
Offloading system dump and resource dump