### PR TITLE
Fix Race condition in PDR generation

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -171,18 +171,15 @@ void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
 
 Response Handler::getPDR(const pldm_msg* request, size_t payloadLength)
 {
-    if (hostPDRHandler)
+    if (oemPlatformHandler != nullptr)
     {
-        if (hostPDRHandler->isHostUp() && oemPlatformHandler != nullptr)
+        //  we assume that the entity manager
+        // already sends the system type information before we
+        // reach BMC ready state.
+        auto rc = oemPlatformHandler->checkBMCState();
+        if (rc != PLDM_SUCCESS)
         {
-            // When host is up, we assume that the entity manager
-            // already sends the system type information before we
-            // reach BMC ready state.
-            auto rc = oemPlatformHandler->checkBMCState();
-            if (rc != PLDM_SUCCESS)
-            {
-                return ccOnlyResponse(request, PLDM_ERROR_NOT_READY);
-            }
+            return ccOnlyResponse(request, PLDM_ERROR_NOT_READY);
         }
     }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1355,8 +1355,8 @@ int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
                 "/xyz/openbmc_project/state/bmc0", "CurrentBMCState",
                 "xyz.openbmc_project.State.BMC");
 
-        if (std::get<std::string>(propertyValue) ==
-            "xyz.openbmc_project.State.BMC.BMCState.NotReady")
+        if (std::get<std::string>(propertyValue) !=
+            "xyz.openbmc_project.State.BMC.BMCState.Ready")
         {
             std::cerr << "GetPDR : PLDM stack is not ready for PDR exchange"
                       << std::endl;


### PR DESCRIPTION
This PR would fix mutiple issues :
1.When ever pldm is started , it sends a getPLDMVersion
  command to host and if we get a response we set HostUp
  to true. But we started to see cases where PHYP does not
  respond to getPLDMVersion but instead does a GetPDR command.
  So we have a minimal window where we could go ahead and create
  PDR's even when BMC is not in Ready State.

2.Check for other BMC states and don't allow anyone to create PDR's
  if BMC is not in Ready state.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>