### PR TITLE
fixes MEX CM and looping issue in MEX systems

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -459,7 +459,7 @@ void HostPDRHandler::mergeEntityAssociations(const std::vector<uint8_t>& pdr)
             auto node = pldm_entity_association_tree_add(
                 entityTree, &entities[i], entities[i].entity_instance_num,
                 pNode, entityPdr->association_type, true,
-                !(entities[i].entity_container_id & 0x8000));
+                !(entities[i].entity_container_id & 0x8000), 0xFFFF);
             if (!node)
             {
                 continue;
@@ -486,8 +486,11 @@ void HostPDRHandler::mergeEntityAssociations(const std::vector<uint8_t>& pdr)
         }
         else
         {
+            // Record Handle is 0xFFFFFFFF(max value uint32_t), for merging
+            // entity association pdr to bmc range
             pldm_entity_association_pdr_add_from_node(
-                node, repo, &entities, numEntities, true, TERMINUS_HANDLE);
+                node, repo, &entities, numEntities, true, TERMINUS_HANDLE,
+                0xFFFFFFFF);
         }
     }
     free(entities);

--- a/host-bmc/test/utils_test.cpp
+++ b/host-bmc/test/utils_test.cpp
@@ -39,29 +39,32 @@ TEST(EntityAssociation, addObjectPathEntityAssociations1)
 
     auto l1 = pldm_entity_association_tree_add(tree, &entities[0], 1, nullptr,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               true, true);
+                                               true, true, 0xFFFF);
 
-    auto l2 = pldm_entity_association_tree_add(
-        tree, &entities[1], 1, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true, true);
+    auto l2 = pldm_entity_association_tree_add(tree, &entities[1], 1, l1,
+                                               PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                               true, true, 0xFFFF);
 
-    auto l3a = pldm_entity_association_tree_add(
-        tree, &entities[2], 0, l2, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true, true);
-    auto l3b = pldm_entity_association_tree_add(
-        tree, &entities[3], 1, l2, PLDM_ENTITY_ASSOCIAION_PHYSICAL, true, true);
+    auto l3a = pldm_entity_association_tree_add(tree, &entities[2], 0, l2,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true, 0xFFFF);
+    auto l3b = pldm_entity_association_tree_add(tree, &entities[3], 1, l2,
+                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+                                                true, true, 0xFFFF);
 
     auto l4a = pldm_entity_association_tree_add(tree, &entities[4], 0, l3a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                true, true);
+                                                true, true, 0xFFFF);
     auto l4b = pldm_entity_association_tree_add(tree, &entities[5], 1, l3a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                true, true);
+                                                true, true, 0xFFFF);
 
     auto l5a = pldm_entity_association_tree_add(tree, &entities[6], 0, l3b,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                true, true);
+                                                true, true, 0xFFFF);
     auto l5b = pldm_entity_association_tree_add(tree, &entities[7], 1, l3b,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                true, true);
+                                                true, true, 0xFFFF);
 
     EntityAssociations entityAssociations = {
         {l1, l2}, {l2, l3a, l3b}, {l3a, l4a, l4b}, {l3b, l5a, l5b}};

--- a/libpldm/meson.build
+++ b/libpldm/meson.build
@@ -9,6 +9,7 @@ headers = [
   'state_set.h',
   'fru.h',
   'utils.h',
+  'pdr_data.h',
   'pdr.h',
   'firmware_update.h'
 ]

--- a/libpldm/pdr_data.h
+++ b/libpldm/pdr_data.h
@@ -1,0 +1,41 @@
+#ifndef PDR_DATA_H
+#define PDR_DATA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct pldm_pdr_record {
+	uint32_t record_handle;
+	uint32_t size;
+	uint8_t *data;
+	struct pldm_pdr_record *next;
+	bool is_remote;
+	uint16_t terminus_handle;
+} pldm_pdr_record;
+
+typedef struct pldm_pdr {
+	uint32_t record_count;
+	uint32_t size;
+	pldm_pdr_record *first;
+	pldm_pdr_record *last;
+} pldm_pdr;
+
+/** @struct pldm_pdr
+ *  *  opaque structure that acts as a handle to a PDR repository
+ *   */
+typedef struct pldm_pdr pldm_pdr;
+
+/** @struct pldm_pdr_record
+ *  *  opaque structure that acts as a handle to a PDR record
+ *   */
+typedef struct pldm_pdr_record pldm_pdr_record;
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PDR_DATA_H */

--- a/libpldm/tests/libpldm_pdr_test.cpp
+++ b/libpldm/tests/libpldm_pdr_test.cpp
@@ -632,39 +632,39 @@ TEST(EntityAssociationPDR, testBuild)
 
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(tree, &entities[3], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2c, nullptr);
     auto l3a = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3a, nullptr);
     auto l3b = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3b, nullptr);
     auto l3c = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3b, nullptr);
     auto l4a = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l3a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l4a, nullptr);
     auto l4b = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l3b,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l4b, nullptr);
 
     EXPECT_EQ(pldm_entity_is_node_parent(l1), true);
