### PR TITLE
Fix pldm crash caused by corrupted iterator

### DIFF
--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -431,6 +431,9 @@ class HostPDRHandler
     /** @brief Object path and entity association and is only loaded once
      */
     bool objPathEntityAssociation;
+
+    /** @brief variable to capture the host state */
+    bool isHostOff;
 };
 
 } // namespace pldm


### PR DESCRIPTION
- When PDR exchange is completed with phyp, pldm will Query
  HBRT and PHYP for the state of the host sensors in a recursive
  loop. and in the middle of that recursion if some one power off the
  system, the iterator is being corrupted and any access further using
  the iterator would crash pldm.

TestedBy:

- Used automation test on the pldm change and it went successful without
any problem for  5 complete iterations of the test.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>