### PR TITLE
Update persistent DBUS objects from Host 

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -2,6 +2,9 @@
 
 #include "libpldm/state_set.h"
 
+#include "serialize.hpp"
+#include "type.hpp"
+
 namespace pldm
 {
 namespace dbus
@@ -350,6 +353,133 @@ void CustomDBus::updateTopologyProperty(bool value)
     {
         pcietopology.at("/xyz/openbmc_project/pldm")
             ->pcIeTopologyRefresh(value);
+    }
+}
+
+void CustomDBus::deleteObject(const std::string& path)
+{
+    if (location.contains(path))
+    {
+        location.erase(location.find(path));
+    }
+
+    if (operationalStatus.contains(path))
+    {
+        operationalStatus.erase(operationalStatus.find(path));
+    }
+
+    if (presentStatus.contains(path))
+    {
+        presentStatus.erase(presentStatus.find(path));
+    }
+
+    if (chassis.contains(path))
+    {
+        chassis.erase(chassis.find(path));
+    }
+
+    if (cpuCore.contains(path))
+    {
+        cpuCore.erase(cpuCore.find(path));
+    }
+
+    if (fan.contains(path))
+    {
+        fan.erase(fan.find(path));
+    }
+
+    if (connector.contains(path))
+    {
+        connector.erase(connector.find(path));
+    }
+
+    if (vrm.contains(path))
+    {
+        vrm.erase(vrm.find(path));
+    }
+
+    if (global.contains(path))
+    {
+        global.erase(global.find(path));
+    }
+
+    if (powersupply.contains(path))
+    {
+        powersupply.erase(powersupply.find(path));
+    }
+
+    if (board.contains(path))
+    {
+        board.erase(board.find(path));
+    }
+
+    if (fabricAdapter.contains(path))
+    {
+        fabricAdapter.erase(fabricAdapter.find(path));
+    }
+
+    if (motherboard.contains(path))
+    {
+        motherboard.erase(motherboard.find(path));
+    }
+
+    if (availabilityState.contains(path))
+    {
+        availabilityState.erase(availabilityState.find(path));
+    }
+
+    if (_enabledStatus.contains(path))
+    {
+        _enabledStatus.erase(_enabledStatus.find(path));
+    }
+
+    if (pcieSlot.contains(path))
+    {
+        pcieSlot.erase(pcieSlot.find(path));
+    }
+
+    if (codLic.contains(path))
+    {
+        codLic.erase(codLic.find(path));
+    }
+
+    if (associations.contains(path))
+    {
+        associations.erase(associations.find(path));
+    }
+
+    if (ledGroup.contains(path))
+    {
+        ledGroup.erase(ledGroup.find(path));
+    }
+
+    if (softWareVersion.contains(path))
+    {
+        softWareVersion.erase(softWareVersion.find(path));
+    }
+}
+
+void CustomDBus::removeDBus(const std::vector<uint16_t> types)
+{
+    if (types.empty())
+    {
+        return;
+    }
+
+    auto savedObjs = pldm::serialize::Serialize::getSerialize().getSavedObjs();
+    for (const auto& type : types)
+    {
+        if (!savedObjs.contains(type))
+        {
+            continue;
+        }
+
+        std::cerr << "Deleting the dbus objects of type : " << (unsigned)type
+                  << std::endl;
+        for (const auto& [path, entites] : savedObjs.at(type))
+        {
+            deleteObject(path);
+        }
     }
 }
 

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -253,6 +253,12 @@ class CustomDBus
      */
     void updateTopologyProperty(bool value);
 
+    /** @brief Remove DBus objects from cache
+     *
+     *  @param[in] types  - entity type
+     */
+    void removeDBus(const std::vector<uint16_t> types);
+
   private:
     std::unordered_map<ObjectPath, std::unique_ptr<LocationCode>> location;
     std::unordered_map<ObjectPath, std::unique_ptr<OperationalStatus>>
