### PR TITLE
PLDM: PCIE topology support

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -220,6 +220,19 @@ void CustomDBus::implementGlobalInterface(const std::string& path)
     }
 }
 
+void CustomDBus::implementPcieTopologyInterface(
+    const std::string& path, uint8_t mctpEid,
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser)
+{
+    if (pcietopology.find(path) == pcietopology.end())
+    {
+        pcietopology.emplace(path,
+                             std::make_unique<PCIETopology>(
+                                 pldm::utils::DBusHandler::getBus(),
+                                 path.c_str(), hostEffecterParser, mctpEid));
+    }
+}
+
 void CustomDBus::implementLicInterfaces(
     const std::string& path, const uint32_t& authdevno, const std::string& name,
     const std::string& serialno, const uint64_t& exptime,
@@ -329,6 +342,15 @@ void CustomDBus::setMicrocode(const std::string& path, uint32_t value)
                                             path.c_str()));
     }
     cpuCore.at(path)->microcode(value);
+}
+
+void CustomDBus::updateTopologyProperty(bool value)
+{
+    if (pcietopology.contains("/xyz/openbmc_project/pldm"))
+    {
+        pcietopology.at("/xyz/openbmc_project/pldm")
+            ->pcIeTopologyRefresh(value);
+    }
 }
 
 } // namespace dbus

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -21,6 +21,7 @@
 #include "motherboard.hpp"
 #include "operational_status.hpp"
 #include "pcie_slot.hpp"
+#include "pcie_topology.hpp"
 #include "power_supply.hpp"
 #include "software_version.hpp"
 #include "vrm.hpp"
@@ -144,6 +145,18 @@ class CustomDBus
      *
      * @param[in] path - The object path to implement Enable interface
      */
+
+    /** @brief Implement PCIE Topology interface
+     *
+     *  @param[in] path - The object path
+     *  @param[in] mctpEid - mctp endpoint
+     *  @param[in] hostEffecterParser - Pointer to host effecter parser
+     *
+     */
+    void implementPcieTopologyInterface(
+        const std::string& path, uint8_t mctpEid,
+        pldm::host_effecters::HostEffecterParser* hostEffecterParser);
+
     void implementObjectEnableIface(const std::string& path, bool value);
     /** @brief Set the Asserted property
      *
@@ -234,6 +247,12 @@ class CustomDBus
      */
     void setMicrocode(const std::string& path, uint32_t value);
 
+    /** @brief update topology property
+     *
+     *  @param[in] value - topology value
+     */
+    void updateTopologyProperty(bool value);
+
   private:
     std::unordered_map<ObjectPath, std::unique_ptr<LocationCode>> location;
     std::unordered_map<ObjectPath, std::unique_ptr<OperationalStatus>>
@@ -260,6 +279,7 @@ class CustomDBus
     std::unordered_map<ObjectPath, std::unique_ptr<LEDGroup>> ledGroup;
     std::unordered_map<ObjectPath, std::unique_ptr<SoftWareVersion>>
         softWareVersion;
+    std::unordered_map<ObjectPath, std::unique_ptr<PCIETopology>> pcietopology;
 };
 
 } // namespace dbus

