### PR TITLE
[OEM_IBM]:Create LED PDRs for unpopulated DIMMs and Procs

### DIFF
--- a/host-bmc/utils.hpp
+++ b/host-bmc/utils.hpp
@@ -39,6 +39,7 @@ const std::map<EntityType, EntityName> entityMaps = {
     {PLDM_ENTITY_SLOT, "slot"},
     {PLDM_ENTITY_CONNECTOR, "connector"},
     {PLDM_ENTITY_CARD, "adapter"},
+    {PLDM_ENTITY_SOCKET, "socket"},
     {PLDM_ENTITY_SLOT | 0x8000, "logical_slot"}};
 
 namespace hostbmc

--- a/oem/ibm/configurations/pdr/ibm,everest/11.json
+++ b/oem/ibm/configurations/pdr/ibm,everest/11.json
@@ -345,9 +345,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 17,
@@ -355,7 +374,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -364,9 +383,9 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
         "instance" : 2,
-        "container" : 4,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 17,
@@ -374,7 +393,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -383,104 +402,9 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
         "instance" : 3,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 5,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 6,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 7,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu3_c61_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 8,
-        "container" : 4,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 17,
@@ -514,8 +438,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -533,8 +457,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -552,8 +476,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -571,8 +495,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -590,8 +514,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -609,8 +533,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -628,8 +552,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -647,8 +571,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -666,8 +590,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -685,8 +609,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -704,8 +628,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -723,8 +647,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -742,8 +666,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -761,8 +685,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -780,8 +704,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -799,8 +723,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -818,8 +742,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -837,8 +761,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -856,8 +780,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -875,8 +799,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -894,8 +818,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -913,8 +837,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -932,8 +856,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -951,8 +875,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -970,8 +894,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -989,8 +913,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1008,8 +932,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1027,8 +951,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1046,8 +970,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1065,8 +989,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1084,8 +1008,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1103,8 +1027,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1122,8 +1046,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 33,
+        "type" : 65,
+        "instance" : 32,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1141,8 +1065,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 34,
+        "type" : 65,
+        "instance" : 33,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1160,8 +1084,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 35,
+        "type" : 65,
+        "instance" : 34,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1179,8 +1103,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 36,
+        "type" : 65,
+        "instance" : 35,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1198,8 +1122,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 37,
+        "type" : 65,
+        "instance" : 36,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1217,8 +1141,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 38,
+        "type" : 65,
+        "instance" : 37,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1236,8 +1160,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 39,
+        "type" : 65,
+        "instance" : 38,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1255,8 +1179,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 40,
+        "type" : 65,
+        "instance" : 39,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1274,8 +1198,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 41,
+        "type" : 65,
+        "instance" : 40,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1293,8 +1217,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 42,
+        "type" : 65,
+        "instance" : 41,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1312,8 +1236,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 43,
+        "type" : 65,
+        "instance" : 42,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1331,8 +1255,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 44,
+        "type" : 65,
+        "instance" : 43,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1350,8 +1274,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 45,
+        "type" : 65,
+        "instance" : 44,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1369,8 +1293,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 46,
+        "type" : 65,
+        "instance" : 45,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1388,8 +1312,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 47,
+        "type" : 65,
+        "instance" : 46,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1407,8 +1331,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 48,
+        "type" : 65,
+        "instance" : 47,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1426,8 +1350,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 49,
+        "type" : 65,
+        "instance" : 48,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1445,8 +1369,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 50,
+        "type" : 65,
+        "instance" : 49,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1464,8 +1388,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 51,
+        "type" : 65,
+        "instance" : 50,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1483,8 +1407,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 52,
+        "type" : 65,
+        "instance" : 51,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1502,8 +1426,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 53,
+        "type" : 65,
+        "instance" : 52,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1521,8 +1445,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 54,
+        "type" : 65,
+        "instance" : 53,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1540,8 +1464,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 55,
+        "type" : 65,
+        "instance" : 54,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1559,8 +1483,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 56,
+        "type" : 65,
+        "instance" : 55,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1578,8 +1502,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 57,
+        "type" : 65,
+        "instance" : 56,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1597,8 +1521,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 58,
+        "type" : 65,
+        "instance" : 57,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1616,8 +1540,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 59,
+        "type" : 65,
+        "instance" : 58,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1635,8 +1559,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 60,
+        "type" : 65,
+        "instance" : 59,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1654,8 +1578,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 61,
+        "type" : 65,
+        "instance" : 60,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1673,8 +1597,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 62,
+        "type" : 65,
+        "instance" : 61,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1692,8 +1616,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 63,
+        "type" : 65,
+        "instance" : 62,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1711,8 +1635,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 64,
+        "type" : 65,
+        "instance" : 63,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3025,9 +2949,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 1,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -3044,28 +2968,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1",
-                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
-                "property_type": "bool",
-                "property_values" : [true, false]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 1,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -3082,28 +2987,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm2/cpu1",
-                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
-                "property_type": "bool",
-                "property_values" : [true, false]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 5,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 2,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -3120,28 +3006,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 6,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm3/cpu1",
-                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
-                "property_type": "bool",
-                "property_values" : [true, false]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 7,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 3,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -3150,25 +3017,6 @@
             },
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0",
-                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
-                "property_type": "bool",
-                "property_values" : [true, false]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 8,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
                 "property_name": "Functional",
                 "property_type": "bool",
