### PR TITLE
Utility to get object Path using location and inventory type

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -390,6 +390,19 @@ PropertyValue DBusHandler::getDbusPropertyVariant(
     return value;
 }
 
+ObjectValueTree DBusHandler::getManagedObj(const char* service,
+                                           const char* rootPath)
+{
+    ObjectValueTree objects;
+    auto& bus = DBusHandler::getBus();
+    auto method = bus.new_method_call(service, rootPath,
+                                      "org.freedesktop.DBus.ObjectManager",
+                                      "GetManagedObjects");
+    auto reply = bus.call(method);
+    reply.read(objects);
+    return objects;
+}
+
 PropertyValue jsonEntryToDbusVal(std::string_view type,
                                  const nlohmann::json& value)
 {

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -157,17 +157,12 @@ void FruImpl::buildFRUTable()
                          panelHotplugMatch);
 
     fru_parser::DBusLookupInfo dbusInfo;
-    // Read the all the inventory D-Bus objects
-    auto& bus = pldm::utils::DBusHandler::getBus();
 
+    // Read the all the inventory D-Bus objects
     try
     {
         dbusInfo = parser.inventoryLookup();
-        auto method = bus.new_method_call(
-            std::get<0>(dbusInfo).c_str(), std::get<1>(dbusInfo).c_str(),
-            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        auto reply = bus.call(method);
-        reply.read(objects);
+        objects = pldm::utils::DBusHandler::getInventoryObjects();
     }
     catch (const std::exception& e)
     {

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -133,6 +133,17 @@ void hostPCIETopologyIntf(
     uint8_t mctp_eid,
     pldm::host_effecters::HostEffecterParser* hostEffecterParser);
 
+/** @brief Fetch D-Bus object path based on location details and the type of
+ * Inventory Item
+ *
+ *  @param[in] locationCode - property value of LocationCode
+ *  @param[in] inventoryItemType - inventory item type
+ *
+ *  @return std::string - the D-Bus object path
+ */
+std::string getObjectPathByLocationCode(const std::string& locationCode,
+                                        const std::string& inventoryItemType);
+
 } // namespace utils
 } // namespace responder
 } // namespace pldm


### PR DESCRIPTION
This function is added to support PCIe-Topology.
Util function takes Location code and Inventory Item Type
as inputs and return the dbus object path.

Tested:
  Reset Reload operation and normal poweon workrs fine.
  Also executed utility function with valid/invalid sets of input
  and got expected results.

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>