--- a/host-bmc/dbus/pcie_topology.cpp
+++ b/host-bmc/dbus/pcie_topology.cpp
@@ -1,0 +1,175 @@
+#include "pcie_topology.hpp"
+
+#include "libpldm/entity.h"
+#include "oem/ibm/libpldm/state_set_oem_ibm.h"
+
+#include "host-bmc/dbus/custom_dbus.hpp"
+
+namespace pldm
+{
+namespace dbus
+{
+
+bool PCIETopology::pcIeTopologyRefresh() const
+{
+    return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+        pcIeTopologyRefresh();
+}
+
+bool PCIETopology::updateTopologyRefresh()
+{
+    stateOfCallback.first = false;
+    stateOfCallback.second = false;
+    return sdbusplus::com::ibm::PLDM::server::PCIeTopology::pcIeTopologyRefresh(
+        true);
+}
+
+bool PCIETopology::callbackGetPCIeTopology(bool value)
+{
+    stateOfCallback.first = value;
+
+    if (stateOfCallback.first && stateOfCallback.second)
+    {
+        // if both the states of the effecter are set only then update the
+        // property
+        return updateTopologyRefresh();
+    }
+    return false;
+}
+
+bool PCIETopology::callbackGetCableInfo(bool value)
+{
+    stateOfCallback.second = value;
+
+    if (stateOfCallback.first && stateOfCallback.second)
+    {
+        // if both the states of the effecter are set only then update the
+        // property
+        return updateTopologyRefresh();
+    }
+    return false;
+}
+
+bool PCIETopology::pcIeTopologyRefresh(bool value)
+{
+    std::vector<set_effecter_state_field> stateField;
+    std::vector<set_effecter_state_field> stateField1;
+
+    if (value ==
+        sdbusplus::com::ibm::PLDM::server::PCIeTopology::pcIeTopologyRefresh())
+    {
+        stateField.push_back({PLDM_NO_CHANGE, 0});
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            pcIeTopologyRefresh(value);
+    }
+    else
+    {
+        stateField.push_back({PLDM_REQUEST_SET, GET_PCIE_TOPOLOGY});
+        stateField1.push_back({PLDM_REQUEST_SET, GET_CABLE_INFO});
+    }
+
+    if (value && hostEffecterParser)
+    {
+        uint16_t effecterID = getEffecterID();
+
+        if (effecterID == 0)
+        {
+            return false;
+        }
+        // callback is done only when setting the effecter is successful
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctpEid, effecterID, 1, stateField,
+            std::bind(
+                std::mem_fn(&pldm::dbus::PCIETopology::callbackGetPCIeTopology),
+                this, std::placeholders::_1),
+            value);
+
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctpEid, effecterID, 1, stateField1,
+            std::bind(
+                std::mem_fn(&pldm::dbus::PCIETopology::callbackGetCableInfo),
+                this, std::placeholders::_1),
+            value);
+    }
+
+    // Set the property to true only when the two set state effecter calls are
+    // successful
+    if (stateOfCallback.first && stateOfCallback.second)
+    {
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            pcIeTopologyRefresh(true);
+    }
+    else
+    {
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            pcIeTopologyRefresh(false);
+    }
+}
+
+bool PCIETopology::savePCIeTopologyInfo() const
+{
+    return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+        savePCIeTopologyInfo();
+}
+
+bool PCIETopology::savePCIeTopologyInfo(bool value)
+{
+    std::vector<set_effecter_state_field> stateField;
+
+    if (value ==
+        sdbusplus::com::ibm::PLDM::server::PCIeTopology::savePCIeTopologyInfo())
+    {
+        stateField.push_back({PLDM_NO_CHANGE, 0});
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            savePCIeTopologyInfo(value);
+    }
+    else
+    {
+        stateField.push_back({PLDM_REQUEST_SET, SAVE_PCIE_TOPLOGY});
+    }
+
+    if (value && hostEffecterParser)
+    {
+        uint16_t effecterID = getEffecterID();
+
+        if (effecterID == 0)
+        {
+            return false;
+        }
+
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctpEid, effecterID, 1, stateField, nullptr, value);
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            savePCIeTopologyInfo(false);
+    }
+    return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+        savePCIeTopologyInfo(value);
+}
+
+uint16_t PCIETopology::getEffecterID()
+{
+    uint16_t effecterID = 0;
+
+    pldm::pdr::EntityType entityType = PLDM_ENTITY_GROUP | 0x8000;
+    auto stateEffecterPDRs = pldm::utils::findStateEffecterPDR(
+        mctpEid, entityType,
+        static_cast<uint16_t>(PLDM_OEM_IBM_PCIE_TOPOLOGY_ACTIONS),
+        hostEffecterParser->getPldmPDR());
+    if (stateEffecterPDRs.empty())
+    {
+        std::cerr
+            << "PCIe Topology: The state set PDR can not be found, entityType = "
+            << entityType << std::endl;
+        return effecterID;
+    }
+    for (auto& rep : stateEffecterPDRs)
+    {
+        auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(rep.data());
+        effecterID = pdr->effecter_id;
+        break;
+    }
+    return effecterID;
+}
+
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/dbus/pcie_topology.hpp
+++ b/host-bmc/dbus/pcie_topology.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "libpldm/pdr.h"
+
+#include "../dbus_to_host_effecters.hpp"
+#include "common/utils.hpp"
+
+#include <com/ibm/PLDM/PCIeTopology/server.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdbusplus/server/object.hpp>
+
+#include <string>
+#include <utility>
+
+namespace pldm
+{
+namespace dbus
+{
+using TopologyObj = sdbusplus::server::object::object<
+    sdbusplus::com::ibm::PLDM::server::PCIeTopology>;
+
+class PCIETopology : public TopologyObj
+{
+  public:
+    PCIETopology() = delete;
+    ~PCIETopology() = default;
+    PCIETopology(const PCIETopology&) = delete;
+    PCIETopology& operator=(const PCIETopology&) = delete;
+    PCIETopology(PCIETopology&&) = default;
+    PCIETopology& operator=(PCIETopology&&) = default;
+
+    PCIETopology(sdbusplus::bus::bus& bus, const std::string& objPath,
+                 pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+                 uint8_t mctpEid) :
+        TopologyObj(bus, objPath.c_str()),
+        hostEffecterParser(hostEffecterParser), mctpEid(mctpEid)
+
+    {}
+
+    bool pcIeTopologyRefresh(bool value) override;
+
+    bool pcIeTopologyRefresh() const override;
+
+    bool savePCIeTopologyInfo(bool value) override;
+
+    bool savePCIeTopologyInfo() const override;
+
+    uint16_t getEffecterID();
+
+    bool updateTopologyRefresh();
+
+    /** @brief callback to getPCIeTopology **/
+    bool callbackGetPCIeTopology(bool value);
+
+    /** @brief callback to getCableInfo **/
+    bool callbackGetCableInfo(bool value);
+
+  private:
+    /** @brief Pointer to host effecter parser */
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser;
+
+    /** mctp endpoint id */
+    uint8_t mctpEid;
+
+    /** Pair to indicate the state of callbacks */
+    std::pair<bool, bool> stateOfCallback = std::make_pair(false, false);
+};
+
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/test/meson.build
+++ b/host-bmc/test/meson.build
@@ -21,6 +21,7 @@ test_sources = [
   '../dbus/serialize.cpp',
   '../dbus/custom_dbus.cpp',
   '../dbus/software_version.cpp',
+  '../dbus/pcie_topology.cpp',
 ]
 
 tests = [

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -42,6 +42,7 @@ sources = [
   '../host-bmc/dbus/location_code.cpp',
   '../host-bmc/dbus/software_version.cpp',
   '../host-bmc/dbus/deserialize.cpp',
+  '../host-bmc/dbus/pcie_topology.cpp',
   'event_parser.cpp'
 ]
 

--- a/oem/ibm/libpldm/state_set_oem_ibm.h
+++ b/oem/ibm/libpldm/state_set_oem_ibm.h
@@ -19,6 +19,7 @@ enum ibm_oem_pldm_state_set_ids {
 	PLDM_OEM_IBM_PANEL_TRIGGER_STATE = 32778,
 	PLDM_OEM_IBM_SLOT_ENABLE_EFFECTER_STATE = 32779,
 	PLDM_OEM_IBM_SLOT_ENABLE_SENSOR_STATE = 32780,
+	PLDM_OEM_IBM_PCIE_TOPOLOGY_ACTIONS = 32781,
 };
 
 enum ibm_slot_enable_effecter_state {
@@ -72,6 +73,12 @@ enum ibm_oem_pldm_state_set_sbe_hreset_state_values {
 	SBE_HRESET_NOT_READY = 0x1,
 	SBE_HRESET_READY = 0x2,
 	SBE_HRESET_FAILED = 0x3,
+};
+
+enum pldm_oem_pcie_topology_actions {
+	GET_PCIE_TOPOLOGY = 0x1,
+	GET_CABLE_INFO = 0x2,
+	SAVE_PCIE_TOPLOGY = 0x03,
 };
 
 #ifdef __cplusplus

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -70,16 +70,19 @@ class Handler : public oem_platform::Handler
             uint8_t mctp_eid, pldm::dbus_api::Requester& requester,
             sdeventplus::Event& event, pldm_pdr* repo,
             pldm::requester::Handler<pldm::requester::Request>* handler,
-            pldm_entity_association_tree* bmcEntityTree) :
+            pldm_entity_association_tree* bmcEntityTree,
+            pldm::host_effecters::HostEffecterParser* hostEffecterParser) :
         oem_platform::Handler(dBusIntf),
         codeUpdate(codeUpdate), slotHandler(slotHandler),
         platformHandler(nullptr), mctp_fd(mctp_fd), mctp_eid(mctp_eid),
         requester(requester), event(event), pdrRepo(repo), handler(handler),
-        bmcEntityTree(bmcEntityTree)
+        bmcEntityTree(bmcEntityTree), hostEffecterParser(hostEffecterParser)
     {
         codeUpdate->setVersions();
         pldm::responder::utils::clearLicenseStatus();
         setEventReceiverCnt = 0;
+        pldm::responder::utils::hostPCIETopologyIntf(mctp_eid,
+                                                     hostEffecterParser);
 
         using namespace sdbusplus::bus::match::rules;
         hostOffMatch = std::make_unique<sdbusplus::bus::match::match>(
@@ -474,6 +477,9 @@ class Handler : public oem_platform::Handler
 
     /** @brief Pointer to BMC's entity association tree */
     pldm_entity_association_tree* bmcEntityTree;
+
+    /** @brief Pointer to host effecter parser */
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser;
 
     /** @brief D-Bus property changed signal match */
     std::unique_ptr<sdbusplus::bus::match::match> hostOffMatch;

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -493,6 +493,14 @@ bool checkFruPresence(const char* objPath)
     return isPresent;
 }
 
+void hostPCIETopologyIntf(
+    uint8_t mctp_eid,
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser)
+{
+    CustomDBus::getCustomDBus().implementPcieTopologyInterface(
+        "/xyz/openbmc_project/pldm", mctp_eid, hostEffecterParser);
+}
+
 } // namespace utils
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "host-bmc/dbus_to_host_effecters.hpp"
+
 #include <nlohmann/json.hpp>
 
 #include <filesystem>
@@ -122,6 +124,15 @@ bool checkFruPresence(const char* objPath);
  */
 void findPortObjects(const std::string& cardObjPath,
                      std::vector<std::string>& portObjects);
+
+/** @brief host PCIE Topology Interface
+ *  @param[in] mctp_eid - MCTP Endpoint ID
+ *  @param[in] hostEffecterParser - Pointer to host effecter parser
+ */
+void hostPCIETopologyIntf(
+    uint8_t mctp_eid,
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser);
+
 } // namespace utils
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
+++ b/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
@@ -49,7 +49,7 @@ class MockOemPlatformHandler : public oem_ibm_platform::Handler
                            sdeventplus::Event& event) :
         oem_ibm_platform::Handler(dBusIntf, codeUpdate, slotHandler, mctp_fd,
                                   mctp_eid, requester, event, nullptr, nullptr,
-                                  nullptr)
+                                  nullptr, nullptr)
     {}
     MOCK_METHOD(uint16_t, getNextEffecterId, ());
     MOCK_METHOD(uint16_t, getNextSensorId, ());
