### PR TITLE
Refresh dbus objects based on a signal from host

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -182,6 +182,7 @@ HostPDRHandler::HostPDRHandler(
                     this->mergedHostParents = false;
                     this->objMapIndex = objPathMap.begin();
                     this->sensorIndex = stateSensorPDRs.begin();
+                    fruRecordSetPDRs.clear();
 
                     // After a power off , the remote notes will be deleted
                     // from the entity association tree, making the nodes point
@@ -411,6 +412,14 @@ int HostPDRHandler::handleStateSensorEvent(
 
             break;
         }
+        else if (stateSetId[0] == PLDM_STATE_SET_VERSION)
+        {
+            // There is a version changed on any of the dbus objects
+            std::cout
+                << "Got a signal from Host about a possible change in Version\n";
+            createDbusObjects();
+            return PLDM_SUCCESS;
+        }
     }
 
     auto rc = stateSensorHandler.eventAction(entry, state);
@@ -627,8 +636,6 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
                                      size_t respMsgLen)
 {
     static bool merged = false;
-    static PDRList fruRecordSetPDRs{};
-
     uint32_t nextRecordHandle{};
     uint32_t prevRh{};
     uint8_t tlEid = 0;
@@ -870,14 +877,13 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
 
         /*received last record*/
         this->parseStateSensorPDRs();
-        this->createDbusObjects(fruRecordSetPDRs);
+        this->createDbusObjects();
         if (isHostUp())
         {
             std::cout << "Host is UP & Completed the PDR Exchange with host\n";
             this->setHostSensorState();
         }
 
-        fruRecordSetPDRs.clear();
         entityAssociations.clear();
         mergedHostParents = false;
 
@@ -1194,8 +1200,7 @@ void HostPDRHandler::_setHostSensorState()
     }
 }
 
