### PR TITLE
mex : Set the real mex firmware version from phyp

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1472,32 +1472,24 @@ void HostPDRHandler::setLocationCode(
                             std::string(reinterpret_cast<const char*>(
                                             tlv.fruFieldValue.data()),
                                         tlv.fruFieldLen));
-
-                        /* Remove this once phyp support is in place */
-                        if (node.entity_type == PLDM_ENTITY_SYSTEM_CHASSIS)
-                        {
-                            CustomDBus::getCustomDBus().setSoftwareVersion(
-                                entity.first, "sample_mex_version");
-                        }
-                        /* Remove this once phyp support is in place */
                     }
                 }
             }
-            /* Enable this once phyp support is in place
             else
             {
-                for(auto& tlv : data.fruTLV)
+                for (auto& tlv : data.fruTLV)
                 {
-                    if(tlv.fruFieldType == PLDM_FRU_FIELD_TYPE_VERSION &&
-            node.entity_type == PLDM_ENTITY_SYSTEM_CHASSIS)
+                    if (tlv.fruFieldType == PLDM_FRU_FIELD_TYPE_VERSION &&
+                        node.entity_type == PLDM_ENTITY_SYSTEM_CHASSIS)
                     {
-                        CustomDBus::getCustomDBus().setSoftwareVersion(entity.first,
+                        CustomDBus::getCustomDBus().setSoftwareVersion(
+                            entity.first,
                             std::string(reinterpret_cast<const char*>(
                                             tlv.fruFieldValue.data()),
-                                        tlv.fruFieldLen))
+                                        tlv.fruFieldLen));
                     }
                 }
-            }*/
+            }
         }
     }
 }


### PR DESCRIPTION
Previously we had just put a dummy string in version property
to unblock other teams, now that phyp is already supporting it
we have removed that hardcoded string and setting it with real
data that is coming from phyp.

Tested by:
1. power on to phyp standby
2. check the mex chassis dbus object
xyz.openbmc_project.Software.Version                 interface -         -                                        -
.Purpose                                             property  s         "xyz.openbmc_project.Software.Version.V… emits-change writable
.Version                                             property  s         "03MEX200924a"                           emits-change writable
3. check the mex version using phyp macro and make sure both match
Rack    Unit  Location           Status                     Start Time           partnumber    partnumber
------  ----  -----------------  -------------------------  -------------------  ------------  ------------
0x3C00  0x0   U78DA.ND0.WZS004K  Not Applicable
0x3C00  0x1   U78DA.ND0.WZS004K  Not Applicable
0x3C03  0x0   U78CD.001.FZHCD44  Not Needed                                      03MEX200924a  03MEX200924a

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>