### PR TITLE
Remove the stale effecters and sensors after the CM

### DIFF
--- a/common/types.hpp
+++ b/common/types.hpp
@@ -55,6 +55,7 @@ using SensorOffset = uint8_t;
 using EventState = uint8_t;
 using TerminusValidity = uint8_t;
 using EffecterID = uint16_t;
+using Pdr_t = uint8_t;
 
 //!< Subset of the State Set that is supported by a effecter/sensor
 using PossibleStates = std::set<uint8_t>;

--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -685,5 +685,182 @@ std::string getCurrentSystemTime()
     return ss.str();
 }
 
+std::vector<std::vector<pldm::pdr::Pdr_t>>
+    getStateEffecterPDRsByType(uint8_t /*tid*/, uint16_t entityType,
+                               const pldm_pdr* repo)
+{
+    uint8_t* outData = nullptr;
+    uint32_t size{};
+    const pldm_pdr_record* record{};
+    std::vector<std::vector<uint8_t>> pdrs;
+
+    do
+    {
+        record = pldm_pdr_find_record_by_type(repo, PLDM_STATE_EFFECTER_PDR,
+                                              record, &outData, &size);
+
+        if (record)
+        {
+            auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(outData);
+            if (pdr)
+            {
+                auto compositeEffecterCount = pdr->composite_effecter_count;
+                auto possible_states_start = pdr->possible_states;
+
+                for (auto effecters = 0x00; effecters < compositeEffecterCount;
+                     effecters++)
+                {
+                    auto possibleStates =
+                        reinterpret_cast<state_effecter_possible_states*>(
+                            possible_states_start);
+                    auto setId = possibleStates->state_set_id;
+                    auto possibleStateSize =
+                        possibleStates->possible_states_size;
+
+                    if (pdr->entity_type == entityType)
+                    {
+                        std::vector<uint8_t> effecter_pdr(&outData[0],
+                                                          &outData[size]);
+                        pdrs.emplace_back(std::move(effecter_pdr));
+                        break;
+                    }
+                    possible_states_start += possibleStateSize + sizeof(setId) +
+                                             sizeof(possibleStateSize);
+                }
+            }
+        }
+    } while (record);
+
+    return pdrs;
+}
+
+std::vector<std::vector<pldm::pdr::Pdr_t>>
+    getStateSensorPDRsByType(uint8_t /*tid*/, uint16_t entityType,
+                             const pldm_pdr* repo)
+{
+    uint8_t* outData = nullptr;
+    uint32_t size{};
+    const pldm_pdr_record* record{};
+    std::vector<std::vector<uint8_t>> pdrs;
+    do
+    {
+        record = pldm_pdr_find_record_by_type(repo, PLDM_STATE_SENSOR_PDR,
+                                              record, &outData, &size);
+
+        if (record)
+        {
+            auto pdr = reinterpret_cast<pldm_state_sensor_pdr*>(outData);
+            if (pdr)
+            {
+                auto compositeSensorCount = pdr->composite_sensor_count;
+                auto possible_states_start = pdr->possible_states;
+
+                for (auto sensors = 0x00; sensors < compositeSensorCount;
+                     sensors++)
+                {
+                    auto possibleStates =
+                        reinterpret_cast<state_sensor_possible_states*>(
+                            possible_states_start);
+                    auto setId = possibleStates->state_set_id;
+                    auto possibleStateSize =
+                        possibleStates->possible_states_size;
+
+                    if (pdr->entity_type == entityType)
+                    {
+                        std::vector<uint8_t> sensor_pdr(&outData[0],
+                                                        &outData[size]);
+                        pdrs.emplace_back(std::move(sensor_pdr));
+                        break;
+                    }
+                    possible_states_start += possibleStateSize + sizeof(setId) +
+                                             sizeof(possibleStateSize);
+                }
+            }
+        }
+
+    } while (record);
+
+    return pdrs;
+}
+
+std::vector<pldm::pdr::EffecterID>
+    findEffecterIds(const pldm_pdr* pdrRepo, uint8_t tid, uint16_t entityType,
+                    uint16_t entityInstance, uint16_t containerId)
+{
+    std::vector<uint16_t> effecterIDs;
+
+    auto pdrs = getStateEffecterPDRsByType(tid, entityType, pdrRepo);
+    for (const auto& pdr : pdrs)
+    {
+        auto effecterPdr =
+            reinterpret_cast<const pldm_state_effecter_pdr*>(pdr.data());
+        if (effecterPdr)
+        {
+            auto compositeEffecterCount = effecterPdr->composite_effecter_count;
+            auto possible_states_start = effecterPdr->possible_states;
+
+            for (auto effecters = 0x00; effecters < compositeEffecterCount;
+                 effecters++)
+            {
+                auto possibleStates =
+                    reinterpret_cast<const state_effecter_possible_states*>(
+                        possible_states_start);
+                auto possibleStateSize = possibleStates->possible_states_size;
+                if (entityType == effecterPdr->entity_type &&
+                    entityInstance == effecterPdr->entity_instance &&
+                    containerId == effecterPdr->container_id)
+                {
+                    uint16_t id = effecterPdr->effecter_id;
+                    effecterIDs.emplace_back(std::move(id));
+                }
+                possible_states_start += possibleStateSize +
+                                         sizeof(possibleStates->state_set_id) +
+                                         sizeof(possibleStateSize);
+            }
+        }
+    }
+    return effecterIDs;
+}
+
+std::vector<pldm::pdr::SensorID> findSensorIds(const pldm_pdr* pdrRepo,
+                                               uint8_t tid, uint16_t entityType,
+                                               uint16_t entityInstance,
+                                               uint16_t containerId)
+{
+
+    std::vector<uint16_t> sensorIDs;
+
+    auto pdrs = getStateSensorPDRsByType(tid, entityType, pdrRepo);
+    for (const auto& pdr : pdrs)
+    {
+        auto sensorPdr =
+            reinterpret_cast<const pldm_state_sensor_pdr*>(pdr.data());
+        if (sensorPdr)
+        {
+            auto compositeSensorCount = sensorPdr->composite_sensor_count;
+            auto possible_states_start = sensorPdr->possible_states;
+
+            for (auto sensors = 0x00; sensors < compositeSensorCount; sensors++)
+            {
+                auto possibleStates =
+                    reinterpret_cast<const state_sensor_possible_states*>(
+                        possible_states_start);
+                auto possibleStateSize = possibleStates->possible_states_size;
+                if (entityType == sensorPdr->entity_type &&
+                    entityInstance == sensorPdr->entity_instance &&
+                    containerId == sensorPdr->container_id)
+                {
+                    uint16_t id = sensorPdr->sensor_id;
+                    sensorIDs.emplace_back(std::move(id));
+                }
+                possible_states_start += possibleStateSize +
+                                         sizeof(possibleStates->state_set_id) +
+                                         sizeof(possibleStateSize);
+            }
+        }
+    }
+    return sensorIDs;
+}
+
 } // namespace utils
 } // namespace pldm

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -428,5 +428,59 @@ std::string getBiosAttrValue(const std::string& dbusAttrName);
  *             to be set
  */
 void setBiosAttr(const BiosAttributeList& biosAttrList);