-void HostPDRHandler::getFRURecordTableMetadataByHost(
-    const PDRList& fruRecordSetPDRs)
+void HostPDRHandler::getFRURecordTableMetadataByHost()
 {
     auto instanceId = requester.getInstanceId(mctp_eid);
     std::vector<uint8_t> requestMsg(
@@ -1213,11 +1218,10 @@ void HostPDRHandler::getFRURecordTableMetadataByHost(
         return;
     }
 
-    auto getFruRecordTableMetadataResponseHandler = [this, fruRecordSetPDRs](
-                                                        mctp_eid_t /*eid*/,
-                                                        const pldm_msg*
-                                                            response,
-                                                        size_t respMsgLen) {
+    auto getFruRecordTableMetadataResponseHandler = [this](mctp_eid_t /*eid*/,
+                                                           const pldm_msg*
+                                                               response,
+                                                           size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
             std::cerr << "Failed to receive response for the Get FRU Record "
@@ -1246,7 +1250,7 @@ void HostPDRHandler::getFRURecordTableMetadataByHost(
         }
 
         // pass total to getFRURecordTableByHost
-        this->getFRURecordTableByHost(total, fruRecordSetPDRs);
+        this->getFRURecordTableByHost(total);
     };
 
     rc = handler->registerRequest(
@@ -1262,8 +1266,7 @@ void HostPDRHandler::getFRURecordTableMetadataByHost(
     return;
 }
 
-void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records,
-                                             const PDRList& fruRecordSetPDRs)
+void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
 {
     fruRecordData.clear();
 
@@ -1289,11 +1292,10 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records,
         return;
     }
 
-    auto getFruRecordTableResponseHandler = [total_table_records, this,
-                                             fruRecordSetPDRs](
-                                                mctp_eid_t /*eid*/,
-                                                const pldm_msg* response,
-                                                size_t respMsgLen) {
+    auto getFruRecordTableResponseHandler = [total_table_records,
+                                             this](mctp_eid_t /*eid*/,
+                                                   const pldm_msg* response,
+                                                   size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
             std::cerr << "Failed to receive response for the Get FRU Record "
@@ -1331,7 +1333,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records,
             return;
         }
 
-        this->setLocationCode(fruRecordSetPDRs, fruRecordData);
+        this->setLocationCode(fruRecordData);
     };
 
     rc = handler->registerRequest(
@@ -1485,8 +1487,7 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
     return;
 }
 
-uint16_t HostPDRHandler::getRSI(const PDRList& fruRecordSetPDRs,
-                                const pldm_entity& entity)
+uint16_t HostPDRHandler::getRSI(const pldm_entity& entity)
 {
     uint16_t fruRSI = 0;
 
@@ -1508,13 +1509,12 @@ uint16_t HostPDRHandler::getRSI(const PDRList& fruRecordSetPDRs,
 }
 
 void HostPDRHandler::setLocationCode(
-    const PDRList& fruRecordSetPDRs,
     const std::vector<responder::pdr_utils::FruRecordDataFormat>& fruRecordData)
 {
     for (auto& entity : objPathMap)
     {
         pldm_entity node = pldm_entity_extract(entity.second);
-        auto fruRSI = getRSI(fruRecordSetPDRs, node);
+        auto fruRSI = getRSI(node);
 
         for (auto& data : fruRecordData)
         {
@@ -1545,6 +1545,11 @@ void HostPDRHandler::setLocationCode(
                     if (tlv.fruFieldType == PLDM_FRU_FIELD_TYPE_VERSION &&
                         node.entity_type == PLDM_ENTITY_SYSTEM_CHASSIS)
                     {
+                        std::cout << "Refreshing the mex firmware version : "
+                                  << std::string(reinterpret_cast<const char*>(
+                                                     tlv.fruFieldValue.data()),
+                                                 tlv.fruFieldLen)
+                                  << std::endl;
                         CustomDBus::getCustomDBus().setSoftwareVersion(
                             entity.first,
                             std::string(reinterpret_cast<const char*>(
@@ -1662,7 +1667,7 @@ void HostPDRHandler::setAvailabilityState(const std::string& path)
     CustomDBus::getCustomDBus().setAvailabilityState(path, true);
 }
 
-void HostPDRHandler::createDbusObjects(const PDRList& fruRecordSetPDRs)
+void HostPDRHandler::createDbusObjects()
 {
     std::cerr << "Refreshing dbus hosted by pldm Started \n";
 
@@ -1739,7 +1744,7 @@ void HostPDRHandler::createDbusObjects(const PDRList& fruRecordSetPDRs)
         }
     }
     this->setFRUDynamicAssociations();
-    getFRURecordTableMetadataByHost(fruRecordSetPDRs);
+    getFRURecordTableMetadataByHost();
 
     // update xyz.openbmc_project.State.Decorator.OperationalStatus
     setOperationStatus();

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -246,42 +246,38 @@ class HostPDRHandler
                                sdeventplus::source::EventBase& source);
 
     /** @brief Get FRU record table metadata by host
-     *
-     *  @param[out] uint16_t    - total table records
      */
-    void getFRURecordTableMetadataByHost(const PDRList& fruRecordSetPDRs);
+    void getFRURecordTableMetadataByHost();
 
     /** @brief Set Location Code in the dbus objects
      *
-     *  @param[in] fruRecordSetPDRs - the Fru Record set PDR's
      *  @param[in] fruRecordData - the Fru Record Data
      */
 
     void setLocationCode(
-        const PDRList& fruRecordSetPDRs,
         const std::vector<responder::pdr_utils::FruRecordDataFormat>&
             fruRecordData);
     void setFRUDynamicAssociations();
 
     /** @brief Get FRU record table by host
      *
+     *  @param[in] uint16_t    - total table records
+     *
      *  @return
      */
-    void getFRURecordTableByHost(uint16_t& total,
-                                 const PDRList& fruRecordSetPDRs);
+    void getFRURecordTableByHost(uint16_t& total);
 
     /** @brief Create DBUS objects
      *
      * @ return
      */
-    void createDbusObjects(const PDRList& fruRecordSetPDRs);
+    void createDbusObjects();
 
     /** @brief Get FRU Record Set Identifier from FRU Record data Format
-     *  @param[in] fruRecordSetPDRs - fru record set pdr
      *  @param[in] entity           - PLDM entity information
      *  @return
      */
-    uint16_t getRSI(const PDRList& fruRecordSetPDRs, const pldm_entity& entity);
+    uint16_t getRSI(const pldm_entity& entity);
 
     /** @brief Get present state from state sensor readings
      *  @param[in] tid          - terminus id
@@ -434,6 +430,9 @@ class HostPDRHandler
 
     /** @brief variable to capture the host state */
     bool isHostOff;
+
+    /** cache the fru record set PDR's */
+    PDRList fruRecordSetPDRs{};
 };
 
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -320,9 +320,6 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
             }
             else
             {
-                std::cerr << "is hosted by pldm is : false\n";
-                std::cerr << "slot : " << slotAndAdapter.first << std::endl;
-                std::cerr << "adapter : " << slotAndAdapter.second << std::endl;
                 // its a secondary link , but its an nvme slot hosted by
                 // inventory manager
                 setProperty(slotAndAdapter.first, "BusId", linkId, itemPCIeSlot,


### PR DESCRIPTION
PHYP sends a sensor event on PLDM_STATE_SET_VERSION
state set to indicate that there is a change in the
mex io enclosure version.

This PR would react to the event and refresh the dbus
objects hosted by PLDM. This PR would also remove extra
unwanted traces.

Fixes : SW550806

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>