### PR TITLE
[OEM]Remove misleading trace in case of BMC reboot

### DIFF
--- a/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
@@ -44,7 +44,10 @@ int sendBiosAttributeUpdateEvent(
     }
     catch (const sdbusplus::exception::exception& e)
     {
-        std::cerr << "Error in getting current host state, continue ... \n";
+        /* Execption is expected to happen in the case when state manager is
+         * started after pldm, this is expected to happen in reboot case where
+         * host is considred to be up. As host is up pldm is expected to send
+         * attribute update event to host so this is not and error case */
     }
 
     auto instanceId = requester->getInstanceId(eid);


### PR DESCRIPTION
In case of BMC reboot state manager starts after pldm,
so while sending bios attribute update event it doesn't get
boot progress state and causes exception. This is not considered
as error and pldm sends sends attribute update events to host.
So removed the trace.

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>