### PR TITLE
Handling the sensor event sent for a sensor after a CM

### DIFF
--- a/host-bmc/dbus_to_event_handler.hpp
+++ b/host-bmc/dbus_to_event_handler.hpp
@@ -54,7 +54,6 @@ class DbusToPLDMEvent
         const pldm::responder::pdr_utils::Repo& repo,
         const pldm::responder::pdr_utils::DbusObjMaps& dbusMaps);
 
-  private:
     /** @brief Send state sensor event msg when a D-Bus property changes
      *  @param[in] sensorId - sensor id
      */
@@ -62,6 +61,7 @@ class DbusToPLDMEvent
         SensorId sensorId,
         const pldm::responder::pdr_utils::DbusObjMaps& dbusMaps);
 
+  private:
     /** @brief Send all of sensor event
      *  @param[in] eventType - PLDM Event types
      *  @param[in] eventDataVec - std::vector, contains send event data

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -1292,6 +1292,11 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
             sensorDbusObjMapsRef.emplace(
                 sensorId, std::make_tuple(std::move(dbusMappings),
                                           std::move(dbusValMaps)));
+
+            // creating a match for the newly added sensor
+            dbusToPLDMEventHandler->sendStateSensorEvent(sensorId,
+                                                         sensorDbusObjMapsRef);
+
             pldm::responder::pdr_utils::PdrEntry pdrEntry{};
             pdrEntry.data = entry.data();
             pdrEntry.size = pdrSize;

--- a/libpldmresponder/fru.hpp
+++ b/libpldmresponder/fru.hpp
@@ -7,6 +7,7 @@
 
 #include "common/utils.hpp"
 #include "fru_parser.hpp"
+#include "host-bmc/dbus_to_event_handler.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
 #include "oem_handler.hpp"
 #include "pldmd/dbus_impl_requester.hpp"
@@ -87,6 +88,7 @@ class FruImpl
      *  @param[in] handler - PLDM request handler
      *  @param[in] mctp_eid - MCTP eid of Host
      *  @param[in] event - reference of main event loop of pldmd
+     *  @param[in] dbusToPLDMEventHandler - dbus to PLDM Event Handler
      */
     FruImpl(const std::string& configPath,
             const std::filesystem::path& fruMasterJsonPath, pldm_pdr* pdrRepo,
@@ -95,11 +97,13 @@ class FruImpl
             pldm::responder::oem_fru::Handler* oemFruHandler,
             Requester& requester,
             pldm::requester::Handler<pldm::requester::Request>* handler,
-            uint8_t mctp_eid, sdeventplus::Event& event) :
+            uint8_t mctp_eid, sdeventplus::Event& event,
+            pldm::state_sensor::DbusToPLDMEvent* dbusToPLDMEventHandler) :
         parser(configPath, fruMasterJsonPath),
         pdrRepo(pdrRepo), entityTree(entityTree), bmcEntityTree(bmcEntityTree),
         oemFruHandler(oemFruHandler), requester(requester), handler(handler),
-        mctp_eid(mctp_eid), event(event)
+        mctp_eid(mctp_eid), event(event),
+        dbusToPLDMEventHandler(dbusToPLDMEventHandler)
     {
         startStateSensorId = 0;
         startStateEffecterId = 0;
@@ -262,6 +266,7 @@ class FruImpl
     pldm::requester::Handler<pldm::requester::Request>* handler;
     uint8_t mctp_eid;
     sdeventplus::Event& event;
+    pldm::state_sensor::DbusToPLDMEvent* dbusToPLDMEventHandler;
 
     std::map<dbus::ObjectPath, pldm_entity> objToEntityNode{};
     dbus::ObjectPathToRSIMap objectPathToRSIMap{};
@@ -363,9 +368,11 @@ class Handler : public CmdHandler
             pldm::responder::oem_fru::Handler* oemFruHandler,
             Requester& requester,
             pldm::requester::Handler<pldm::requester::Request>* handler,
-            uint8_t mctp_eid, sdeventplus::Event& event) :
+            uint8_t mctp_eid, sdeventplus::Event& event,
+            pldm::state_sensor::DbusToPLDMEvent* dbusToPLDMEventHandler) :
         impl(configPath, fruMasterJsonPath, pdrRepo, entityTree, bmcEntityTree,
-             oemFruHandler, requester, handler, mctp_eid, event)
+             oemFruHandler, requester, handler, mctp_eid, event,
+             dbusToPLDMEventHandler)
     {
         handlers.emplace(PLDM_GET_FRU_RECORD_TABLE_METADATA,
                          [this](const pldm_msg* request, size_t payloadLength) {

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -294,7 +294,7 @@ int main(int argc, char** argv)
     auto fruHandler = std::make_unique<fru::Handler>(
         FRU_JSONS_DIR, FRU_MASTER_JSON, pdrRepo.get(), entityTree.get(),
         bmcEntityTree.get(), oemFruHandler.get(), dbusImplReq, &reqHandler,
-        hostEID, event);
+        hostEID, event, dbusToPLDMEventHandler.get());
     // FRU table is built lazily when a FRU command or Get PDR command is
     // handled. To enable building FRU table, the FRU handler is passed to the
     // Platform handler.


### PR DESCRIPTION
This commit adds the matcher signal after the sensor is
created after a CM. This matcher signal is used to catch
any property change of that newly added sensor.

Fixes:SW549200

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>