### PR TITLE
oem: ibm: Close fd after transferFileData

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -152,14 +152,15 @@ class LidHandler : public FileHandler
                       << "\n";
             return PLDM_ERROR;
         }
-        close(fd);
-
         rc = transferFileData(lidPath, false, offset, length, address);
         if (rc != PLDM_SUCCESS)
         {
             std::cerr << "writeFileFromMemory failed with rc= " << rc << " \n";
             return rc;
         }
+        fsync(fd);
+        close(fd);
+
         if (lidType == PLDM_FILE_TYPE_LID_MARKER)
         {
             markerLIDremainingSize -= length;
@@ -267,6 +268,7 @@ class LidHandler : public FileHandler
         {
             rc = PLDM_ERROR;
         }
+        fsync(fd);
         close(fd);
 
         if (lidType == PLDM_FILE_TYPE_LID_MARKER)


### PR DESCRIPTION
The file descriptor was being closed before the call to transferFileData
which performs a write to it, move the close call after the call to
write. Also add an fsync call to ensure the data has made it to the
filesystem and can be processed.

Tested: Performed an inband update.

Change-Id: I199782e2a1b96496d57f3f6e840a298ba66de9c5
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>