### PR TITLE
Change LanesInUse to int64_t

### DIFF
--- a/host-bmc/dbus/pcie_device.cpp
+++ b/host-bmc/dbus/pcie_device.cpp
@@ -17,13 +17,13 @@ auto PCIeDevice::generationInUse(Generations value) -> Generations
         PCIeDevice::generationInUse(value);
 }
 
-size_t PCIeDevice::lanesInUse() const
+int64_t PCIeDevice::lanesInUse() const
 {
     return sdbusplus::xyz::openbmc_project::Inventory::Item::server::
         PCIeDevice::lanesInUse();
 }
 
-size_t PCIeDevice::lanesInUse(size_t value)
+int64_t PCIeDevice::lanesInUse(int64_t value)
 {
     return sdbusplus::xyz::openbmc_project::Inventory::Item::server::
         PCIeDevice::lanesInUse(value);

--- a/host-bmc/dbus/pcie_device.hpp
+++ b/host-bmc/dbus/pcie_device.hpp
@@ -36,10 +36,10 @@ class PCIeDevice : public ItemDevice
     }
 
     /** Get lanes in use */
-    size_t lanesInUse() const override;
+    int64_t lanesInUse() const override;
 
     /** Set lanes in use */
-    size_t lanesInUse(size_t value) override;
+    int64_t lanesInUse(int64_t value) override;
 
     /** Get Generation in use */
     Generations generationInUse() const override;

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -287,7 +287,7 @@ std::string PCIeInfoHandler::getDownStreamChassis(
 void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
     uint8_t linkType, const std::pair<std::string, std::string>& slotAndAdapter,
     const uint32_t& linkId, const std::string& linkStatus, uint8_t linkSpeed,
-    uint32_t linkWidth, bool isHostedByPLDM)
+    int64_t linkWidth, bool isHostedByPLDM)
 {
     if (!slotAndAdapter.first.empty())
     {
@@ -353,7 +353,7 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
 
             // set link width
             setProperty(slotAndAdapter.second, "LanesInUse", linkWidth,
-                        itemPCIeDevice, "uint32_t");
+                        itemPCIeDevice, "int64_t");
             std::filesystem::path adapter(slotAndAdapter.second);
 
             std::cerr << "Primary Link, "
@@ -399,7 +399,7 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
 
                 // set link width
                 setProperty(slotAndAdapter.second, "LanesInUse", linkWidth,
-                            itemPCIeDevice, "uint32_t");
+                            itemPCIeDevice, "int64_t");
             }
 
             std::filesystem::path adapter(slotAndAdapter.second);
@@ -417,7 +417,7 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
 void PCIeInfoHandler::parsePrimaryLink(
     uint8_t linkType, const io_slot_location_t& ioSlotLocationCode,
     const localport_t& localPortLocation, const uint32_t& linkId,
-    const std::string& linkStatus, uint8_t linkSpeed, uint32_t linkWidth,
+    const std::string& linkStatus, uint8_t linkSpeed, int64_t linkWidth,
     uint8_t parentLinkId)
 {
     // Check the io_slot_location_code size
@@ -511,7 +511,7 @@ void PCIeInfoHandler::parsePrimaryLink(
 void PCIeInfoHandler::parseSecondaryLink(
     uint8_t linkType, const io_slot_location_t& ioSlotLocationCode,
     const localport_t& /*localPortLocation*/, const uint32_t& linkId,
-    const std::string& linkStatus, uint8_t linkSpeed, uint32_t linkWidth)
+    const std::string& linkStatus, uint8_t linkSpeed, int64_t linkWidth)
 {
     if (ioSlotLocationCode.size() == 1)
     {

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -52,8 +52,9 @@ static std::map<uint8_t, std::string> link_speed{
                                                                          // BMC
     {0xFF, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Unknown"}};
 
-static std::map<uint8_t, uint32_t> link_width{{0x01, 1}, {0x02, 2},  {0x04, 4},
-                                              {0x08, 8}, {0x10, 16}, {0xFF, 0}};
+static std::map<uint8_t, int64_t> link_width{{0x01, 1}, {0x02, 2},  {0x04, 4},
+                                             {0x08, 8}, {0x10, 16}, {0xFF, -1},
+                                             {0x00, 0}};
 
 struct SlotLocCode_t
 {
@@ -108,7 +109,7 @@ using linkId_t = uint16_t;
 using linkStatus_t = std::string;
 using linkType_t = uint8_t;
 using linkSpeed_t = uint8_t;
-using linkWidth_t = uint32_t;
+using linkWidth_t = int64_t;
 using pcieHostBidgeloc_t = std::string;
 using localport_top_t = std::string;
 using localport_bot_t = std::string;
@@ -229,17 +230,17 @@ class PCIeInfoHandler : public FileHandler
                                   const localport_t& localPortLocation,
                                   const uint32_t& linkId,
                                   const std::string& linkStatus,
-                                  uint8_t linkSpeed, uint32_t linkWidth,
+                                  uint8_t linkSpeed, int64_t linkWidth,
                                   uint8_t parentLinkId);
     virtual void parseSecondaryLink(
         uint8_t linkType, const io_slot_location_t& ioSlotLocationCode,
         const localport_t& localPortLocation, const uint32_t& linkId,
-        const std::string& linkStatus, uint8_t linkSpeed, uint32_t linkWidth);
+        const std::string& linkStatus, uint8_t linkSpeed, int64_t linkWidth);
     virtual void setTopologyOnSlotAndAdapter(
         uint8_t linkType,
         const std::pair<std::string, std::string>& slotAndAdapter,
         const uint32_t& linkId, const std::string& linkStatus,
-        uint8_t linkSpeed, uint32_t linkWidth, bool isHostedByPLDM);
+        uint8_t linkSpeed, int64_t linkWidth, bool isHostedByPLDM);
 
     virtual void setProperty(const std::string& objPath,
                              const std::string& propertyName,


### PR DESCRIPTION
LanesInUse is changed from size_t to int64_t to cater for
unknown case, this PR would align pldm changes to the new PDI
change.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>