### PR TITLE
[OEM_IBM]:Power off chassis in case of Hard Poweroff Event

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1671,6 +1671,7 @@ void pldm::responder::oem_ibm_platform::Handler::updateContainerIDofProcLed()
 void pldm::responder::oem_ibm_platform::Handler::
     processPowerCycleOffSoftGraceful()
 {
+    std::cerr << "Received soft graceful power cycle request" << std::endl;
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot";
     pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/host0",
@@ -1690,6 +1691,7 @@ void pldm::responder::oem_ibm_platform::Handler::
 
 void pldm::responder::oem_ibm_platform::Handler::processPowerOffSoftGraceful()
 {
+    std::cerr << "Received soft power off graceful request" << std::endl;
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.State.Chassis.Transition.Off";
     pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/chassis0",
@@ -1709,6 +1711,7 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffSoftGraceful()
 
 void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
 {
+    std::cerr << "Received hard power off graceful request" << std::endl;
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn";
     pldm::utils::DBusMapping dbusMapping{
@@ -1725,6 +1728,7 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
             << "Setting one-time restore policy failed, Unable to set property PowerRestorePolicy. ERROR="
             << e.what() << "\n";
     }
+    processPowerOffSoftGraceful();
 }
 
 void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(bool value)


### PR DESCRIPTION
In case of PLDM_POWER_OFF_HARD_GRACEFUL event PLDM shall update APR
and poweroff Chassis.

The OEM PowerDown effecter was defined to support 3 paths.
1. phyp initiated normal shutdown - PLDM_POWER_OFF_SOFT_GRACEFUL
2. phyp initiated re-ipl - PLDM_POWER_CYCLE_OFF_SOFT_GRACEFUL
3. phyp shutdown due to UPS event - PLDM_POWER_OFF_HARD_GRACEFUL

In all 3 cases, phyp has shut things down and is supposed
to be powered off.

When phyp receives the UPS event, phyp shuts things down
After phyp shuts down and sets the boot parms, phyp sets the OEM
PowerDown effecter to PLDM_POWER_OFF_HARD_GRACEFUL.
Then BMC should power off phyp.

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>