### PR TITLE
oem-ibm: Unmap the memory selectively

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -119,13 +119,21 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
     {
         pageAlignedLength += pageSize;
     }
-
-    auto mmapCleanup = [pageAlignedLength](void* vgaMem) {
-        munmap(vgaMem, pageAlignedLength);
+    int rc = 0;
+    auto mmapCleanup = [pageAlignedLength, &rc](void* vgaMem) {
+        if (rc != -EINTR)
+        {
+            munmap(vgaMem, pageAlignedLength);
+        }
+        else
+        {
+            std::cerr
+                << "Received interrupt during DMA transfer. Skipping Unmap"
+                << std::endl;
+        }
     };
 
     int dmaFd = -1;
-    int rc = 0;
     dmaFd = open(xdmaDev, O_RDWR);
     if (dmaFd < 0)
     {


### PR DESCRIPTION
These changes will handle the case where host crashes in the
middle of outofband DMA transfer.

With the existing code, after the DMA transfer PLDM unmaps
the memory and closes the file handler(XDMA FD).
Closing the XDMA file handler will reset the XDMA Driver which
internally will unmap the memory if not already unmapped.

But when the host crashes during the DMA transfer,
PLDM receives EINTR(interrupt) and it unmaps the memory.
XDMA driver doesn't know that the operation is interrupted,
it still thinks that operation is in progress.
munmap will hang if xdma driver thinks the operation is in progress.

To solve the PLDM Hang in munmap, in case of EINTR during DMA transfer
PLDM should skip munmap and just close the file handler.
Once PLDM closes the file handler driver gets reset and
it munmaps the memory which is not unmapped yet.

Tested: Powered on the host and confirmed if the munmap is called
for all possitive cases.
Hardcoded return value to EINTR and confirmed that memory
is not getting unmapped

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>