### PR TITLE
FFDC enhancement

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -492,6 +492,9 @@ void HostPDRHandler::mergeEntityAssociations(const std::vector<uint8_t>& pdr)
 void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
                                                uint8_t eventDataFormat)
 {
+    std::cerr
+        << "Sending the repo change event after merging the PDRs, MCTP_ID:"
+        << (unsigned)mctp_eid << std::endl;
     assert(eventDataFormat == FORMAT_IS_PDR_HANDLES);
 
     // Extract from the PDR repo record handles of PDRs we want the host
@@ -707,6 +710,12 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
 
                     terminusHandle = tlpdr->terminus_handle;
                     tid = tlpdr->tid;
+                    std::cerr
+                        << "Got a terminus Locator PDR with TID:"
+                        << (unsigned)tid
+                        << " and Terminus handle:" << terminusHandle
+                        << " with Valid bit as:" << (unsigned)tlpdr->validity
+                        << std::endl;
                     auto terminus_locator_type = tlpdr->terminus_locator_type;
                     if (terminus_locator_type ==
                         PLDM_TERMINUS_LOCATOR_TYPE_MCTP_EID)
@@ -837,6 +846,13 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
     }
     if (!nextRecordHandle)
     {
+        pldm_pdr_record* firstRecord = repo->first;
+        pldm_pdr_record* lastRecord = repo->last;
+        std::cerr << "First Record in the repo after PDR exchange is: "
+                  << firstRecord->record_handle << std::endl;
+        std::cerr << "Last Record in the repo after PDR exchange is:"
+                  << lastRecord->record_handle << std::endl;
+
         pldm::hostbmc::utils::updateEntityAssociation(
             entityAssociations, entityTree, objPathMap, oemPlatformHandler);
 

--- a/libpldmresponder/pdr_utils.cpp
+++ b/libpldmresponder/pdr_utils.cpp
@@ -277,7 +277,8 @@ std::vector<uint8_t> fetchBitMap(const std::vector<std::vector<uint8_t>>& pdrs)
                 tempStream << std::setfill('0') << std::setw(2) << std::hex
                            << byte << " ";
             }
-            std::cout << tempStream.str() << std::endl;
+            std::cout << "Panel:BitMap received: " << tempStream.str()
+                      << std::endl;
             if (compEffCount)
             {
                 statesPtr += sizeof(state_effecter_possible_states) +

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -515,6 +515,8 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                                        uint8_t /*formatVersion*/, uint8_t tid,
                                        size_t eventDataOffset)
 {
+    std::cerr << "Got a repo change event from TID: " << (unsigned)tid
+              << std::endl;
     uint8_t eventDataFormat{};
     uint8_t eventDataOperation{};
     uint8_t numberOfChangeRecords{};

--- a/oem/ibm/libpldmresponder/file_io_type_cert.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.cpp
@@ -90,8 +90,6 @@ int CertHandler::read(uint32_t offset, uint32_t& length, Response& response,
 int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
                        oem_platform::Handler* /*oemPlatformHandler*/)
 {
-    std::cout << "Client certificate write, file handle: " << fileHandle
-              << std::endl;
     auto it = certMap.find(certType);
     if (it == certMap.end())
     {


### PR DESCRIPTION
1. Adding trace when we get the repo change event which indicates
   did PLDM exchange between BMC and host happen (i.e. did BMC see
   the "PDRs changed" event come in from host, and read out the PDRS).

2. Adding trace when we send repo change event back after
   merging the PDRs which indicates did host come down and read
   all the PDRs after BMC told it that the PDR repo changed.

3. printing the first and last record handle in bmc repo after each
   PDR exchange.

4. Adding trace when we get a TerminusLocator PDR from host.

Solution for #SW548456

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>