### PR TITLE
Fix the DBus persist bug

### DIFF
--- a/host-bmc/dbus/deserialize.cpp
+++ b/host-bmc/dbus/deserialize.cpp
@@ -257,5 +257,30 @@ void restoreDbusObj(HostPDRHandler* hostPDRHandler)
     }
 }
 
+void reSerialize(std::vector<uint16_t> types)
+{
+    if (types.empty())
+    {
+        return;
+    }
+
+    if (!pldm::serialize::Serialize::getSerialize().deserialize())
+    {
+        return;
+    }
+
+    auto savedObjs = pldm::serialize::Serialize::getSerialize().getSavedObjs();
+    for (const auto& type : types)
+    {
+        if (savedObjs.contains(type))
+        {
+            savedObjs.erase(savedObjs.find(type));
+        }
+    }
+
+    pldm::serialize::Serialize::getSerialize().reSerialize(
+        std::move(savedObjs));
+}
+
 } // namespace deserialize
 } // namespace pldm

--- a/host-bmc/dbus/deserialize.hpp
+++ b/host-bmc/dbus/deserialize.hpp
@@ -14,5 +14,7 @@ namespace deserialize
 
 void restoreDbusObj(HostPDRHandler* hostPDRHandler);
 
+void reSerialize(std::vector<uint16_t> type);
+
 } // namespace deserialize
 } // namespace pldm

--- a/host-bmc/dbus/serialize.cpp
+++ b/host-bmc/dbus/serialize.cpp
@@ -100,5 +100,20 @@ void Serialize::setObjectPathMaps(const ObjectPathMaps& maps)
     }
 }
 
+void Serialize::reSerialize(dbus::SavedObjs&& savedObjs)
+{
+    this->savedObjs = std::move(savedObjs);
+
+    auto dir = filePath.parent_path();
+    if (!fs::exists(dir))
+    {
+        fs::create_directories(dir);
+    }
+
+    std::ofstream os(filePath.c_str(), std::ios::binary);
+    cereal::JSONOutputArchive oarchive(os);
+    oarchive(this->savedObjs);
+}
+
 } // namespace serialize
 } // namespace pldm

--- a/host-bmc/dbus/serialize.hpp
+++ b/host-bmc/dbus/serialize.hpp
@@ -56,6 +56,8 @@ class Serialize
 
     void setObjectPathMaps(const ObjectPathMaps& maps);
 
+    void reSerialize(dbus::SavedObjs&& savedObjs);
+
   private:
     dbus::SavedObjs savedObjs;
     fs::path filePath{PERSISTENT_FILE};

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -962,6 +962,10 @@ void HostPDRHandler::setHostFirmwareCondition()
                                   std::move(getPLDMVersionHandler));
     if (rc)
     {
+        // Since the Host is off, remove all cores in the persist file
+        std::vector<uint16_t> types = {32903};
+        pldm::deserialize::reSerialize(types);
+
         std::cerr << "Failed to discover Host state. Assuming Host as off \n";
     }
 }


### PR DESCRIPTION
There is a bug here: if bmc is started or restarted and the host is
closed, all attribute values of the core type should not be restored
at this time, because when the host is powered on again, all the PDRs
of the core type will be sent again, so there will be bmc
Inconsistent with the state of the host's cores.

Signed-off-by: George Liu <liuxiwei@inspur.com>