### PR TITLE
pcie-topology : Integrate topology blob parsers to file io infrastructure

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include <iostream>
+#include <ranges>
 
 namespace pldm
 {
@@ -21,6 +22,16 @@ constexpr auto cableInfoFile = "cableinfo";
 
 namespace fs = std::filesystem;
 std::unordered_map<uint16_t, bool> PCIeInfoHandler::receivedFiles;
+std::unordered_map<linkId_t,
+                   std::tuple<linkStatus_t, linkType_t, linkSpeed_t,
+                              linkWidth_t, pcieHostBidgeloc_t, localport_t,
+                              remoteport_t, io_slot_location_t>>
+    PCIeInfoHandler::topologyInformation;
+std::unordered_map<
+    cable_link_no_t,
+    std::tuple<linkId_t, local_port_loc_code_t, io_slot_location_code_t,
+               cable_part_no_t, cable_length_t, cable_type_t, cable_status_t>>
+    PCIeInfoHandler::cableInformation;
 
 PCIeInfoHandler::PCIeInfoHandler(uint32_t fileHandle, uint16_t fileType) :
     FileHandler(fileHandle), infoType(fileType)
@@ -103,12 +114,368 @@ int PCIeInfoHandler::fileAck(uint8_t /*fileStatus*/)
             receivedFiles[PLDM_FILE_TYPE_PCIE_TOPOLOGY])
         {
             receivedFiles.clear();
+
+            // parse the topology blob and cache the information
+            // for further processing
+            parseTopologyData();
+
+            // even when we fail to parse /set the topology infromation on to
+            // the dbus, we need to set the property back to false - to allow
+            // the redfish/user to be able to ask the topology information again
             pldm::dbus::CustomDBus::getCustomDBus().updateTopologyProperty(
                 false);
+
+            // clear all the cached information
+            clearTopologyInfo();
         }
     }
 
     return PLDM_SUCCESS;
