### PR TITLE
support a BootProgress of SystemSetup for host running

### DIFF
--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -166,7 +166,9 @@ void HostEffecterParser::processHostEffecterChangeNotification(
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
                               "ProgressStages.OSRunning") &&
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
-                              "ProgressStages.OSStart"))
+                              "ProgressStages.OSStart") &&
+            (currHostState != "xyz.openbmc_project.State.Boot.Progress."
+                              "ProgressStages.SystemSetup"))
         {
             std::cout << "Host is not up. Current host state: "
                       << currHostState.c_str() << "\n";

--- a/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
@@ -35,7 +35,9 @@ int sendBiosAttributeUpdateEvent(
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
                               "ProgressStages.OSRunning") &&
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
-                              "ProgressStages.OSStart"))
+                              "ProgressStages.OSStart") &&
+            (currHostState != "xyz.openbmc_project.State.Boot.Progress."
+                              "ProgressStages.SystemSetup"))
         {
             return PLDM_SUCCESS;
         }


### PR DESCRIPTION
SystemSetup is a BootProgress that indicates the host is booted, but in
a state where user interaction is needed. On an IBM system, this state
is entered when VMI needs some configuration or when PHYP's NVRAM has
been cleared.

pldm needs to consider the host running in this scenario because it's
needed to send user configuration information like the VMI IP and
static vs. dhcp information.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>