### PR TITLE
PLDM: Log RecvSurveillancePingFail only if PHYP fails to send surveil…

### DIFF
--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -145,10 +145,11 @@ class Handler : public CmdHandler
 
     /** @brief Interface to monitor the surveillance pings from host
      *
+     * @param[in] tid - TID of the host
      * @param[in] value - true or false, to indicate if the timer is
      *                    running or not
      */
-    virtual void setSurvTimer(bool value) = 0;
+    virtual void setSurvTimer(uint8_t tid, bool value) = 0;
 
     virtual ~Handler() = default;
 

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -387,7 +387,7 @@ Response Handler::platformEventMessage(const pldm_msg* request,
             }
             else
             {
-                oemPlatformHandler->setSurvTimer(true);
+                oemPlatformHandler->setSurvTimer(tid, true);
             }
         }
     }

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1727,9 +1727,10 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
     }
 }
 
-void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(bool value)
+void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
+                                                              bool value)
 {
-    if (hostOff)
+    if (tid != HYPERVISOR_TID)
     {
         return;
     }

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -49,6 +49,8 @@ static constexpr auto PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER = 24580;
 constexpr uint16_t ENTITY_INSTANCE_0 = 0;
 constexpr uint16_t ENTITY_INSTANCE_1 = 1;
 
+const pldm::pdr::TerminusID HYPERVISOR_TID = 208;
+
 static constexpr uint8_t HEARTBEAT_TIMEOUT_DELTA = 10;
 struct InstanceInfo
 {
@@ -78,8 +80,8 @@ class Handler : public oem_platform::Handler
         platformHandler(nullptr), mctp_fd(mctp_fd), mctp_eid(mctp_eid),
         requester(requester), event(event), pdrRepo(repo), handler(handler),
         bmcEntityTree(bmcEntityTree), hostEffecterParser(hostEffecterParser),
-        timer(event,
-              std::bind(std::mem_fn(&Handler::setSurvTimer), this, false))
+        timer(event, std::bind(std::mem_fn(&Handler::setSurvTimer), this,
+                               HYPERVISOR_TID, false))
 
     {
         codeUpdate->setVersions();
@@ -433,9 +435,10 @@ class Handler : public oem_platform::Handler
      * surveillance ping and logs informational error if host fails to send the
      * surveillance pings
      *
+     * @param[in] tid - TID of the host
      * @param[in] value - true or false, to indicate if the timer is
      *                    running or not*/
-    void setSurvTimer(bool value);
+    void setSurvTimer(uint8_t tid, bool value);
 
     ~Handler() = default;
 


### PR DESCRIPTION
…lance pings

Whenever we receive a heartbeat message from Host(HB or PHYP),
check for the TID of the HOST to identify if TID is from PHYP
and we failed to receive the heartbeat pings after the elapsed
timer interval, log the informational PEL.

1.Tested by creating a manual guard which will push the system to a reconfig loop.
2.Flashed a new single image and powered on host
3.Intensionally stopped surveillance pings from PHYP using PHYP macro

DEFECT:SW550554

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>