### PR TITLE
Clear DumpHandle::fd in dump offload error scenarios

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -40,7 +40,6 @@ static constexpr auto sbeDumpObjPath = "/xyz/openbmc_project/dump/sbe/entry";
 static constexpr auto hardwareDumpObjPath =
     "/xyz/openbmc_project/dump/hardware/entry";
 
-int DumpHandler::fd = -1;
 namespace fs = std::filesystem;
 extern SocketWriteStatus socketWriteStatus;
 

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -6,7 +6,6 @@ namespace pldm
 {
 namespace responder
 {
-
 /** @class DumpHandler
  *
  *  @brief Inherits and implements FileHandler. This class is used
@@ -59,8 +58,8 @@ class DumpHandler : public FileHandler
     ~DumpHandler()
     {}
 
+    static int fd; //!< fd to manage the dump offload to bmc
   private:
-    static int fd;     //!< fd to manage the dump offload to bmc
     uint16_t dumpType; //!< type of the dump
     std::string
         resDumpRequestDirPath; //!< directory where the resource

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -3,6 +3,7 @@
 #include "libpldm/base.h"
 
 #include "common/utils.hpp"
+#include "file_io_type_dump.hpp"
 #include "host-bmc/dbus/custom_dbus.hpp"
 
 #include <sys/mman.h>
@@ -23,7 +24,7 @@ namespace pldm
 using namespace pldm::dbus;
 namespace responder
 {
-
+int DumpHandler::fd = -1;
 std::atomic<SocketWriteStatus> socketWriteStatus = Free;
 std::mutex lockMutex;
 
@@ -176,6 +177,7 @@ void writeToUnixSocket(const int sock, const char* buf,
                 std::cerr << "writeToUnixSocket: Failed to write " << errno
                           << std::endl;
                 close(sock);
+                DumpHandler::fd = -1;
                 socketWriteStatus = Error;
                 return;
             }


### PR DESCRIPTION
In case of unix socket close from bmcweb side due to network issue
then pldm side DumpHandle::fd needs to reset to -1.

Tested By:

Abrutply closing client side connection while offloading dump.
Tested few iterations