@@ -280,6 +286,12 @@ class CustomDBus
     std::unordered_map<ObjectPath, std::unique_ptr<SoftWareVersion>>
         softWareVersion;
     std::unordered_map<ObjectPath, std::unique_ptr<PCIETopology>> pcietopology;
+
+    /** @brief Remove all DBus object paths from cache
+     *
+     *  @param[in] types  - entity type
+     */
+    void deleteObject(const std::string& path);
 };
 
 } // namespace dbus

--- a/host-bmc/dbus/serialize.cpp
+++ b/host-bmc/dbus/serialize.cpp
@@ -100,5 +100,33 @@ void Serialize::setObjectPathMaps(const ObjectPathMaps& maps)
     }
 }
 
+void Serialize::reSerialize(const std::vector<uint16_t> types)
+{
+    if (types.empty())
+    {
+        return;
+    }
+
+    for (const auto& type : types)
+    {
+        if (savedObjs.contains(type))
+        {
+            std::cerr << "Removing objects of type : " << (unsigned)type
+                      << " from the persistent cache\n";
+            savedObjs.erase(savedObjs.find(type));
+        }
+    }
+
+    auto dir = filePath.parent_path();
+    if (!fs::exists(dir))
+    {
+        fs::create_directories(dir);
+    }
+
+    std::ofstream os(filePath.c_str(), std::ios::binary);
+    cereal::JSONOutputArchive oarchive(os);
+    oarchive(this->savedObjs);
+}
+
 } // namespace serialize
 } // namespace pldm

--- a/host-bmc/dbus/serialize.hpp
+++ b/host-bmc/dbus/serialize.hpp
@@ -56,6 +56,10 @@ class Serialize
 
     void setObjectPathMaps(const ObjectPathMaps& maps);
 
+    void deleteObjsFromType(uint16_t type);
+
+    void reSerialize(const std::vector<uint16_t> types);
+
   private:
     dbus::SavedObjs savedObjs;
     fs::path filePath{PERSISTENT_FILE};

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -967,12 +967,6 @@ void HostPDRHandler::setHostFirmwareCondition()
                   << std::showbase
                   << static_cast<uint16_t>(response->payload[0]) << "\n";
         this->responseReceived = true;
-
-        if (!this->isRestoreDBusObj)
-        {
-            this->isRestoreDBusObj = true;
-            pldm::deserialize::restoreDbusObj(this);
-        }
     };
     rc = handler->registerRequest(mctp_eid, instanceId, PLDM_BASE,
                                   PLDM_GET_PLDM_VERSION, std::move(requestMsg),

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -404,9 +404,6 @@ class HostPDRHandler
     /** @brief request message instance id */
     uint8_t insId;
 
-    /** @brief Restore the identity of the object */
-    bool isRestoreDBusObj = false;
-
     /** @brief maps an object path to pldm_entity from the BMC's entity
      *         association tree
      */

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -468,6 +468,7 @@ class Handler : public CmdHandler
     bool pdrCreated;
     std::vector<fs::path> pdrJsonsDir;
     std::unique_ptr<sdeventplus::source::Defer> deferredGetPDREvent;
+    bool isFirstGetPDR = true;
 };
 
 /** @brief Function to check if the effecter falls in OEM range

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -6,6 +6,7 @@
 #include "common/flight_recorder.hpp"
 #include "common/utils.hpp"
 #include "dbus_impl_requester.hpp"
+#include "host-bmc/dbus/deserialize.hpp"
 #include "invoker.hpp"
 #include "requester/handler.hpp"
 #include "requester/request.hpp"
@@ -322,6 +323,8 @@ int main(int argc, char** argv)
     dbus_api::Pdr dbusImplPdr(bus, "/xyz/openbmc_project/pldm", pdrRepo.get());
     sdbusplus::xyz::openbmc_project::PLDM::server::Event dbusImplEvent(
         bus, "/xyz/openbmc_project/pldm");
+
+    pldm::deserialize::restoreDbusObj(hostPDRHandler.get());
 
 #endif
 


### PR DESCRIPTION
This commit destroy & create new core DBus objects for every
first getPDR command.

Refer ibm-openbmc/dev#3547

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>