### PR TITLE
PLDM: Fix for OpPanel enable function 34

### DIFF
--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -183,6 +183,10 @@ class HostPDRHandler
      */
     bool isHostPdrModified = false;
 
+    /** @brief counter to count the number of modified records sent from host
+     */
+    uint8_t modifiedCounter = 0;
+
     /** @brief map that captures various terminus information **/
     TLPDRMap tlPDRInfo;
 

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -587,6 +587,7 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                 {
                     return rc;
                 }
+                hostPDRHandler->modifiedCounter += pdrRecordHandles.size();
             }
 
             changeRecordData +=


### PR DESCRIPTION
This commit fixes the incorrect handling of multiple
PDR records modified events sent by the host which are
all sent within fraction of seconds.

Defect: SW546471

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>