### PR TITLE
PLDM: Check host state before logging PEL

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1734,7 +1734,7 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
 void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
                                                               bool value)
 {
-    if (tid != HYPERVISOR_TID)
+    if (hostOff || hostTransitioningToOff || tid != HYPERVISOR_TID)
     {
         return;
     }

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -116,6 +116,13 @@ class Handler : public oem_platform::Handler
                              "xyz.openbmc_project.State.Host.HostState.Running")
                     {
                         hostOff = false;
+                        hostTransitioningToOff = false;
+                    }
+                    else if (
+                        propVal ==
+                        "xyz.openbmc_project.State.Host.HostState.TransitioningToOff")
+                    {
+                        hostTransitioningToOff = true;
                     }
                 }
             });
@@ -509,6 +516,8 @@ class Handler : public oem_platform::Handler
     sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
 
     bool hostOff = true;
+
+    bool hostTransitioningToOff = true;
 
     int setEventReceiverCnt = 0;
 


### PR DESCRIPTION
Adding a check to check the host state is either
running or transitioningToOff, before creating the
error log if pldm fails to receive the surveillance ping
within the elapsed time of 120 seconds.

DEFECT:SW551173

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>