### PR TITLE
softoff: ensure stopped on any boot of host

### DIFF
--- a/softoff/services/pldmSoftPowerOff.service
+++ b/softoff/services/pldmSoftPowerOff.service
@@ -4,7 +4,7 @@ Wants=pldmd.service
 After=pldmd.service
 Wants=obmc-host-stop-pre@0.target
 Before=obmc-host-stop-pre@0.target
-Conflicts=obmc-host-start@0.target
+Conflicts=obmc-host-startmin@0.target
 
 [Service]
 Restart=no


### PR DESCRIPTION
Saw an interesting issue recently where the system ended up in a
situation where the pldmSoftPowerOff application was running through an
entire reboot of the host firmware.

Another bug induced the issue, but basically the pldmSoftPowerOff
service was waiting for the host to indicate it had shutdown, when in
fact the host had already been stopped and the system was rebooted. The
reason the pldmSoftPowerOff service was not stopped on the reboot of the
host is because it conflicts with the incorrect target. The
obmc-host-start@.target is only run on fresh boots of the system. The
obmc-host-startmin@.target is called on all boots, including reboots.

To ensure pldmSoftPowerOff is always stopped when the host is being
booted, change the conflicts.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: Ib2c730b9472a39bd73d85046f61a6f093b7a5a80