### PR TITLE
[PLDM FRU]: Removing FRU Record from FRU Record Table

### DIFF
--- a/libpldmresponder/fru.hpp
+++ b/libpldmresponder/fru.hpp
@@ -335,6 +335,12 @@ class FruImpl
      */
     void removeIndividualFRU(const std::string& fruObjPath);
 
+    /** @brief Deletes a FRU record from record set table.
+     *  @param[in] rsi - the FRU Record Set Identifier
+     *  @return none
+     */
+    void deleteFruRecord(uint16_t rsi);
+
     void reGenerateStatePDR(const std::string& fruObjectPath,
                             std::vector<uint32_t>& recordHdlList);
 


### PR DESCRIPTION
When a CEC FRU such as a Fan or Power Supply is concurrently removed,
BMC properly sends event to remove the FRU Record Set ID and to
 modify the Entity Association PDRs.
BMC also removes the corresponding state sensors/ effecters PDRs.
However, BMC does not remove the FRU entry from the FRU Record Table

Modified code to delete FRU Record from FRU Record table.

Tested: Using busctl command and pldmtool
 busctl set-property xyz.openbmc_project.Inventory.Manager
      /xyz/openbmc_project/inventory/system/chassis/motherboard/fan0
     xyz.openbmc_project.Inventory.Item Present b false

 pldmtool fru GetFruRecordTable -v

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>