### PR TITLE
PLDM: Disable surveillance timer

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -223,6 +223,7 @@ HostPDRHandler::HostPDRHandler(
                 {
                     if (oemPlatformHandler)
                     {
+                        oemPlatformHandler->startStopTimer(false);
                         oemPlatformHandler->handleBootTypesAtChassisOff();
                     }
                     static constexpr auto searchpath =

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -143,6 +143,11 @@ class Handler : public CmdHandler
     /** @brief To update container ID of Proc LED PDRs */
     virtual void updateContainerIDofProcLed() = 0;
 
+    /** @brief Interface to reset or stop the surveillance timer
+     *  @param[in] value - true or false, to indicate if the timer
+     *                     should be reset or turned off*/
+    virtual void startStopTimer(bool value) = 0;
+
     /** @brief Interface to monitor the surveillance pings from host
      *
      * @param[in] tid - TID of the host

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1738,13 +1738,8 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
     processPowerOffSoftGraceful();
 }
 
-void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
-                                                              bool value)
+void pldm::responder::oem_ibm_platform::Handler::startStopTimer(bool value)
 {
-    if (hostOff || hostTransitioningToOff || tid != HYPERVISOR_TID)
-    {
-        return;
-    }
     if (value)
     {
         timer.restart(
@@ -1752,7 +1747,35 @@ void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
     }
     else
     {
-        timer.setEnabled(false);
+        timer.setEnabled(value);
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
+                                                              bool value)
+{
+    std::cout << "setSurvTimer:hostOff=" << (bool)hostOff
+              << " hostTransitioningToOff=" << (bool)hostTransitioningToOff
+              << " tid=" << (uint16_t)tid << std::endl;
+    if ((hostOff == true) || (hostTransitioningToOff == true) ||
+        (tid != HYPERVISOR_TID))
+    {
+        if (timer.isEnabled())
+        {
+            startStopTimer(false);
+        }
+        return;
+    }
+    if (value)
+    {
+        startStopTimer(true);
+    }
+    else if (!value && timer.isEnabled())
+    {
+        std::cout << "setSurvTimer:LogginPel:hostOff=" << (bool)hostOff
+                  << " hostTransitioningToOff=" << (bool)hostTransitioningToOff
+                  << " tid=" << (uint16_t)tid << std::endl;
+        startStopTimer(false);
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.setSurvTimer.RecvSurveillancePingFail",
             pldm::PelSeverity::INFORMATIONAL);

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -439,6 +439,12 @@ class Handler : public oem_platform::Handler
     /** @brief To process auto power restore policy*/
     void processPowerOffHardGraceful();
 
+    /** @brief Method to reset or stop the surveillance timer
+     *
+     *  @param[in] value - true or false, to indicate if the timer
+     *                     should be reset or turned off*/
+    void startStopTimer(bool value);
+
     /** @brief Method to Enable/Disable timer to see if host sends the
      * surveillance ping and logs informational error if host fails to send the
      * surveillance pings


### PR DESCRIPTION
This commit is to disable the timer when we fail
to receive the surveillance pings from PHYP.

DEFECT:SW551173

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>