### PR TITLE
Handle Empty LicenseString

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -345,6 +345,10 @@ class Handler : public CmdHandler
                     {
                         pldm::utils::PropertyValue licStrVal{prop.second};
                         licenseStr = std::get<std::string>(licStrVal);
+                        if (licenseStr.empty())
+                        {
+                            return;
+                        }
                         dbusToFileHandlers
                             .emplace_back(
                                 std::make_unique<pldm::requester::oem_ibm::


### PR DESCRIPTION
Currently there is no check for empty LicenseString
This commit adds check for empty license string.

This PR fixes https://w3.rchland.ibm.com/projects/bestquest/?defect=SW544557#nle79
MUSTFIX approved

Tested By:
Set empty string to LicenseString D-bus property