### PR TITLE
[OEM-IBM]Send TM keyword to PHYP reading FC keyword from Dbus

### DIFF
--- a/oem/ibm/configurations/fru/Chassis_VCEN.json
+++ b/oem/ibm/configurations/fru/Chassis_VCEN.json
@@ -29,7 +29,7 @@
         "dbus":
            {
               "interface" : "com.ibm.ipzvpd.VCEN",
-              "property_name" : "TM",
+              "property_name" : "FC",
               "property_type" : "bytearray"
            }
         },

--- a/oem/ibm/configurations/fru/Motherboard_VCEN.json
+++ b/oem/ibm/configurations/fru/Motherboard_VCEN.json
@@ -29,7 +29,7 @@
          "dbus":
             {
                "interface" : "com.ibm.ipzvpd.VCEN",
-               "property_name" : "TM",
+               "property_name" : "FC",
                "property_type" : "bytearray"
             }
       },


### PR DESCRIPTION
Updated Json files to pick FC keyword from Dbus and type remains
the same as that of TM.

Tested using pldmtool

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>