### PR TITLE
oem: ibm: Do not remove the staging directory

### DIFF
--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -516,12 +516,13 @@ void CodeUpdate::setOemPlatformHandler(
 
 void CodeUpdate::clearDirPath(const std::string& dirPath)
 {
-    if (!fs::exists(dirPath))
+    if (std::filesystem::is_directory(dirPath))
     {
-        std::cerr << dirPath << " does not exists, nothing to clear \n";
-        return;
+        for (const auto& iter : std::filesystem::directory_iterator(dirPath))
+        {
+            std::filesystem::remove_all(iter);
+        }
     }
-    fs::remove_all(dirPath);
 }
 
 void CodeUpdate::sendStateSensorEvent(


### PR DESCRIPTION
The staging directory is created by the software manager application,
therefore it should not be deleted by pldm or it won't be re-created
until the next BMC reboot, and the inband update would fail with:

Apr 29 20:21:53 p10bmc pldmd[1980]: Cannot stat source directory
"/var/lib/phosphor-software-manager/hostfw/staging/lid" because No such
file or directory

Instead iterate over the contents of the directory to clear them.

Tested: The contents of the staging directory got removed, but not the
staging directory itself.

Change-Id: Id76ac325d49ca48891c99e7b71b1a0d5d64c85c3
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>