### PR TITLE
PLDM: Minimise sending BIOS attr change event

### DIFF
--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -497,6 +497,11 @@ void CodeUpdate::processPriorityChangeNotification(
                                                               : "Temp");
     writeBootSideFile(pldmBootSideData);
     nextBootSide = (pldmBootSideData.next_boot_side == "Temp" ? Tside : Pside);
+    std::string currNextBootSide = getBiosAttrValue(bootNextSideAttrName);
+    if (currNextBootSide == nextBootSide)
+    {
+        return;
+    }
     BiosAttributeList biosAttrList;
     biosAttrList.push_back(
         std::make_pair(bootNextSideAttrName, pldmBootSideData.next_boot_side));


### PR DESCRIPTION
This commits add code to minimise sending redundant bios
attribute change events to host.

Defect:SW546927

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>