### PR TITLE
Workaround to mark the health status also as "Critical" for absent FRUs.

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1787,9 +1787,17 @@ void HostPDRHandler::setRecordPresent(uint32_t recordHandle)
                 recordEntity.entity_instance_num &&
             dbusEntity.entity_container_id == recordEntity.entity_container_id)
         {
+            std::cerr << "Removing Host FRU "
+                      << "[ " << path << " ]  with entityid [ "
+                      << recordEntity.entity_type << ","
+                      << recordEntity.entity_instance_num << ","
+                      << recordEntity.entity_container_id << "]" << std::endl;
             // if the record has the same entity id, mark that dbus object as
             // not present
             CustomDBus::getCustomDBus().updateItemPresentStatus(path, false);
+            CustomDBus::getCustomDBus().setOperationalStatus(
+                path, false, getParentChassis(path));
+            return;
         }
     }
 }
@@ -1798,6 +1806,7 @@ void HostPDRHandler::deletePDRFromRepo(PDRRecordHandles&& recordHandles)
 {
     for (auto& recordHandle : recordHandles)
     {
+        std::cerr << "Record handle deleted: " << recordHandle << std::endl;
         this->setRecordPresent(recordHandle);
         pldm_delete_by_record_handle(repo, recordHandle, true);
     }

--- a/libpldmresponder/base.cpp
+++ b/libpldmresponder/base.cpp
@@ -240,6 +240,7 @@ void Handler::processSetEventReceiver(
 
 Response Handler::getTID(const pldm_msg* request, size_t /*payloadLength*/)
 {
+    std::cerr << "Got a getTID request " << std::endl;
     // assigned 1 to the bmc as the PLDM terminus
     uint8_t tid = 1;
 

--- a/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
+++ b/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
@@ -263,7 +263,9 @@ uint8_t SlotHandler::fetchSlotSensorState(const std::string& slotObjectPath)
     }
     catch (const std::bad_optional_access& e)
     {
-        std::cerr << e.what() << '\n';
+        std::cerr
+            << "Failed to get the adapterObjectPath from slotObjectPath : "
+            << slotObjectPath << e.what() << '\n';
         return uint8_t(SLOT_STATE_UNKOWN);
     }
 


### PR DESCRIPTION
the health status is marked as "OK" even for a FRU that is removed in MEX
but health status of removed FRUs in CEC would be marked as "Critical".
- fixes : SW549614
- also add debug traces in few parts of the code.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>