@@ -76,7 +76,7 @@ TEST(OemSetStateEffecterStatesHandler, testGoodRequest)
 
     oemPlatformHandler = std::make_unique<oem_ibm_platform::Handler>(
         mockDbusHandler.get(), mockCodeUpdate.get(), nullptr, 0x1, 0x9,
-        requester, event, nullptr, nullptr, nullptr);
+        requester, event, nullptr, nullptr, nullptr, nullptr);
 
     auto rc = oemPlatformHandler->getOemStateSensorReadingsHandler(
         entityID_, entityInstance_, containerId_, stateSetId_, compSensorCnt_,

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -241,6 +241,14 @@ int main(int argc, char** argv)
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     std::unique_ptr<oem_fru::Handler> oemFruHandler{};
 
+    if (hostEID)
+    {
+        hostEffecterParser =
+            std::make_unique<pldm::host_effecters::HostEffecterParser>(
+                &dbusImplReq, sockfd, pdrRepo.get(), &dbusHandler,
+                HOST_JSONS_DIR, &reqHandler);
+    }
+
 #ifdef OEM_IBM
     std::unique_ptr<pldm::responder::CodeUpdate> codeUpdate =
         std::make_unique<pldm::responder::CodeUpdate>(&dbusHandler);
@@ -249,7 +257,8 @@ int main(int argc, char** argv)
     codeUpdate->clearDirPath(LID_STAGING_DIR);
     oemPlatformHandler = std::make_unique<oem_ibm_platform::Handler>(
         &dbusHandler, codeUpdate.get(), slotHandler.get(), sockfd, hostEID,
-        dbusImplReq, event, pdrRepo.get(), &reqHandler, bmcEntityTree.get());
+        dbusImplReq, event, pdrRepo.get(), &reqHandler, bmcEntityTree.get(),
+        hostEffecterParser.get());
     oemFruHandler =
         std::make_unique<oem_ibm_fru::Handler>(&dbusHandler, pdrRepo.get());
     codeUpdate->setOemPlatformHandler(oemPlatformHandler.get());
