### PR TITLE
Remove Petitboot

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -236,8 +236,7 @@
             "SavedList",
             "SmsMenu",
             "OkPrompt",
-            "DefaultList",
-            "PblBootLid"
+            "DefaultList"
          ],
          "default_values":[
             "Normal"
@@ -252,8 +251,7 @@
             "SavedList",
             "SmsMenu",
             "OkPrompt",
-            "DefaultList",
-            "PblBootLid"
+            "DefaultList"
          ],
          "default_values":[
             "Normal"


### PR DESCRIPTION
This commit is to remove petitboot from the pvm_rpa_boot_mode and
pvm_rpa_boot_mode_current attributes. For Everest and Rainier,
we do not need to support booting from petitboot, that was for
internal purposes only. To ensure that the petitboot option is
not an option on the GUI, it needs to be removed on the backend.

Defect SW547984:
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW547984