### PR TITLE
fix to persist the indicator status after BMC R/R

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1222,8 +1222,6 @@ void HostPDRHandler::getFRURecordTableMetadataByHost(
         {
             std::cerr << "Failed to receive response for the Get FRU Record "
                          "Table Metadata\n";
-            // update xyz.openbmc_project.State.Decorator.OperationalStatus
-            setOperationStatus();
             return;
         }
 
@@ -1244,8 +1242,6 @@ void HostPDRHandler::getFRURecordTableMetadataByHost(
             std::cerr << "Faile to decode get fru record table metadata resp, "
                          "Message Error: "
                       << "rc=" << rc << ",cc=" << (int)cc << std::endl;
-            // update xyz.openbmc_project.State.Decorator.OperationalStatus
-            setOperationStatus();
             return;
         }
 
@@ -1302,8 +1298,6 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records,
         {
             std::cerr << "Failed to receive response for the Get FRU Record "
                          "Table\n";
-            // update xyz.openbmc_project.State.Decorator.OperationalStatus
-            setOperationStatus();
             return;
         }
 
@@ -1323,8 +1317,6 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records,
             std::cerr
                 << "Failed to decode get fru record table resp, Message Error: "
                 << "rc=" << rc << ",cc=" << (int)cc << std::endl;
-            // update xyz.openbmc_project.State.Decorator.OperationalStatus
-            setOperationStatus();
             return;
         }
 
@@ -1563,9 +1555,6 @@ void HostPDRHandler::setLocationCode(
             }
         }
     }
-
-    // update xyz.openbmc_project.State.Decorator.OperationalStatus
-    setOperationStatus();
 }
 void HostPDRHandler::setOperationStatus()
 {
@@ -1738,6 +1727,9 @@ void HostPDRHandler::createDbusObjects(const PDRList& fruRecordSetPDRs)
     }
     this->setFRUDynamicAssociations();
     getFRURecordTableMetadataByHost(fruRecordSetPDRs);
+
+    // update xyz.openbmc_project.State.Decorator.OperationalStatus
+    setOperationStatus();
     std::cerr << "Refreshing dbus hosted by pldm Completed \n";
 }
 void HostPDRHandler::setFRUDynamicAssociations()

--- a/libpldmresponder/platform_state_sensor.hpp
+++ b/libpldmresponder/platform_state_sensor.hpp
@@ -153,8 +153,8 @@ int getStateSensorReadingsHandler(
                 opState = PLDM_SENSOR_UNAVAILABLE;
             }
 
-            stateField.push_back({opState, PLDM_SENSOR_NORMAL,
-                                  PLDM_SENSOR_UNKNOWN, sensorEvent});
+            stateField.push_back(
+                {opState, sensorEvent, PLDM_SENSOR_UNKNOWN, sensorEvent});
         }
     }
     catch (const std::out_of_range& e)

--- a/libpldmresponder/test/libpldmresponder_platform_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_platform_test.cpp
@@ -620,7 +620,7 @@ TEST(getStateSensorReadingsHandler, testGoodRequest)
     ASSERT_EQ(rc, 0);
     ASSERT_EQ(compSensorCnt, 1);
     ASSERT_EQ(stateField[0].sensor_op_state, PLDM_SENSOR_UNAVAILABLE);
-    ASSERT_EQ(stateField[0].present_state, PLDM_SENSOR_NORMAL);
+    ASSERT_EQ(stateField[0].present_state, PLDM_SENSOR_UNKNOWN);
     ASSERT_EQ(stateField[0].previous_state, PLDM_SENSOR_UNKNOWN);
     ASSERT_EQ(stateField[0].event_state, PLDM_SENSOR_UNKNOWN);
 


### PR DESCRIPTION
This commit sets the present and the event state of the sensors
same. when the led was turned on before R/R the sensor state is updated. 
After R/R event state of the sensor contains the changed state but the 
present state  was pointing to old state. the host was looking at the 
present state field of the sensor after the R/R.
- adds the setOperationStatus in createDbusObjects method

fixes - SW550014

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>