@@ -269,10 +278,6 @@ int main(int argc, char** argv)
         associationsParser =
             std::make_unique<pldm::host_associations::HostAssociationsParser>(
                 HOST_JSONS_DIR);
-        hostEffecterParser =
-            std::make_unique<pldm::host_effecters::HostEffecterParser>(
-                &dbusImplReq, sockfd, pdrRepo.get(), &dbusHandler,
-                HOST_JSONS_DIR, &reqHandler);
         hostPDRHandler = std::make_shared<HostPDRHandler>(
             sockfd, hostEID, event, pdrRepo.get(), EVENTS_JSONS_DIR,
             entityTree.get(), bmcEntityTree.get(), hostEffecterParser.get(),


### PR DESCRIPTION
This commit adds support to implement the topology interface
defined here - https://github.com/ibm-openbmc/phosphor-dbus-interfaces/blob/1020/yaml/com/ibm/PLDM/PCIeTopology.interface.yaml
and also host it under PLDM and also supports the set and get
property under the topology interface.

When PCIeTopologyRefresh property is set to true, we send the
setEffecterCall to host to set the effecter state 1 and 2.
When SaveTopologyRefresh property is set to true we send the
setEffecterCall to host to set the effecter state to 3 and then
sets it back to false.

Tested using busctl commands.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>