+}
+
+void PCIeInfoHandler::clearTopologyInfo()
+{
+    std::cerr << "Topology information :\n";
+    for (const auto& [link, info] : topologyInformation)
+    {
+        std::cerr << "linkid :" << (unsigned)link << std::endl;
+        std::cerr << "link status : " << std::get<0>(info) << std::endl;
+        std::cerr << "link type :" << std::get<1>(info) << std::endl;
+        std::cerr << "link speed : " << std::get<2>(info) << std::endl;
+        std::cerr << "link wdith : " << std::get<3>(info) << std::endl;
+        std::cerr << "pcie host bridge loc code : " << std::get<4>(info)
+                  << std::endl;
+        std::cerr << "local port top loc code : " << std::get<5>(info).first
+                  << std::endl;
+        std::cerr << "local port bottom loc code : " << std::get<5>(info).second
+                  << std::endl;
+        std::cerr << "remote port top loc code : " << std::get<6>(info).first
+                  << std::endl;
+        std::cerr << "remote port bottom loc code : "
+                  << std::get<6>(info).second << std::endl;
+        for (const auto& slot : std::get<7>(info))
+        {
+            std::cerr << "io slot location code : " << slot << std::endl;
+        }
+    }
+    topologyInformation.clear();
+
+    std::cerr << "Cable iformation : \n";
+    for (const auto& [cable_no, info] : cableInformation)
+    {
+        std::cerr << "cable no : " << (unsigned)cable_no << std::endl;
+        std::cerr << "link id : " << (unsigned)std::get<0>(info) << std::endl;
+        std::cerr << "local port loc code : " << std::get<1>(info) << std::endl;
+        std::cerr << "io slot loc code : " << std::get<2>(info) << std::endl;
+        std::cerr << "cable part no : " << std::get<3>(info) << std::endl;
+        std::cerr << "cable length : " << std::get<4>(info) << std::endl;
+        std::cerr << "cable type : " << std::get<5>(info) << std::endl;
+        std::cerr << "cable status :" << std::get<6>(info) << std::endl;
+    }
+    cableInformation.clear();
+}
+
+void PCIeInfoHandler::parseTopologyData()
+{
+
+    int fd = open((fs::path(pciePath) / topologyFile).string().c_str(),
+                  O_RDONLY, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        perror("Topology file not present");
+        return;
+    }
+    pldm::utils::CustomFD topologyFd(fd);
+    struct stat sb;
+    if (fstat(fd, &sb) == -1)
+    {
+        perror("Could not get topology file size");
+        return;
+    }
+
+    auto topologyCleanup = [sb](void* file_in_memory) {
+        munmap(file_in_memory, sb.st_size);
+    };
+
+    // memory map the topology file into pldm memory
+    void* file_in_memory =
+        mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, topologyFd(), 0);
+    if (MAP_FAILED == file_in_memory)
+    {
+        int rc = -errno;
+        std::cerr << "mmap on topology file failed, RC=" << rc << std::endl;
+        return;
+    }
+
+    std::unique_ptr<void, decltype(topologyCleanup)> topologyPtr(
+        file_in_memory, topologyCleanup);
+
+    auto pcie_link_list =
+        reinterpret_cast<struct topology_blob*>(file_in_memory);
+    uint16_t no_of_links = 0;
+    if (pcie_link_list != nullptr)
+    {
+        no_of_links = htobe16(pcie_link_list->num_pcie_link_entries);
+    }
+    else
+    {
+        std::cerr
+            << "Parsing of topology file failed : pcie_link_list is null\n";
+        return;
+    }
+
+    struct pcie_link_entry* single_entry_data =
+        (struct pcie_link_entry*)(((uint8_t*)pcie_link_list) + 8);
+
+    if (single_entry_data == nullptr)
+    {
+        std::cerr << "Parsing of topology file failed : single_link is null \n";
+        return;
+    }
+
+    // iterate over every pcie link and get the link specific attributes
+    for ([[maybe_unused]] const auto& link :
+         std::views::iota(0) | std::views::take(no_of_links))
+    {
+
+        // get the link id
+        auto linkid = htobe16(single_entry_data->link_id);
+
+        // get link status
+        auto linkStatus = single_entry_data->link_status;
+
+        // get link type
+        auto linkType = single_entry_data->link_type;
+
+        // get link speed
+        auto linkSpeed = single_entry_data->link_speed;
+
+        // get link width
+        auto linkWidth = single_entry_data->link_width;
+
+        // get the PCIe Host Bridge Location
+        size_t pcie_loc_code_size =
+            single_entry_data->PCIehostBridgeLocCodeSize;
+        std::vector<char> pcie_host_bridge_location(
+            (char*)single_entry_data +
+                htobe16(single_entry_data->PCIehostBridgeLocCodeOff),
+            (char*)single_entry_data +
+                htobe16(single_entry_data->PCIehostBridgeLocCodeOff) +
+                (unsigned)pcie_loc_code_size);
+        std::string pcie_host_bridge_location_code(
+            pcie_host_bridge_location.begin(), pcie_host_bridge_location.end());
+
+        // get the local port - top location
+        size_t local_top_port_loc_size =
+            single_entry_data->TopLocalPortLocCodeSize;
+        std::vector<char> local_top_port_location(
+            (char*)single_entry_data +
+                htobe16(single_entry_data->TopLocalPortLocCodeOff),
+            (char*)single_entry_data +
+                htobe16(single_entry_data->TopLocalPortLocCodeOff) +
+                (int)local_top_port_loc_size);
+        std::string local_top_port_location_code(
+            local_top_port_location.begin(), local_top_port_location.end());
+
+        // get the local port - bottom location
+        size_t local_bottom_port_loc_size =
+            single_entry_data->BottomLocalPortLocCodeSize;
+        std::vector<char> local_bottom_port_location(
+            (char*)single_entry_data +
+                htobe16(single_entry_data->BottomLocalPortLocCodeOff),
+            (char*)single_entry_data +
+                htobe16(single_entry_data->BottomLocalPortLocCodeOff) +
+                (int)local_bottom_port_loc_size);
+        std::string local_bottom_port_location_code(
+            local_bottom_port_location.begin(),
+            local_bottom_port_location.end());
+
+        // get the remote port - top location
+        size_t remote_top_port_loc_size =
+            single_entry_data->TopRemotePortLocCodeSize;
+        std::vector<char> remote_top_port_location(
+            (char*)single_entry_data +
+                htobe16(single_entry_data->TopRemotePortLocCodeOff),
+            (char*)single_entry_data +
+                htobe16(single_entry_data->TopRemotePortLocCodeOff) +
+                (int)remote_top_port_loc_size);
+        std::string remote_top_port_location_code(
+            remote_top_port_location.begin(), remote_top_port_location.end());
+
+        // get the remote port - bottom location
+        size_t remote_bottom_loc_size =
+            single_entry_data->BottomRemotePortLocCodeSize;
+        std::vector<char> remote_bottom_port_location(
+            (char*)single_entry_data +
+                htobe16(single_entry_data->BottomRemotePortLocCodeOff),
+            (char*)single_entry_data +
+                htobe16(single_entry_data->BottomRemotePortLocCodeOff) +
+                (int)remote_bottom_loc_size);
+        std::string remote_bottom_port_location_code(
+            remote_bottom_port_location.begin(),
+            remote_bottom_port_location.end());
+
+        struct SlotLocCode_t* slot_data =
+            (struct SlotLocCode_t*)(((uint8_t*)single_entry_data) +
+                                    htobe16(single_entry_data
+                                                ->slot_loc_codes_offset));
+
+        if (slot_data == nullptr)
+        {
+            std::cerr
+                << "Parsing the topology file failed : slot_data is null \n";
+            return;
+        }
+        // get the Slot location code common part
+        size_t no_of_slots = slot_data->numSlotLocCodes;
+        size_t slot_loccode_compart_size = slot_data->slotLocCodesCmnPrtSize;
+        std::vector<char> slot_location((char*)slot_data->slotLocCodesCmnPrt,
+                                        (char*)slot_data->slotLocCodesCmnPrt +
+                                            (int)slot_loccode_compart_size);
+        std::string slot_location_code(slot_location.begin(),
+                                       slot_location.end());
+
+        struct SlotLocCodeSuf_t* slot_loc_suf_data =
+            (struct SlotLocCodeSuf_t*)(((uint8_t*)slot_data) + 2 +
+                                       slot_data->slotLocCodesCmnPrtSize);
+        if (slot_loc_suf_data == nullptr)
+        {
+            std::cerr << "slot location suffix data is nullptr \n";
+            return;
+        }
+
+        // create the full slot location code by combining common part and
+        // suffix part
+        std::string slot_suffix_location_code;
+        std::vector<std::string> slot_final_location_code{};
+        for ([[maybe_unused]] const auto& slot :
+             std::views::iota(0) | std::views::take(no_of_slots))
+        {
+            size_t slot_loccode_suffix_size = slot_loc_suf_data->slotLocCodeSz;
+            if (slot_loccode_suffix_size > 0)
+            {
+                std::vector<char> slot_suffix_location(
+                    (char*)slot_loc_suf_data + 1,
+                    (char*)slot_loc_suf_data + 1 +
+                        (int)slot_loccode_suffix_size);
+                std::string slot_suff_location_code(
+                    slot_suffix_location.begin(), slot_suffix_location.end());
+
+                slot_suffix_location_code = slot_suff_location_code;
+            }
+            std::string slot_full_location_code =
+                slot_location_code + slot_suffix_location_code;
+            slot_final_location_code.push_back(slot_full_location_code);
+
+            // move the pointer to next slot
+            slot_loc_suf_data += 2;
+        }
+
+        // store the information into a map
+        topologyInformation[linkid] =
+            std::make_tuple(link_state_map[linkStatus], link_type[linkType],
+                            link_speed[linkSpeed], link_width[linkWidth],
+                            pcie_host_bridge_location_code,
+                            std::make_pair(local_top_port_location_code,
+                                           local_bottom_port_location_code),
+                            std::make_pair(remote_top_port_location_code,
+                                           remote_bottom_port_location_code),
+                            slot_final_location_code);
+
+        // move the pointer to next link
+        single_entry_data =
+            (struct pcie_link_entry*)((uint8_t*)single_entry_data +
+                                      htons(single_entry_data->entry_length));
+    }
+    // Need to call cable info at the end , because we dont want to parse
+    // cable info without parsing the successfull topology successfully
+    // Having partial information is of no use.
+    parseCableInfo();
+}
+
+void PCIeInfoHandler::parseCableInfo()
+{
+    int fd = open((fs::path(pciePath) / cableInfoFile).string().c_str(),
+                  O_RDONLY, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        perror("CableInfo file not present");
+        return;
+    }
+    pldm::utils::CustomFD cableInfoFd(fd);
+    struct stat sb;
+
+    if (fstat(fd, &sb) == -1)
+    {
+        perror("Could not get cableinfo file size");
+        return;
+    }
+
+    auto cableInfoCleanup = [sb](void* file_in_memory) {
+        munmap(file_in_memory, sb.st_size);
+    };
+
+    void* file_in_memory =
+        mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, cableInfoFd(), 0);
+
+    if (MAP_FAILED == file_in_memory)
+    {
+        int rc = -errno;
+        std::cerr << "mmap on cable ifno file failed, RC=" << rc << std::endl;
+        return;
+    }
+
+    std::unique_ptr<void, decltype(cableInfoCleanup)> cablePtr(
+        file_in_memory, cableInfoCleanup);
+
+    auto cable_list =
+        reinterpret_cast<struct cable_attributes_list*>(file_in_memory);
+
+    // get number of cable links
+    auto no_of_cable_links = htobe16(cable_list->no_of_cables);
+
+    struct pcilinkcableattr_t* cable_data =
+        (struct pcilinkcableattr_t*)(((uint8_t*)cable_list) + 8);
+
+    if (cable_data == nullptr)
+    {
+        std::cerr << "Cable info parsing failed , cable_data = nullptr \n";
+        return;
+    }
+
+    // iterate over each pci cable link
+    for (const auto& cable :
+         std::views::iota(0) | std::views::take(no_of_cable_links))
+    {
+        // get the link id
+        auto linkid = htobe16(cable_data->link_id);
+
+        std::string local_port_loc_code(
+            (char*)cable_data +
+                htobe16(cable_data->host_port_location_code_offset),
+            cable_data->host_port_location_code_size);
+
+        std::string io_slot_location_code(
+            (char*)cable_data +
+                htobe16(cable_data->io_enclosure_port_location_code_offset),
+            cable_data->io_enclosure_port_location_code_size);
+
+        std::string cable_part_num(
+            (char*)cable_data + htobe16(cable_data->cable_part_number_offset),
+            cable_data->cable_part_number_size);
+
+        // cache the data into a map
+        cableInformation[cable] = std::make_tuple(
+            linkid, local_port_loc_code, io_slot_location_code, cable_part_num,
+            cable_length_map[cable_data->cable_length],
+            cable_type_map[cable_data->cable_type],
+            cable_status_map[cable_data->cable_status]);
+        // move the cable data pointer
+
+        cable_data =
+            (struct pcilinkcableattr_t*)(((uint8_t*)cable_data) +
+                                         ntohs(cable_data->entry_length));
+    }
 }
 
 int PCIeInfoHandler::newFileAvailable(uint64_t)

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -2,12 +2,152 @@
 
 #include "file_io_by_type.hpp"
 
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstring>
 #include <unordered_map>
 
 namespace pldm
 {
 namespace responder
 {
+
+/* Topology enum definitions*/
+
+static std::map<uint8_t, std::string> link_state_map{
+    {0x00, "Operational"}, {0x01, "Degraded"}, {0x02, "Unused1"},
+    {0x03, "Unused2"},     {0x04, "Failed"},   {0x05, "Open"},
+    {0x06, "Inactive"},    {0x07, "Unused3"},  {0xFF, "Unknown"}};
+
+static std::map<uint8_t, std::string> link_type{{0x00, "Primary"},
+                                                {0x01, "Secondary"},
+                                                {0x02, "OpenCAPI"},
+                                                {0xFF, "Unknown"}};
+
+static std::map<uint8_t, std::string> link_speed{
+    {0x00, "Gen1"}, {0x01, "Gen2"}, {0x02, "Gen3"},   {0x03, "Gen4"},
+    {0x04, "Gen5"}, {0x10, "OC25"}, {0xFF, "Unknown"}};
+
+static std::map<uint8_t, std::string> link_width{
+    {0x01, "x1"}, {0x02, "x2"},  {0x04, "x4"},
+    {0x08, "x8"}, {0x10, "x16"}, {0xFF, "Unknown"}};
+
+struct SlotLocCode_t
+{
+    uint8_t numSlotLocCodes;
+    uint8_t slotLocCodesCmnPrtSize;
+    uint8_t slotLocCodesCmnPrt[1];
+} __attribute__((packed));
+
+struct SlotLocCodeSuf_t
+{
+    uint8_t slotLocCodeSz;
+    uint8_t slotLocCodeSuf[1];
+} __attribute__((packed));
+
+struct pcie_link_entry
+{
+    uint16_t entry_length;
+    uint8_t version;
+    uint8_t reserved_1;
+    uint16_t link_id;
+    uint16_t parent_link_id;
+    uint32_t link_drc_index;
+    uint32_t hub_drc_index;
+    uint8_t link_status;
+    uint8_t link_type;
+    uint16_t reserved_2;
+    uint8_t link_speed;
+    uint8_t link_width;
+    uint8_t PCIehostBridgeLocCodeSize;
+    uint16_t PCIehostBridgeLocCodeOff;
+    uint8_t TopLocalPortLocCodeSize;
+    uint16_t TopLocalPortLocCodeOff;
+    uint8_t BottomLocalPortLocCodeSize;
+    uint16_t BottomLocalPortLocCodeOff;
+    uint8_t TopRemotePortLocCodeSize;
+    uint16_t TopRemotePortLocCodeOff;
+    uint8_t BottomRemotePortLocCodeSize;
+    uint16_t BottomRemotePortLocCodeOff;
+    uint16_t slot_loc_codes_offset;
+    uint8_t pci_link_entry_loc_code[1];
+} __attribute__((packed));
+
+struct topology_blob
+{
+    uint32_t total_data_size;
+    uint16_t num_pcie_link_entries;
+    uint16_t reserved;
+    pcie_link_entry pci_link_entry[1];
+} __attribute__((packed));
+
+using linkId_t = uint16_t;
+using linkStatus_t = std::string;
+using linkType_t = std::string;
+using linkSpeed_t = std::string;
+using linkWidth_t = std::string;
+using pcieHostBidgeloc_t = std::string;
+using localport_top_t = std::string;
+using localport_bot_t = std::string;
+using localport_t = std::pair<localport_top_t, localport_bot_t>;
+using remoteport_top_t = std::string;
+using remoteport_bot_t = std::string;
+using remoteport_t = std::pair<remoteport_top_t, remoteport_bot_t>;
+using io_slot_location_t = std::vector<std::string>;
+
+/* Cable Attributes Info */
+
+static std::map<uint8_t, std::string> cable_length_map{
+    {0x00, "0m"},  {0x01, "2m"},  {0x02, "3m"},
+    {0x03, "10m"}, {0x04, "20m"}, {0xFF, "Unknown"}};
+
+static std::map<uint8_t, std::string> cable_type_map{
+    {0x00, "optical"}, {0x01, "copper"}, {0xFF, "Unknown"}};
+
+static std::map<uint8_t, std::string> cable_status_map{{0x00, "inactive"},
+                                                       {0x01, "running"},
+                                                       {0x02, "powered off"},
+                                                       {0xFF, "Unknown"}};
+
+using cable_link_no_t = unsigned short int;
+using local_port_loc_code_t = std::string;
+using io_slot_location_code_t = std::string;
+using cable_part_no_t = std::string;
+using cable_length_t = std::string;
+using cable_type_t = std::string;
+using cable_status_t = std::string;
+
+struct pcilinkcableattr_t
+{
+    uint16_t entry_length;
+    uint8_t version;
+    uint8_t reserved_1;
+    uint16_t link_id;
+    uint16_t reserved_2;
+    uint32_t link_drc_index;
+    uint8_t cable_length;
+    uint8_t cable_type;
+    uint8_t cable_status;
+    uint8_t host_port_location_code_size;
+    uint8_t io_enclosure_port_location_code_size;
+    uint8_t cable_part_number_size;
+    uint16_t host_port_location_code_offset;
+    uint16_t io_enclosure_port_location_code_offset;
+    uint16_t cable_part_number_offset;
+    uint8_t cable_attr_loc_code[1];
+};
+
+struct cable_attributes_list
+{
+    uint32_t length_of_response;
+    uint16_t no_of_cables;
+    uint16_t reserved;
+    pcilinkcableattr_t pci_link_cable_attr[1];
+};
 
 /** @class PCIeInfoHandler
  *
@@ -51,6 +191,15 @@ class PCIeInfoHandler : public FileHandler
                                              uint32_t /*metaDataValue3*/,
                                              uint32_t /*metaDataValue4*/);
 
+    /** @brief method to parse the pcie topology information */
+    virtual void parseTopologyData();
+
+    /** @brief method to parse the cable information */
+    virtual void parseCableInfo();
+
+    /** @brief method to clear the topology cache */
+    virtual void clearTopologyInfo();
+
     /** @brief PCIeInfoHandler destructor
      */
     ~PCIeInfoHandler()
@@ -59,6 +208,17 @@ class PCIeInfoHandler : public FileHandler
   private:
     uint16_t infoType; //!< type of the information
     static std::unordered_map<uint16_t, bool> receivedFiles;
+    static std::unordered_map<
+        linkId_t, std::tuple<linkStatus_t, linkType_t, linkSpeed_t, linkWidth_t,
+                             pcieHostBidgeloc_t, localport_t, remoteport_t,
+                             io_slot_location_t>>
+        topologyInformation;
+    static std::unordered_map<
+        cable_link_no_t,
+        std::tuple<linkId_t, local_port_loc_code_t, io_slot_location_code_t,
+                   cable_part_no_t, cable_length_t, cable_type_t,
+                   cable_status_t>>
+        cableInformation;
 };
 
 } // namespace responder


### PR DESCRIPTION
This PR would add the necessary parsing support for both
the topology file and the cable attributes file and caches
them into pldm memory for further processing.

Tested By:
1. busctl set on PCIeTopologyRefresh property to true.
2. And made sure the parsed data matches with the date printed
   by phyp macros.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>