@@ -821,7 +821,7 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     auto tree = pldm_entity_association_tree_init();
     auto node = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(node, nullptr);
     size_t num{};
     pldm_entity* out = nullptr;
@@ -837,15 +837,15 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false, true);
+                                            false, true, 0XFFFF);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false, true);
+                                            false, true, 0xFFFF);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false, true);
+                                            false, true, 0xFFFF);
     EXPECT_NE(node, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 3u);
@@ -869,15 +869,15 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false, true);
+                                            false, true, 0xFFFF);
     EXPECT_NE(node, nullptr);
     auto node1 = pldm_entity_association_tree_add(
         tree, &entities[1], 0xFFFF, node, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(node1, nullptr);
     auto node2 = pldm_entity_association_tree_add(
         tree, &entities[2], 0xFFFF, node1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(node2, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 3u);
@@ -899,19 +899,19 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     tree = pldm_entity_association_tree_init();
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false, true);
+                                            false, true, 0xFFFF);
     EXPECT_NE(node, nullptr);
     node = pldm_entity_association_tree_add(tree, &entities[0], 0xFFFF, nullptr,
                                             PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                            false, true);
+                                            false, true, 0xFFFF);
     EXPECT_NE(node, nullptr);
     node1 = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, node,
                                              PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                             false, true);
+                                             false, true, 0xFFFF);
     EXPECT_NE(node1, nullptr);
     node2 = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, node,
                                              PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                             false, true);
+                                             false, true, 0xFFFF);
     EXPECT_NE(node2, nullptr);
     pldm_entity_association_tree_visit(tree, &out, &num);
     EXPECT_EQ(num, 4u);
@@ -970,54 +970,54 @@ TEST(EntityAssociationPDR, testPDR)
 
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l1, nullptr);
     auto l1a = pldm_entity_association_tree_add(
         tree, &entities[1], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l1a, nullptr);
 
     auto l2a = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_LOGICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(tree, &entities[3], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2c, nullptr);
     auto l2d = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_LOGICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2d, nullptr);
 
     auto l3a = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3a, nullptr);
     auto l3b = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3b, nullptr);
     auto l3c = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_LOGICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3c, nullptr);
     auto l3d = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_LOGICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3d, nullptr);
 
     auto l4a = pldm_entity_association_tree_add(tree, &entities[9], 0xFFFF, l3a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l4a, nullptr);
     auto l4b = pldm_entity_association_tree_add(
         tree, &entities[10], 0xFFFF, l3b, PLDM_ENTITY_ASSOCIAION_LOGICAL, false,
-        true);
+        true, 0xFFFF);
     EXPECT_NE(l4b, nullptr);
 
     EXPECT_EQ(pldm_entity_get_num_children(l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL),
@@ -1279,39 +1279,39 @@ TEST(EntityAssociationPDR, testFind)
 
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(tree, &entities[3], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2c, nullptr);
     auto l3a = pldm_entity_association_tree_add(tree, &entities[4], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3a, nullptr);
     auto l3b = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3b, nullptr);
     auto l3c = pldm_entity_association_tree_add(tree, &entities[6], 0xFFFF, l2a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l3c, nullptr);
     auto l4a = pldm_entity_association_tree_add(tree, &entities[7], 0xFFFF, l3a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l4a, nullptr);
     auto l4b = pldm_entity_association_tree_add(tree, &entities[8], 0xFFFF, l3b,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l4b, nullptr);
 
     pldm_entity entity{};
@@ -1359,19 +1359,19 @@ TEST(EntityAssociationPDR, testCopyTree)
     auto newTree = pldm_entity_association_tree_init();
     auto l1 = pldm_entity_association_tree_add(
         orgTree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(
         orgTree, &entities[1], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(
         orgTree, &entities[2], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(
         orgTree, &entities[3], 0xFFFF, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l2c, nullptr);
     size_t orgNum{};
     pldm_entity* orgOut = nullptr;
@@ -1469,19 +1469,19 @@ TEST(EntityAssociationPDR, testGetChildren)
     auto tree = pldm_entity_association_tree_init();
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l1, nullptr);
     auto l2a = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2a, nullptr);
     auto l2b = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2b, nullptr);
     auto l2c = pldm_entity_association_tree_add(tree, &entities[3], 0xFFFF, l1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l2c, nullptr);
 
     pldm_entity et1;
