### PR TITLE
oem-ibm: define new pvm_sys_dump_active bios value

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -314,6 +314,18 @@
          "displayName" : "Virtual Trusted Platform Module (current)"
       },
       {
+         "attribute_name":"pvm_sys_dump_active",
+         "possible_values":[
+            "Enabled",
+            "Disabled"
+         ],
+         "default_values":[
+            "Disabled"
+         ],
+         "helpText" : "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+         "displayName" : "System Dump Active"
+      },
+      {
          "attribute_name":"hb_memory_region_size",
          "possible_values":[
             "128MB",


### PR DESCRIPTION
Upstream Commit: https://gerrit.openbmc-project.xyz/c/openbmc/pldm/+/52268

External IBM clients to the BMC need to known when a memory preserving
reboot is occurring. A power off of the system during this process will
result in all the debug data that is collected during this process be
lost. This new BIOS value will be set when a memory preserving reboot is
started, and cleared when the debug data has been offloaded by the
client. Redfish clients can look at this BIOS value to know if they
should allow a power off of the system.

The initial goal was to work this into the official system states
reported by the BMC (redfish/v1/Systems/system) but Redfish really
doesn't have this type of function well represented currently. A memory
preserving reboot is pretty specific to IBM systems. Hacking this into
the existing BMC state management framework was getting messy so the
agreement was to move this to a IBM specific BIOS for now.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: Ia3341517638ac93a2deaa1fe71c9ae7b408b25e8