### PR TITLE
PLDM: Remove old boot side setting

### DIFF
--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -447,9 +447,13 @@ void BIOSConfig::updateBaseBIOSTableProperty()
                                           dbusProperties, "Set");
         std::variant<BaseBIOSTable> value = baseBIOSTableMaps;
 #ifdef OEM_IBM
+        const fs::path bootSideDirPath = "/var/lib/pldm/bootSide";
         for (const auto& [attrName, biostabObj] : baseBIOSTableMaps)
         {
-            if (attrName == "fw_boot_side")
+            // The additional check to see if /var/lib/pldm/bootSide file exists
+            // is added to make sure we are doing the fw_boot_side setting after
+            // the base bios table is initialised.
+            if ((attrName == "fw_boot_side") && fs::exists(bootSideDirPath))
             {
                 BiosAttributeList biosAttrList;
                 std::string nextBootSide =

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -234,8 +234,6 @@ void CodeUpdate::setVersions()
             biosAttrList.push_back(std::make_pair(
                 bootSideAttrName, pldmBootSideData.current_boot_side));
             biosAttrList.push_back(std::make_pair(
-                "pvm_fw_boot_side", pldmBootSideData.current_boot_side));
-            biosAttrList.push_back(std::make_pair(
                 bootNextSideAttrName, pldmBootSideData.next_boot_side));
             setBiosAttr(biosAttrList);
         }
@@ -258,8 +256,6 @@ void CodeUpdate::setVersions()
                 writeBootSideFile(pldmBootSideData);
                 biosAttrList.push_back(
                     std::make_pair(bootSideAttrName, current_boot_side));
-                biosAttrList.push_back(
-                    std::make_pair("pvm_fw_boot_side", current_boot_side));
                 biosAttrList.push_back(std::make_pair(
                     bootNextSideAttrName, pldmBootSideData.next_boot_side));
                 setBiosAttr(biosAttrList);
@@ -275,8 +271,6 @@ void CodeUpdate::setVersions()
                 writeBootSideFile(pldmBootSideData);
                 biosAttrList.push_back(std::make_pair(
                     bootSideAttrName, pldmBootSideData.current_boot_side));
-                biosAttrList.push_back(std::make_pair(
-                    "pvm_fw_boot_side", pldmBootSideData.current_boot_side));
                 biosAttrList.push_back(std::make_pair(
                     bootNextSideAttrName, pldmBootSideData.next_boot_side));
                 setBiosAttr(biosAttrList);
@@ -446,8 +440,6 @@ void CodeUpdate::processRenameEvent()
     writeBootSideFile(pldmBootSideData);
     biosAttrList.push_back(
         std::make_pair(bootSideAttrName, pldmBootSideData.current_boot_side));
-    biosAttrList.push_back(
-        std::make_pair("pvm_fw_boot_side", pldmBootSideData.current_boot_side));
     biosAttrList.push_back(
         std::make_pair(bootNextSideAttrName, pldmBootSideData.next_boot_side));
     setBiosAttr(biosAttrList);


### PR DESCRIPTION
This commit removes the old boot side setting of
bios attribute pvm_fw_boot_side which is now
deprecated.

Also adds an additional check before setting the
fw_boot_side bios attribute before setting the new
value which is set by host to make sure that the
bios attibute table is initiated before we try to
set the value.

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>