### PR TITLE
Change the entity type for CMC from 63 to 62

### DIFF
--- a/host-bmc/utils.hpp
+++ b/host-bmc/utils.hpp
@@ -34,7 +34,7 @@ const std::map<EntityType, EntityName> entityMaps = {
     {PLDM_ENTITY_PROC | 0x8000, "core"},
     {PLDM_ENTITY_IO_MODULE, "io_module"},
     {PLDM_ENTITY_FAN, "fan"},
-    {PLDM_ENTITY_SYS_MGMT_MODULE, "system_management_module"},
+    {PLDM_ENTITY_MODULE, "system_management_module"},
     {PLDM_ENTITY_POWER_CONVERTER, "power_converter"},
     {PLDM_ENTITY_SLOT, "slot"},
     {PLDM_ENTITY_CONNECTOR, "connector"},


### PR DESCRIPTION
Tested By:

1. With change powered on the system
2. Checked that pldm generated the dbus object for CMC FRU
3. Checked that pldm generated the dbus object for CMC LED's
4. Checked the redfish Assembly schema & found the CMC with the
   correct location code.

Fixes : SW551748

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>