### PR TITLE
PLDM:SoftPowerOff request BMC dump during graceful shutdown

### DIFF
--- a/softoff/main.cpp
+++ b/softoff/main.cpp
@@ -65,6 +65,23 @@ int main(int argc, char* argv[])
         pldm::utils::reportError(
             "pldm soft off: Waiting for the host soft off timeout",
             pldm::PelSeverity::ERROR);
+
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.Dump.Manager", "/xyz/openbmc_project/dump/bmc",
+            "xyz.openbmc_project.Dump.Create", "CreateDump");
+        method.append(
+            std::vector<
+                std::pair<std::string, std::variant<std::string, uint64_t>>>());
+        try
+        {
+            bus.call_noreply(method);
+        }
+        catch (const sdbusplus::exception::exception& e)
+        {
+            std::cerr << "SoftPowerOff:Failed to create BMC dump, ERROR="
+                      << e.what() << std::endl;
+        }
+
         std::cerr
             << "PLDM host soft off: ERROR! Wait for the host soft off timeout."
             << "Exit the pldm-softpoweroff "


### PR DESCRIPTION
When we do a graceful shutdown of the host, the PLDM softoff app
does a setStateEffecter call on the Phyp's power down effecter,
after we receive the response for the same, softoff app starts a
timeout of 45 minutes for PHYP to finishing shutting down all its
services. The requirement is to request for a BMC Dump from the
PLDM softoff app when we hit this timeout and the Dump manager
should collect the BMC dump created.

Defect: SW549983
Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>