### PR TITLE
Remove Default Option

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -194,11 +194,10 @@
          "possible_values":[
             "AIX",
             "Linux",
-            "IBM I",
-            "Default"
+            "IBM I"
          ],
          "default_values":[
-            "Default"
+            "AIX"
          ],
          "helpText" : "CEC Primary OS",
          "displayName" : "CEC Primary OS"
@@ -208,11 +207,10 @@
          "possible_values":[
             "AIX",
             "Linux",
-            "IBM I",
-            "Default"
+            "IBM I"
          ],
          "default_values":[
-            "Default"
+            "AIX"
          ],
          "helpText" : "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
          "displayName" : "CEC Primary OS (current)"


### PR DESCRIPTION
Default should not be an option for the current eBMC system. This
option was applicable for FSP and ASMI based systems. Rainier and
Everest based systems should not have this option. The default
choice needs to be removed from pvm_default_os_type and
pvm_default_os_type_current, and the default value needs to be
changed to AIX.

Defect SW547992 :
https://w3.rchland.ibm.com/projects/SLIC/bestquest/index.php?defect=SW547992