@@ -3194,8 +3042,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3213,8 +3061,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3232,8 +3080,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3251,8 +3099,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3270,8 +3118,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3282,15 +3130,15 @@
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Asserted",
+                "property_name": "Functional",
                 "property_type": "bool",
                 "property_values" : [true, false]
              }
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3301,15 +3149,15 @@
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
+                "property_name": "Asserted",
                 "property_type": "bool",
                 "property_values" : [true, false]
              }
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3327,8 +3175,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3346,8 +3194,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3365,8 +3213,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3384,8 +3232,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3403,8 +3251,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3422,8 +3270,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3441,8 +3289,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3460,8 +3308,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3479,8 +3327,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3498,8 +3346,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3517,8 +3365,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3536,8 +3384,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3555,8 +3403,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3574,8 +3422,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3593,8 +3441,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3612,8 +3460,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3631,8 +3479,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3650,8 +3498,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3669,8 +3517,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3688,8 +3536,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3707,8 +3555,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3726,8 +3574,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3745,8 +3593,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3764,8 +3612,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3783,8 +3631,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3802,8 +3650,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 33,
+        "type" : 65,
+        "instance" : 32,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3821,8 +3669,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 34,
+        "type" : 65,
+        "instance" : 33,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3840,8 +3688,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 35,
+        "type" : 65,
+        "instance" : 34,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3859,8 +3707,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 36,
+        "type" : 65,
+        "instance" : 35,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3878,8 +3726,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 37,
+        "type" : 65,
+        "instance" : 36,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3897,8 +3745,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 38,
+        "type" : 65,
+        "instance" : 37,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3916,8 +3764,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 39,
+        "type" : 65,
+        "instance" : 38,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3935,8 +3783,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 40,
+        "type" : 65,
+        "instance" : 39,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3954,8 +3802,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 41,
+        "type" : 65,
+        "instance" : 40,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3973,8 +3821,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 42,
+        "type" : 65,
+        "instance" : 41,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -3992,8 +3840,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 43,
+        "type" : 65,
+        "instance" : 42,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4011,8 +3859,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 44,
+        "type" : 65,
+        "instance" : 43,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4030,8 +3878,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 45,
+        "type" : 65,
+        "instance" : 44,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4049,8 +3897,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 46,
+        "type" : 65,
+        "instance" : 45,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4068,8 +3916,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 47,
+        "type" : 65,
+        "instance" : 46,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4087,8 +3935,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 48,
+        "type" : 65,
+        "instance" : 47,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4106,8 +3954,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 49,
+        "type" : 65,
+        "instance" : 48,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4125,8 +3973,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 50,
+        "type" : 65,
+        "instance" : 49,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4144,8 +3992,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 51,
+        "type" : 65,
+        "instance" : 50,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4163,8 +4011,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 52,
+        "type" : 65,
+        "instance" : 51,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4182,8 +4030,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 53,
+        "type" : 65,
+        "instance" : 52,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4201,8 +4049,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 54,
+        "type" : 65,
+        "instance" : 53,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4220,8 +4068,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 55,
+        "type" : 65,
+        "instance" : 54,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4239,8 +4087,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 56,
+        "type" : 65,
+        "instance" : 55,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4258,8 +4106,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 57,
+        "type" : 65,
+        "instance" : 56,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4277,8 +4125,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 58,
+        "type" : 65,
+        "instance" : 57,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4296,8 +4144,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 59,
+        "type" : 65,
+        "instance" : 58,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4315,8 +4163,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 60,
+        "type" : 65,
+        "instance" : 59,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4334,8 +4182,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 61,
+        "type" : 65,
+        "instance" : 60,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4353,8 +4201,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 62,
+        "type" : 65,
+        "instance" : 61,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4372,8 +4220,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 63,
+        "type" : 65,
+        "instance" : 62,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -4391,8 +4239,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 64,
+        "type" : 65,
+        "instance" : 63,
         "container" : 3,
         "effecters" : [{
             "set" : {

--- a/oem/ibm/configurations/pdr/ibm,everest/4.json
+++ b/oem/ibm/configurations/pdr/ibm,everest/4.json
@@ -348,9 +348,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 17,
@@ -358,7 +377,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -367,9 +386,9 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
         "instance" : 2,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 17,
@@ -377,7 +396,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -386,104 +405,9 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
         "instance" : 3,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 5,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 6,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 7,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu3_c61_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 8,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 17,
@@ -517,8 +441,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -536,8 +460,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -555,8 +479,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -574,8 +498,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -593,8 +517,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -612,8 +536,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -631,8 +555,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -650,8 +574,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -669,8 +593,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -688,8 +612,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -707,8 +631,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -726,8 +650,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -745,8 +669,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -764,8 +688,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -783,8 +707,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -802,8 +726,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -821,8 +745,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -840,8 +764,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -859,8 +783,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -878,8 +802,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -897,8 +821,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -916,8 +840,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -935,8 +859,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -954,8 +878,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -973,8 +897,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -992,8 +916,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1011,8 +935,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1030,8 +954,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1049,8 +973,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1068,8 +992,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1087,8 +1011,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1106,8 +1030,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1125,8 +1049,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 33,
+        "type" : 65,
+        "instance" : 32,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1144,8 +1068,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 34,
+        "type" : 65,
+        "instance" : 33,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1163,8 +1087,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 35,
+        "type" : 65,
+        "instance" : 34,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1182,8 +1106,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 36,
+        "type" : 65,
+        "instance" : 35,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1201,8 +1125,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 37,
+        "type" : 65,
+        "instance" : 36,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1220,8 +1144,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 38,
+        "type" : 65,
+        "instance" : 37,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1239,8 +1163,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 39,
+        "type" : 65,
+        "instance" : 38,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1258,8 +1182,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 40,
+        "type" : 65,
+        "instance" : 39,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1277,8 +1201,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 41,
+        "type" : 65,
+        "instance" : 40,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1296,8 +1220,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 42,
+        "type" : 65,
+        "instance" : 41,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1315,8 +1239,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 43,
+        "type" : 65,
+        "instance" : 42,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1334,8 +1258,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 44,
+        "type" : 65,
+        "instance" : 43,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1353,8 +1277,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 45,
+        "type" : 65,
+        "instance" : 44,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1372,8 +1296,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 46,
+        "type" : 65,
+        "instance" : 45,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1391,8 +1315,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 47,
+        "type" : 65,
+        "instance" : 46,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1410,8 +1334,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 48,
+        "type" : 65,
+        "instance" : 47,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1429,8 +1353,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 49,
+        "type" : 65,
+        "instance" : 48,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1448,8 +1372,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 50,
+        "type" : 65,
+        "instance" : 49,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1467,8 +1391,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 51,
+        "type" : 65,
+        "instance" : 50,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1486,8 +1410,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 52,
+        "type" : 65,
+        "instance" : 51,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1505,8 +1429,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 53,
+        "type" : 65,
+        "instance" : 52,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1524,8 +1448,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 54,
+        "type" : 65,
+        "instance" : 53,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1543,8 +1467,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 55,
+        "type" : 65,
+        "instance" : 54,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1562,8 +1486,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 56,
+        "type" : 65,
+        "instance" : 55,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1581,8 +1505,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 57,
+        "type" : 65,
+        "instance" : 56,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1600,8 +1524,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 58,
+        "type" : 65,
+        "instance" : 57,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1619,8 +1543,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 59,
+        "type" : 65,
+        "instance" : 58,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1638,8 +1562,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 60,
+        "type" : 65,
+        "instance" : 59,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1657,8 +1581,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 61,
+        "type" : 65,
+        "instance" : 60,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1676,8 +1600,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 62,
+        "type" : 65,
+        "instance" : 61,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1695,8 +1619,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 63,
+        "type" : 65,
+        "instance" : 62,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1714,8 +1638,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 64,
+        "type" : 65,
+        "instance" : 63,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3030,9 +2954,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 10,
@@ -3040,7 +2983,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_fault",
+                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_fault",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -3049,9 +2992,9 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
         "instance" : 2,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 10,
@@ -3059,7 +3002,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_fault",
+                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_fault",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -3068,104 +3011,9 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
         "instance" : 3,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 5,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 6,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 7,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu3_c61_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 8,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 10,
@@ -3199,8 +3047,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3218,8 +3066,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3237,8 +3085,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3256,8 +3104,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3275,8 +3123,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3294,8 +3142,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3313,8 +3161,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3332,8 +3180,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3351,8 +3199,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3370,8 +3218,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3389,8 +3237,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3408,8 +3256,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3427,8 +3275,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3446,8 +3294,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3465,8 +3313,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3484,8 +3332,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3503,8 +3351,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3522,8 +3370,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3541,8 +3389,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3560,8 +3408,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3579,8 +3427,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3598,8 +3446,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3617,8 +3465,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3636,8 +3484,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3655,8 +3503,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3674,8 +3522,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3693,8 +3541,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3712,8 +3560,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3731,8 +3579,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3750,8 +3598,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3769,8 +3617,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3788,8 +3636,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3807,8 +3655,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 33,
+        "type" : 65,
+        "instance" : 32,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3826,8 +3674,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 34,
+        "type" : 65,
+        "instance" : 33,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3845,8 +3693,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 35,
+        "type" : 65,
+        "instance" : 34,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3864,8 +3712,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 36,
+        "type" : 65,
+        "instance" : 35,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3883,8 +3731,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 37,
+        "type" : 65,
+        "instance" : 36,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3902,8 +3750,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 38,
+        "type" : 65,
+        "instance" : 37,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3921,8 +3769,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 39,
+        "type" : 65,
+        "instance" : 38,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3940,8 +3788,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 40,
+        "type" : 65,
+        "instance" : 39,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3959,8 +3807,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 41,
+        "type" : 65,
+        "instance" : 40,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3978,8 +3826,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 42,
+        "type" : 65,
+        "instance" : 41,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -3997,8 +3845,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 43,
+        "type" : 65,
+        "instance" : 42,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4016,8 +3864,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 44,
+        "type" : 65,
+        "instance" : 43,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4035,8 +3883,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 45,
+        "type" : 65,
+        "instance" : 44,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4054,8 +3902,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 46,
+        "type" : 65,
+        "instance" : 45,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4073,8 +3921,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 47,
+        "type" : 65,
+        "instance" : 46,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4092,8 +3940,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 48,
+        "type" : 65,
+        "instance" : 47,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4111,8 +3959,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 49,
+        "type" : 65,
+        "instance" : 48,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4130,8 +3978,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 50,
+        "type" : 65,
+        "instance" : 49,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4149,8 +3997,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 51,
+        "type" : 65,
+        "instance" : 50,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4168,8 +4016,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 52,
+        "type" : 65,
+        "instance" : 51,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4187,8 +4035,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 53,
+        "type" : 65,
+        "instance" : 52,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4206,8 +4054,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 54,
+        "type" : 65,
+        "instance" : 53,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4225,8 +4073,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 55,
+        "type" : 65,
+        "instance" : 54,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4244,8 +4092,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 56,
+        "type" : 65,
+        "instance" : 55,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4263,8 +4111,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 57,
+        "type" : 65,
+        "instance" : 56,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4282,8 +4130,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 58,
+        "type" : 65,
+        "instance" : 57,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4301,8 +4149,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 59,
+        "type" : 65,
+        "instance" : 58,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4320,8 +4168,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 60,
+        "type" : 65,
+        "instance" : 59,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4339,8 +4187,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 61,
+        "type" : 65,
+        "instance" : 60,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4358,8 +4206,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 62,
+        "type" : 65,
+        "instance" : 61,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4377,8 +4225,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 63,
+        "type" : 65,
+        "instance" : 62,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -4396,8 +4244,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 64,
+        "type" : 65,
+        "instance" : 63,
         "container" : 3,
         "sensors" : [{
             "set" : {

--- a/oem/ibm/configurations/pdr/ibm,rainier-1s4u/11.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-1s4u/11.json
@@ -226,28 +226,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 1,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 17,
@@ -315,8 +296,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -334,8 +315,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -353,8 +334,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -372,8 +353,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -391,8 +372,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -410,8 +391,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -429,8 +410,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -448,8 +429,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1132,9 +1113,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 1,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -1151,9 +1132,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 1,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -1238,8 +1219,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1257,8 +1238,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1276,8 +1257,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1295,8 +1276,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1314,8 +1295,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1333,8 +1314,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1352,8 +1333,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1371,8 +1352,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "effecters" : [{
             "set" : {

--- a/oem/ibm/configurations/pdr/ibm,rainier-1s4u/4.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-1s4u/4.json
@@ -229,28 +229,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 1,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 17,
@@ -318,8 +299,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -337,8 +318,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -356,8 +337,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -375,8 +356,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -394,8 +375,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -413,8 +394,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -432,8 +413,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -451,8 +432,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1162,27 +1143,8 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 1,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
+        "type" : 190,
+        "instance" : 0,
         "container" : 4,
         "sensors" : [{
             "set" : {
@@ -1251,8 +1213,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1270,8 +1232,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1289,8 +1251,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1308,8 +1270,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1327,8 +1289,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1346,8 +1308,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1365,8 +1327,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1384,8 +1346,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "sensors" : [{
             "set" : {

--- a/oem/ibm/configurations/pdr/ibm,rainier-2u/11.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-2u/11.json
@@ -260,66 +260,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 17,
@@ -404,8 +366,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -423,8 +385,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -442,8 +404,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -461,8 +423,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -480,8 +442,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -499,8 +461,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -518,8 +480,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -537,8 +499,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -556,8 +518,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -575,8 +537,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -594,8 +556,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -613,8 +575,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -632,8 +594,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -651,8 +613,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -670,8 +632,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -689,8 +651,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -708,8 +670,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -727,8 +689,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -746,8 +708,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -765,8 +727,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -784,8 +746,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -803,8 +765,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -822,8 +784,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -841,8 +803,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -860,8 +822,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -879,8 +841,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -898,8 +860,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -917,8 +879,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -936,8 +898,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -955,8 +917,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -974,8 +936,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -993,8 +955,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1949,9 +1911,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 1,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -1968,28 +1930,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1",
-                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
-                "property_type": "bool",
-                "property_values" : [true, false]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 1,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -1998,25 +1941,6 @@
             },
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0",
-                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
-                "property_type": "bool",
-                "property_values" : [true, false]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
                 "property_name": "Functional",
                 "property_type": "bool",
@@ -2093,8 +2017,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2112,8 +2036,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2131,8 +2055,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2150,8 +2074,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2169,8 +2093,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2188,8 +2112,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2207,8 +2131,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2226,8 +2150,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2245,8 +2169,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2264,8 +2188,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2283,8 +2207,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2302,8 +2226,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2321,8 +2245,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2340,8 +2264,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2359,8 +2283,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2378,8 +2302,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2397,8 +2321,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2416,8 +2340,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2435,8 +2359,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2454,8 +2378,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2473,8 +2397,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2492,8 +2416,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2511,8 +2435,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2530,8 +2454,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2549,8 +2473,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2568,8 +2492,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2587,8 +2511,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2606,8 +2530,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2625,8 +2549,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2644,8 +2568,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2663,8 +2587,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2682,8 +2606,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "effecters" : [{
             "set" : {

--- a/oem/ibm/configurations/pdr/ibm,rainier-2u/4.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-2u/4.json
@@ -263,66 +263,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 17,
@@ -407,8 +369,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -426,8 +388,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -445,8 +407,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -464,8 +426,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -483,8 +445,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -502,8 +464,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -521,8 +483,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -540,8 +502,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -559,8 +521,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -578,8 +540,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -597,8 +559,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -616,8 +578,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -635,8 +597,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -654,8 +616,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -673,8 +635,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -692,8 +654,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -711,8 +673,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -730,8 +692,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -749,8 +711,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -768,8 +730,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -787,8 +749,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -806,8 +768,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -825,8 +787,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -844,8 +806,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -863,8 +825,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -882,8 +844,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -901,8 +863,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -920,8 +882,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -939,8 +901,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -958,8 +920,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -977,8 +939,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -996,8 +958,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1950,66 +1912,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 10,
@@ -2094,8 +2018,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2113,8 +2037,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2132,8 +2056,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2151,8 +2075,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2170,8 +2094,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2189,8 +2113,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2208,8 +2132,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2227,8 +2151,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2246,8 +2170,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2265,8 +2189,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2284,8 +2208,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2303,8 +2227,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2322,8 +2246,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2341,8 +2265,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2360,8 +2284,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2379,8 +2303,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2398,8 +2322,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2417,8 +2341,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2436,8 +2360,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2455,8 +2379,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2474,8 +2398,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2493,8 +2417,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2512,8 +2436,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2531,8 +2455,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2550,8 +2474,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2569,8 +2493,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2588,8 +2512,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2607,8 +2531,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2626,8 +2550,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2645,8 +2569,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2664,8 +2588,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2683,8 +2607,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "sensors" : [{
             "set" : {

--- a/oem/ibm/configurations/pdr/ibm,rainier-4u/11.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-4u/11.json
@@ -328,66 +328,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "effecters" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 17,
@@ -472,8 +434,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -491,8 +453,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -510,8 +472,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -529,8 +491,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -548,8 +510,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -567,8 +529,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -586,8 +548,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -605,8 +567,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -624,8 +586,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -643,8 +605,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -662,8 +624,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -681,8 +643,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -700,8 +662,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -719,8 +681,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -738,8 +700,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -757,8 +719,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -776,8 +738,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -795,8 +757,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -814,8 +776,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -833,8 +795,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -852,8 +814,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -871,8 +833,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -890,8 +852,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -909,8 +871,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -928,8 +890,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -947,8 +909,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -966,8 +928,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -985,8 +947,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1004,8 +966,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1023,8 +985,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1042,8 +1004,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -1061,8 +1023,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2102,9 +2064,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 1,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -2121,28 +2083,9 @@
         }]
     },
     {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1",
-                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
-                "property_type": "bool",
-                "property_values" : [true, false]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
+        "type" : 190,
+        "instance" : 1,
+        "container" : 3,
         "effecters" : [{
             "set" : {
                 "id" : 10,
@@ -2151,25 +2094,6 @@
             },
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0",
-                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
-                "property_type": "bool",
-                "property_values" : [true, false]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
-        "effecters" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
                 "property_name": "Functional",
                 "property_type": "bool",
@@ -2246,8 +2170,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2265,8 +2189,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2284,8 +2208,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2303,8 +2227,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2322,8 +2246,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2334,15 +2258,15 @@
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Asserted",
+                "property_name": "Functional",
                 "property_type": "bool",
                 "property_values" : [true, false]
              }
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2353,15 +2277,15 @@
             "dbus" : {
                 "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5",
                 "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "property_name": "Functional",
+                "property_name": "Asserted",
                 "property_type": "bool",
                 "property_values" : [true, false]
              }
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2379,8 +2303,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2398,8 +2322,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2417,8 +2341,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2436,8 +2360,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2455,8 +2379,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2474,8 +2398,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2493,8 +2417,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2512,8 +2436,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2531,8 +2455,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2550,8 +2474,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2569,8 +2493,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2588,8 +2512,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2607,8 +2531,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2626,8 +2550,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2645,8 +2569,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2664,8 +2588,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2683,8 +2607,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2702,8 +2626,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2721,8 +2645,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2740,8 +2664,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2759,8 +2683,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2778,8 +2702,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2797,8 +2721,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2816,8 +2740,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "effecters" : [{
             "set" : {
@@ -2835,8 +2759,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "effecters" : [{
             "set" : {

--- a/oem/ibm/configurations/pdr/ibm,rainier-4u/4.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-4u/4.json
@@ -331,66 +331,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "sensors" : [{
+            "set" : {
+                "id" : 17,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 17,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_identify",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 17,
@@ -475,8 +437,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -494,8 +456,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -513,8 +475,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -532,8 +494,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -551,8 +513,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -570,8 +532,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -589,8 +551,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -608,8 +570,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -627,8 +589,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -646,8 +608,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -665,8 +627,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -684,8 +646,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -703,8 +665,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -722,8 +684,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -741,8 +703,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -760,8 +722,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -779,8 +741,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -798,8 +760,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -817,8 +779,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -836,8 +798,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -855,8 +817,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -874,8 +836,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -893,8 +855,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -912,8 +874,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -931,8 +893,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -950,8 +912,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -969,8 +931,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -988,8 +950,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1007,8 +969,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1026,8 +988,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1045,8 +1007,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -1064,8 +1026,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2132,66 +2094,28 @@
         }]
     },
     {
-        "type" : 135,
+        "type" : 190,
+        "instance" : 0,
+        "container" : 3,
+        "sensors" : [{
+            "set" : {
+                "id" : 10,
+                "size" : 1,
+                "states" : [1,2]
+            },
+            "dbus" : {
+                "path": "/xyz/openbmc_project/led/groups/cpu0_fault",
+                "interface": "xyz.openbmc_project.Led.Group",
+                "property_name": "Asserted",
+                "property_type": "bool",
+                "property_values" : [false, true]
+             }
+        }]
+    },
+    {
+        "type" : 190,
         "instance" : 1,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 2,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 3,
-        "container" : 4,
-        "sensors" : [{
-            "set" : {
-                "id" : 10,
-                "size" : 1,
-                "states" : [1,2]
-            },
-            "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_fault",
-                "interface": "xyz.openbmc_project.Led.Group",
-                "property_name": "Asserted",
-                "property_type": "bool",
-                "property_values" : [false, true]
-             }
-        }]
-    },
-    {
-        "type" : 135,
-        "instance" : 4,
-        "container" : 4,
+        "container" : 3,
         "sensors" : [{
             "set" : {
                 "id" : 10,
@@ -2276,8 +2200,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 1,
+        "type" : 65,
+        "instance" : 0,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2295,8 +2219,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 2,
+        "type" : 65,
+        "instance" : 1,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2314,8 +2238,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 3,
+        "type" : 65,
+        "instance" : 2,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2333,8 +2257,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 4,
+        "type" : 65,
+        "instance" : 3,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2352,8 +2276,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 5,
+        "type" : 65,
+        "instance" : 4,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2371,8 +2295,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 6,
+        "type" : 65,
+        "instance" : 5,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2390,8 +2314,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 7,
+        "type" : 65,
+        "instance" : 6,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2409,8 +2333,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 8,
+        "type" : 65,
+        "instance" : 7,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2428,8 +2352,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 9,
+        "type" : 65,
+        "instance" : 8,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2447,8 +2371,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 10,
+        "type" : 65,
+        "instance" : 9,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2466,8 +2390,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 11,
+        "type" : 65,
+        "instance" : 10,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2485,8 +2409,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 12,
+        "type" : 65,
+        "instance" : 11,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2504,8 +2428,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 13,
+        "type" : 65,
+        "instance" : 12,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2523,8 +2447,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 14,
+        "type" : 65,
+        "instance" : 13,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2542,8 +2466,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 15,
+        "type" : 65,
+        "instance" : 14,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2561,8 +2485,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 16,
+        "type" : 65,
+        "instance" : 15,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2580,8 +2504,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 17,
+        "type" : 65,
+        "instance" : 16,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2599,8 +2523,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 18,
+        "type" : 65,
+        "instance" : 17,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2618,8 +2542,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 19,
+        "type" : 65,
+        "instance" : 18,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2637,8 +2561,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 20,
+        "type" : 65,
+        "instance" : 19,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2656,8 +2580,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 21,
+        "type" : 65,
+        "instance" : 20,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2675,8 +2599,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 22,
+        "type" : 65,
+        "instance" : 21,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2694,8 +2618,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 23,
+        "type" : 65,
+        "instance" : 22,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2713,8 +2637,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 24,
+        "type" : 65,
+        "instance" : 23,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2732,8 +2656,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 25,
+        "type" : 65,
+        "instance" : 24,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2751,8 +2675,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 26,
+        "type" : 65,
+        "instance" : 25,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2770,8 +2694,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 27,
+        "type" : 65,
+        "instance" : 26,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2789,8 +2713,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 28,
+        "type" : 65,
+        "instance" : 27,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2808,8 +2732,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 29,
+        "type" : 65,
+        "instance" : 28,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2827,8 +2751,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 30,
+        "type" : 65,
+        "instance" : 29,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2846,8 +2770,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 31,
+        "type" : 65,
+        "instance" : 30,
         "container" : 3,
         "sensors" : [{
             "set" : {
@@ -2865,8 +2789,8 @@
         }]
     },
     {
-        "type" : 66,
-        "instance" : 32,
+        "type" : 65,
+        "instance" : 31,
         "container" : 3,
         "sensors" : [{
             "set" : {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1184,6 +1184,12 @@ void pldm::responder::oem_ibm_platform::Handler::upadteOemDbusPaths(
         size_t pos = dbusPath.find(toFind);
         dbusPath.replace(pos, toFind.length(), "system");
     }
+    toFind = "socket";
+    if (dbusPath.find(toFind) != std::string::npos)
+    {
+        std::regex reg(R"(\/motherboard\/socket[0-9]+)");
+        dbusPath = regex_replace(dbusPath, reg, "/motherboard");
+    }
 }
 void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
     sdeventplus::source::EventBase& /*source */)


### PR DESCRIPTION
Those changes are required to toggle the LEDs for unpopulated
Procs and DIMMs

So, irrespective of whether a DIMM or ProcessorModule is present,
host will always send Memory Board & Physical Socket ,
    Memory Module(DIMM) under Memory Board entiity
    Processor Module(DCM) under Physical Socket entity
so from pldm side, we need to modify the above mentioned led PDR's
with the same entity type , instance number & container id for both
Memory Board entity & Physical Socket entity from hostboot.

Tested:
Verified the PLDM tree using busctl command
Also tested deconfiguring the core using busctl command

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>