### PR TITLE
PLDM: Error log when host does not respond to newFileAvailable

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_cert.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.cpp
@@ -29,7 +29,8 @@ int CertHandler::writeFromMemory(uint32_t offset, uint32_t length,
     auto it = certMap.find(certType);
     if (it == certMap.end())
     {
-        std::cerr << "file for type " << certType << " doesn't exist\n";
+        std::cerr << "CertHandler::writeFromMemory:file for type " << certType
+                  << " doesn't exist\n";
         return PLDM_ERROR;
     }
 
@@ -70,8 +71,9 @@ int CertHandler::readIntoMemory(uint32_t offset, uint32_t& length,
 int CertHandler::read(uint32_t offset, uint32_t& length, Response& response,
                       oem_platform::Handler* /*oemPlatformHandler*/)
 {
-    std::cout << "Read file response for Sign CSR, file handle: " << fileHandle
-              << std::endl;
+    std::cout
+        << "CertHandler::read:Read file response for Sign CSR, file handle: "
+        << fileHandle << std::endl;
     std::string filePath = certFilePath;
     filePath += "CSR_" + std::to_string(fileHandle);
     if (certType != PLDM_FILE_TYPE_CERT_SIGNING_REQUEST)
@@ -93,7 +95,8 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
     auto it = certMap.find(certType);
     if (it == certMap.end())
     {
-        std::cerr << "file for type " << certType << " doesn't exist\n";
+        std::cerr << "CertHandler::write:file for type " << certType
+                  << " doesn't exist\n";
         return PLDM_ERROR;
     }
 
@@ -101,14 +104,14 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
     int rc = lseek(fd, offset, SEEK_SET);
     if (rc == -1)
     {
-        std::cerr << "lseek failed, ERROR=" << errno << ", OFFSET=" << offset
-                  << "\n";
+        std::cerr << "CertHandler::write:lseek failed, ERROR=" << errno
+                  << ", OFFSET=" << offset << "\n";
         return PLDM_ERROR;
     }
     rc = ::write(fd, buffer, length);
     if (rc == -1)
     {
-        std::cerr << "file write failed, ERROR=" << errno
+        std::cerr << "CertHandler::write:file write failed, ERROR=" << errno
                   << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
         return PLDM_ERROR;
     }
@@ -149,9 +152,10 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
             }
             catch (const std::exception& e)
             {
-                std::cerr << "failed to set Client certificate, "
-                             "ERROR="
-                          << e.what() << "\n";
+                std::cerr
+                    << "CertHandler::write:failed to set Client certificate, "
+                       "ERROR="
+                    << e.what() << "\n";
                 return PLDM_ERROR;
             }
             PropertyValue valueStatus{
@@ -162,7 +166,7 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
             try
             {
                 std::cout
-                    << "Client cert write, status: complete. File handle: "
+                    << "CertHandler::write:Client cert write, status: complete. File handle: "
                     << fileHandle << std::endl;
                 pldm::utils::DBusHandler().setDbusProperty(dbusMappingStatus,
                                                            valueStatus);
@@ -170,7 +174,7 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
             catch (const std::exception& e)
             {
                 std::cerr
-                    << "failed to set status property of certicate entry, "
+                    << "CertHandler::write:failed to set status property of certicate entry, "
                        "ERROR="
                     << e.what() << "\n";
                 return PLDM_ERROR;
@@ -184,14 +188,15 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
                                     certEntryIntf, "Status", "string"};
             try
             {
-                std::cout << "Client cert write, status: Bad CSR. File handle: "
-                          << fileHandle << std::endl;
+                std::cout
+                    << "CertHandler::write:Client cert write, status: Bad CSR. File handle: "
+                    << fileHandle << std::endl;
                 pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
             }
             catch (const std::exception& e)
             {
                 std::cerr
-                    << "failed to set status property of certicate entry, "
+                    << "CertHandler::write:failed to set status property of certicate entry, "
                        "ERROR="
                     << e.what() << "\n";
                 return PLDM_ERROR;
@@ -216,8 +221,9 @@ int CertHandler::newFileAvailable(uint64_t length)
     }
     if (certType == PLDM_FILE_TYPE_SIGNED_CERT)
     {
-        std::cout << "new file available client cert file, file handle: "
-                  << fileHandle << std::endl;
+        std::cout
+            << "CertHandler::newFileAvailable:new file available client cert file, file handle: "
+            << fileHandle << std::endl;
         fileFd = open(
             (filePath + "ClientCert_" + std::to_string(fileHandle)).c_str(),
             flags, S_IRUSR | S_IWUSR);
@@ -229,8 +235,9 @@ int CertHandler::newFileAvailable(uint64_t length)
     }
     if (fileFd == -1)
     {
-        std::cerr << "failed to open file for type " << certType
-                  << " ERROR=" << errno << "\n";
+        std::cerr
+            << "CertHandler::newFileAvailable:failed to open file for type "
+            << certType << " ERROR=" << errno << "\n";
         return PLDM_ERROR;
     }
     certMap.emplace(certType, std::tuple(fileFd, length));
@@ -259,16 +266,18 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
     {
         if (certSigningStatus == PLDM_SUCCESS)
         {
-            std::cerr << "new file available client cert file, file handle: "
-                      << fileHandle << std::endl;
+            std::cerr
+                << "CertHandler::newFileAvailableWithMetaData:new file available client cert file, file handle: "
+                << fileHandle << std::endl;
             fileFd = open(
                 (filePath + "ClientCert_" + std::to_string(fileHandle)).c_str(),
                 flags, S_IRUSR | S_IWUSR);
         }
         else if (certSigningStatus == PLDM_INVALID_CERT_DATA)
         {
-            std::cerr << "client cert file Invalid data, file handle: "
-                      << fileHandle << std::endl;
+            std::cerr
+                << "newFileAvailableWithMetaData:client cert file Invalid data, file handle: "
+                << fileHandle << std::endl;
             DBusMapping dbusMapping{certObjPath + std::to_string(fileHandle),
                                     certEntryIntf, "Status", "string"};
             std::string status = "xyz.openbmc_project.Certs.Entry.State.BadCSR";
@@ -280,7 +289,7 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
             catch (const std::exception& e)
             {
                 std::cerr
-                    << "Failed to set status property of certicate entry, "
+                    << "newFileAvailableWithMetaData:Failed to set status property of certicate entry, "
                        "ERROR="
                     << e.what() << "\n";
                 return PLDM_ERROR;
@@ -294,8 +303,9 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
     }
     if (fileFd == -1)
     {
-        std::cerr << "failed to open file for type " << certType
-                  << " ERROR=" << errno << "\n";
+        std::cerr
+            << "newFileAvailableWithMetaData:failed to open file for type "
+            << certType << " ERROR=" << errno << "\n";
         return PLDM_ERROR;
     }
     certMap.emplace(certType, std::tuple(fileFd, length));
@@ -330,9 +340,10 @@ int CertHandler::fileAckWithMetaData(uint8_t fileStatus,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to set status property of certicate entry, "
-                         "ERROR="
-                      << e.what() << "\n";
+            std::cerr
+                << "CertHandler::fileAckWithMetaData:Failed to set status property of certicate entry, "
+                   "ERROR="
+                << e.what() << "\n";
             return PLDM_ERROR;
         }
     }

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -22,7 +22,9 @@ static constexpr auto resDumpProgressIntf =
     "xyz.openbmc_project.Common.Progress";
 static constexpr auto resDumpStatus =
     "xyz.openbmc_project.Common.Progress.OperationStatus.Failed";
-
+static constexpr auto certFilePath = "/var/lib/ibm/bmcweb/";
+constexpr auto certObjPath = "/xyz/openbmc_project/certs/ca/entry/";
+constexpr auto certEntryIntf = "xyz.openbmc_project.Certs.Entry";
 DbusToFileHandler::DbusToFileHandler(
     int mctp_fd, uint8_t mctp_eid, dbus_api::Requester* requester,
     sdbusplus::message::object_path resDumpCurrentObjPath,
@@ -275,7 +277,7 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
 {
     if (requester == NULL)
     {
-        std::cerr << "Failed to send file to host.";
+        std::cerr << "newFileAvailableSendToHost:Failed to send file to host.";
         pldm::utils::reportError(
             "xyz.openbmc_project.bmc.pldm.SendFileToHostFail",
             pldm::PelSeverity::ERROR);
@@ -291,29 +293,61 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
     if (rc != PLDM_SUCCESS)
     {
         requester->markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_new_file_req, rc = " << rc << std::endl;
+        std::cerr
+            << "newFileAvailableSendToHost:Failed to encode_new_file_req, rc = "
+            << rc << std::endl;
         return;
     }
-    std::cout << "Sending Sign CSR request to Host for fileHandle: "
-              << fileHandle << std::endl;
-    auto newFileAvailableRespHandler = [](mctp_eid_t /*eid*/,
-                                          const pldm_msg* response,
-                                          size_t respMsgLen) {
+    std::cout
+        << "newFileAvailableSendToHost:Sending Sign CSR request to Host for fileHandle: "
+        << fileHandle << std::endl;
+    auto newFileAvailableRespHandler = [fileHandle,
+                                        type](mctp_eid_t /*eid*/,
+                                              const pldm_msg* response,
+                                              size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
             std::cerr << "Failed to receive response for NewFileAvailable "
                          "command\n";
+            if (type == PLDM_FILE_TYPE_CERT_SIGNING_REQUEST)
+            {
+                std::string filePath = certFilePath;
+                filePath += "CSR_" + std::to_string(fileHandle);
+                fs::remove(filePath);
+
+                DBusMapping dbusMapping{certObjPath +
+                                            std::to_string(fileHandle),
+                                        certEntryIntf, "Status", "string"};
+                PropertyValue value =
+                    "xyz.openbmc_project.Certs.Entry.State.Pending";
+                try
+                {
+                    pldm::utils::DBusHandler().setDbusProperty(dbusMapping,
+                                                               value);
+                }
+                catch (const std::exception& e)
+                {
+                    std::cerr
+                        << "newFileAvailableSendToHost:Failed to set status property of certicate entry, "
+                           "ERROR="
+                        << e.what() << "\n";
+                }
+
+                pldm::utils::reportError(
+                    "xyz.openbmc_project.bmc.pldm.SendFileToHostFail",
+                    pldm::PelSeverity::ERROR);
+            }
             return;
         }
         uint8_t completionCode{};
         auto rc = decode_new_file_resp(response, respMsgLen, &completionCode);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_new_file_resp for file, or"
-                      << " Host returned error for new_file_available"
-                      << " rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << "\n";
+            std::cerr
+                << "newFileAvailableSendToHost:Failed to decode_new_file_resp for file, or"
+                << " Host returned error for new_file_available"
+                << " rc=" << rc
+                << ", cc=" << static_cast<unsigned>(completionCode) << "\n";
             pldm::utils::reportError(
                 "xyz.openbmc_project.bmc.pldm.DecodeNewFileResponseFail",
                 pldm::PelSeverity::ERROR);
@@ -324,7 +358,8 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
         std::move(requestMsg), std::move(newFileAvailableRespHandler));
     if (rc)
     {
-        std::cerr << "Failed to send NewFileAvailable Request to Host\n";
+        std::cerr
+            << "newFileAvailableSendToHost:Failed to send NewFileAvailable Request to Host\n";
         pldm::utils::reportError(
             "xyz.openbmc_project.bmc.NewFileAvailableRequestFail",
             pldm::PelSeverity::ERROR);


### PR DESCRIPTION
This commit logs an error log when the host does not
respond to newFileAvailable command sent and also set the
status of certificate signing request to Pending.

This commit also enhances the FFDC which tells from
which function the errors are logged

DEFECT:SW549145

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>