@@ -1530,12 +1530,12 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto node = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(node, nullptr);
 
     auto l1 = pldm_entity_association_tree_add(tree, &entities[1], 63, node,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     auto first = pldm_pdr_add_fru_record_set(
         repo, 1, 1, entities[1].entity_type, entities[1].entity_instance_num,
         entities[1].entity_container_id, 1, false);
@@ -1550,7 +1550,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto l2 = pldm_entity_association_tree_add(tree, &entities[2], 37, node,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     auto second = pldm_pdr_add_fru_record_set(
         repo, 1, 2, entities[2].entity_type, entities[2].entity_instance_num,
         entities[2].entity_container_id, 2, false);
@@ -1565,7 +1565,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto l3 = pldm_entity_association_tree_add(tree, &entities[3], 44, node,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     auto third = pldm_pdr_add_fru_record_set(
         repo, 1, 3, entities[3].entity_type, entities[3].entity_instance_num,
         entities[3].entity_container_id, 3, false);
@@ -1580,7 +1580,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto l4 = pldm_entity_association_tree_add(tree, &entities[4], 89, node,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     auto fourth = pldm_pdr_add_fru_record_set(
         repo, 1, 4, entities[4].entity_type, entities[4].entity_instance_num,
         entities[4].entity_container_id, 4, false);
@@ -1595,7 +1595,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto l5 = pldm_entity_association_tree_add(tree, &entities[5], 0xFFFF, node,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     auto fifth = pldm_pdr_add_fru_record_set(
         repo, 1, 5, entities[5].entity_type, entities[5].entity_instance_num,
         entities[5].entity_container_id, 5, false);
@@ -1610,12 +1610,12 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto l6 = pldm_entity_association_tree_add(tree, &entities[6], 90, node,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     EXPECT_EQ(l6, nullptr);
 
     auto l7 = pldm_entity_association_tree_add(tree, &entities[7], 100, l1,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     auto seventh = pldm_pdr_add_fru_record_set(
         repo, 1, 7, entities[7].entity_type, entities[7].entity_instance_num,
         entities[7].entity_container_id, 7, false);
@@ -1630,7 +1630,7 @@ TEST(EntityAssociationPDR, testEntityInstanceNumber)
 
     auto l8 = pldm_entity_association_tree_add(tree, &entities[8], 100, l2,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     auto eighth = pldm_pdr_add_fru_record_set(
         repo, 1, 8, entities[8].entity_type, entities[8].entity_instance_num,
         entities[8].entity_container_id, 8, false);
@@ -1684,31 +1684,31 @@ TEST(EntityAssociationPDR, findAndAddHostPDR)
 
     auto l1 = pldm_entity_association_tree_add(
         tree, &entities[0], 0xFFFF, nullptr, PLDM_ENTITY_ASSOCIAION_LOGICAL,
-        false, true);
+        false, true, 0xFFFF);
     EXPECT_NE(l1, nullptr);
     auto l2 = pldm_entity_association_tree_add(tree, &entities[1], 0xFFFF, l1,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     EXPECT_NE(l2, nullptr);
     auto l3 = pldm_entity_association_tree_add(tree, &entities[2], 0xFFFF, l2,
                                                PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                               false, true);
+                                               false, true, 0xFFFF);
     EXPECT_NE(l3, nullptr);
     auto l4a = pldm_entity_association_tree_add(tree, &entities[3], 0, l3,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l4a, nullptr);
     auto l4b = pldm_entity_association_tree_add(tree, &entities[4], 1, l3,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                false, true);
+                                                false, true, 0xFFFF);
     EXPECT_NE(l4b, nullptr);
     auto l5a = pldm_entity_association_tree_add(tree, &entities[5], 0, l4a,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                true, true);
+                                                true, true, 0xFFFF);
     EXPECT_NE(l5a, nullptr);
     auto l5b = pldm_entity_association_tree_add(tree, &entities[6], 0, l4b,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                true, true);
+                                                true, true, 0xFFFF);
     EXPECT_NE(l5b, nullptr);
 
     pldm_entity entity{};
@@ -1723,7 +1723,7 @@ TEST(EntityAssociationPDR, findAndAddHostPDR)
 
     auto l6a = pldm_entity_association_tree_add(tree, &entities[7], 0, result1,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                true, true);
+                                                true, true, 0xFFFF);
     EXPECT_NE(l6a, nullptr);
 
     entity.entity_type = 135;
@@ -1736,7 +1736,7 @@ TEST(EntityAssociationPDR, findAndAddHostPDR)
 
     auto l7a = pldm_entity_association_tree_add(tree, &entities[8], 0, result2,
                                                 PLDM_ENTITY_ASSOCIAION_PHYSICAL,
-                                                true, true);
+                                                true, true, 0xFFFF);
     EXPECT_NE(l7a, nullptr);
 
     pldm_entity_association_tree_destroy(tree);

--- a/libpldmresponder/pdr_state_sensor.hpp
+++ b/libpldmresponder/pdr_state_sensor.hpp
@@ -4,6 +4,10 @@
 
 #include "libpldmresponder/pdr_utils.hpp"
 
+#ifdef OEM_IBM
+#include "oem/ibm/libpldm/pdr_oem_ibm.h"
+#endif
+
 namespace pldm
 {
 
@@ -132,10 +136,17 @@ void generateStateSensorPDR(const DBusInterface& dBusIntf, const Json& json,
                     pldm_entity_association_tree_add(
                         bmcEntityTree, &child_entity, pdr->entity_instance,
                         parent_node, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false,
-                        false);
+                        false, 0xFFFF);
+                    uint32_t bmc_record_handle = 0;
+#ifdef OEM_IBM
+                    auto lastLocalRecord =
+                        pldm_pdr_find_last_local_record(repo.getPdr());
+                    bmc_record_handle = lastLocalRecord->record_handle;
+#endif
+
                     pldm_entity_association_pdr_add_contained_entity(
                         repo.getPdr(), child_entity, parent_entity,
-                        &bmcEventDataOps, false);
+                        &bmcEventDataOps, false, bmc_record_handle);
                 }
             }
         }