+
+/** @brief Method to find all state effecter PDRs
+ *
+ *  @param[in] tid - Terminus ID
+ *  @param[in] entityType - the entity type
+ *  @param[in] repo - opaque pointer acting as a PDR repo handle
+ *
+ *  @return vector of vector of all state effecter PDRs
+ */
+std::vector<std::vector<pldm::pdr::Pdr_t>>
+    getStateEffecterPDRsByType(uint8_t /*tid*/, uint16_t entityType,
+                               const pldm_pdr* repo);
+
+/** @brief Method to find all state sensor PDRs
+ *
+ *  @param[in] tid - terminus ID
+ *  @param[in] entityType - the entity type
+ *  @param[in] repo - opaque pointer acting as a PDR repo handle
+ *
+ *  @return vector of vector of all state sensor PDRs
+ */
+std::vector<std::vector<pldm::pdr::Pdr_t>>
+    getStateSensorPDRsByType(uint8_t /*tid*/, uint16_t entityType,
+                             const pldm_pdr* repo);
+
+/** @brief method to find effecter IDs based on the pldm_entity
+ *
+ *  @param[in] pdrRepo - opaque pointer acting as a PDR repo handle
+ *  @param[in] tid - terminus ID
+ *  @param[in] entityType - the entity type
+ *  @param[in] entityInstance - the entity instance number
+ *  @param[in] containerId - the container ID
+ *
+ *  @return vector of all effecter IDs
+ */
+std::vector<pldm::pdr::EffecterID> findEffecterIds(const pldm_pdr* pdrRepo,
+                                                   uint8_t /*tid*/,
+                                                   uint16_t entityType,
+                                                   uint16_t entityInstance,
+                                                   uint16_t containerId);
+
+/** @brief method to find sensor IDs based on the pldm_entity
+ *
+ *  @param[in] pdrRepo - opaque pointer acting as a PDR repo handle
+ *  @param[in] tid - terminus ID
+ *  @param[in] entityType - the entity type
+ *  @param[in] entityInstance - the entity instance number
+ *  @param[in] containerId - the container ID
+ *
+ *  @return vector of all sensor IDs
+ */
+std::vector<pldm::pdr::SensorID>
+    findSensorIds(const pldm_pdr* pdrRepo, uint8_t /*tid*/, uint16_t entityType,
+                  uint16_t entityInstance, uint16_t containerId);
 } // namespace utils
 } // namespace pldm

--- a/libpldm/pdr.c
+++ b/libpldm/pdr.c
@@ -724,6 +724,96 @@ void pldm_change_instance_number_of_sensor(const pldm_pdr *repo,
 	}
 }
 
+uint16_t pldm_delete_by_effecter_id(pldm_pdr *repo, uint16_t effecter_id,
+				    bool is_remote)
+{
+	assert(repo != NULL);
+
+	uint32_t delete_handle = 0;
+	pldm_pdr_record *record = repo->first;
+	pldm_pdr_record *prev = NULL;
+	while (record != NULL) {
+		pldm_pdr_record *next = record->next;
+		struct pldm_pdr_hdr *hdr = (struct pldm_pdr_hdr *)record->data;
+		if ((record->is_remote == is_remote) &&
+		    hdr->type == PLDM_STATE_EFFECTER_PDR) {
+			struct pldm_state_effecter_pdr *pdr =
+			    (struct pldm_state_effecter_pdr *)((uint8_t *)record
+								   ->data);
+			if (pdr->effecter_id == effecter_id) {
+				delete_handle = hdr->record_handle;
+				if (repo->first == record) {
+					repo->first = next;
+				} else {
+					prev->next = next;
+				}
+				if (repo->last == record) {
+					repo->last = prev;
+					prev->next = NULL;
+				}
+				--repo->record_count;
+				repo->size -= record->size;
+				if (record->data) {
+					free(record->data);
+				}
+				free(record);
+				break;
+			} else {
+				prev = record;
+			}
+		} else {
+			prev = record;
+		}
+		record = next;
+	}
+	return delete_handle;
+}
+
+uint16_t pldm_delete_by_sensor_id(pldm_pdr *repo, uint16_t sensor_id,
+				  bool is_remote)
+{
+	assert(repo != NULL);
+
+	uint32_t delete_handle = 0;
+	pldm_pdr_record *record = repo->first;
+	pldm_pdr_record *prev = NULL;
+	while (record != NULL) {
+		pldm_pdr_record *next = record->next;
+		struct pldm_pdr_hdr *hdr = (struct pldm_pdr_hdr *)record->data;
+		if ((record->is_remote == is_remote) &&
+		    hdr->type == PLDM_STATE_SENSOR_PDR) {
+			struct pldm_state_sensor_pdr *pdr =
+			    (struct pldm_state_sensor_pdr *)((uint8_t *)
+								 record->data);
+			if (pdr->sensor_id == sensor_id) {
+				delete_handle = hdr->record_handle;
+				if (repo->first == record) {
+					repo->first = next;
+				} else {
+					prev->next = next;
+				}
+				if (repo->last == record) {
+					repo->last = prev;
+					prev->next = NULL;
+				}
+				--repo->record_count;
+				repo->size -= record->size;
+				if (record->data) {
+					free(record->data);
+				}
+				free(record);
+				break;
+			} else {
+				prev = record;
+			}
+		} else {
+			prev = record;
+		}
+		record = next;
+	}
+	return delete_handle;
+}
+
 typedef struct pldm_entity_association_tree {
 	pldm_entity_node *root;
 	uint16_t last_used_container_id;

--- a/libpldm/pdr.h
+++ b/libpldm/pdr.h
@@ -272,6 +272,23 @@ void pldm_change_instance_number_of_effecter(const pldm_pdr *repo,
 void pldm_change_instance_number_of_sensor(const pldm_pdr *repo,
 					   uint16_t sensorId,
 					   uint16_t instanceNumber);
+/** @brief delete the pdr by effecter id
+ *
+ *  @param[in] repo - opaque pointer acting as a PDR repo handle
+ *  @param[in] effecter_id - effecter ID
+ *  @param[in] is_remote - indicates which PDR to remove, local or remote
+ */
+uint16_t pldm_delete_by_effecter_id(pldm_pdr *repo, uint16_t effecter_id,
+				    bool is_remote);
+
+/** @brief delete the pdr by sensor id
+ *
+ *  @param[in] repo - opaque pointer acting as a PDR repo handle
+ *  @param[in] sensor_id - sensor ID
+ *  @param[in] is_remote - indicates which PDR to remove, local or remote
+ */
+uint16_t pldm_delete_by_sensor_id(pldm_pdr *repo, uint16_t sensor_id,
+				  bool is_remote);
 
 /* ======================= */
 /* FRU Record Set PDR APIs */

--- a/libpldmresponder/fru.hpp
+++ b/libpldmresponder/fru.hpp
@@ -271,6 +271,9 @@ class FruImpl
     std::map<dbus::ObjectPath, pldm_entity> objToEntityNode{};
     dbus::ObjectPathToRSIMap objectPathToRSIMap{};
 
+    pdr_utils::DbusObjMaps effecterDbusObjMaps{};
+    pdr_utils::DbusObjMaps sensorDbusObjMaps{};
+
     /** @brief populateRecord builds the FRU records for an instance of FRU and
      *         updates the FRU table with the FRU records.
      *


### PR DESCRIPTION
This commit removes the duplicate sensor and effecter PDRs
that were present in our repo after the CM/hotplug.

tested the CM operation scenarios.

Fixes:SW548661

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>