--- a/oem/ibm/libpldm/pdr_oem_ibm.c
+++ b/oem/ibm/libpldm/pdr_oem_ibm.c
@@ -8,24 +8,22 @@ pldm_pdr_record *pldm_pdr_find_last_local_record(const pldm_pdr *repo)
 	assert(repo != NULL);
 	pldm_pdr_record *curr = repo->first;
 	pldm_pdr_record *prev = repo->first;
+	pldm_pdr_record *record = curr;
+	uint32_t recent_record_handle = curr->record_handle;
 
 	while (curr != NULL) {
 		if ((curr->record_handle > 0x00000000) &&
 		    (curr->record_handle < 0x00FFFFFF)) {
-			if (curr->next != NULL) {
-				if (curr->next->record_handle >= 0x00FFFFFF) {
-					prev = curr;
-					return prev;
-				}
-			} else {
-				return curr;
+			if (recent_record_handle < curr->record_handle) {
+				recent_record_handle = curr->record_handle;
+				record = curr;
 			}
 		}
 		prev = curr;
 		curr = curr->next;
 	}
 	if (curr == NULL && prev != NULL) {
-		return prev;
+		return record;
 	}
 	return NULL;
 }

--- a/oem/ibm/libpldm/pdr_oem_ibm.h
+++ b/oem/ibm/libpldm/pdr_oem_ibm.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include "pdr.h"
+#include "pdr_data.h"
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -655,12 +655,19 @@ void attachOemEntityToEntityAssociationPDR(
                       << " not found in the BMC Entity Association tree\n";
             return;
         }
+        uint32_t bmc_record_handle = 0;
+#ifdef OEM_IBM
+        auto lastLocalRecord = pldm_pdr_find_last_local_record(repo.getPdr());
+        bmc_record_handle = lastLocalRecord->record_handle;
+#endif
         pldm_entity_association_tree_add(
             bmcEntityTree, &childEntity, 0xFFFF, parent_node,
-            PLDM_ENTITY_ASSOCIAION_PHYSICAL, false, false);
+            PLDM_ENTITY_ASSOCIAION_PHYSICAL, false, false, 0xFFFF);
+
         uint8_t bmcEventDataOps = PLDM_INVALID_OP;
         pldm_entity_association_pdr_add_contained_entity(
-            repo.getPdr(), childEntity, parent_entity, &bmcEventDataOps, false);
+            repo.getPdr(), childEntity, parent_entity, &bmcEventDataOps, false,
+            bmc_record_handle);
     }
 }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "libpldm/entity.h"
 #include "libpldm/platform.h"
+#include "oem/ibm/libpldm/pdr_oem_ibm.h"
 #include "oem/ibm/libpldm/state_set_oem_ibm.h"
 
 #include "collect_slot_vpd.hpp"


### PR DESCRIPTION
In MEX systems, PLDM receives multiple refresh repo events from host.
After receiving refresh repo event, PLDM delete the host PDRs except the
Entity association PDRs and then fetches list of PDRs from host again.
In this scenario PDRs are added such a way that it causes loop.

Fixed the issue by merging Entity association PDRs(from Phyp) in the BMC range.
Following are the modification:

    Using record handle 0xFFFFFFFF to mention that PDR has to be added to
    BMC range
    Modified oem function to traverse the complete repository and get the
    latest BMC PDR

For MEX CM - whenever connectors are present under the card and a
CM is done on the card, it was not handled properly and PHYP task
would crash. With this changes it is fixed.

Tested:
Tested using pldmtool and busctl command

    pldmtool platform getpdr -a
    Always returned expected number of PDRs without causing a loop
    busctl tree PLDMD
    PLDM tree had all the objects populated
    Tried Power on/off operation and verified pdr list
    Same with reset reload operation

fixes : SW551128

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>