### PR TITLE
PCIeTopology : Parse special links & set the topology information

### DIFF
--- a/configurations/host/host_fru_associations.json
+++ b/configurations/host/host_fru_associations.json
@@ -43,6 +43,12 @@
             "to_entity_type":45,
             "forward_association":"chassis",
             "reverse_association":"inventory"
+        },
+        {
+            "from_entity_type":32954,
+            "to_entity_type":45,
+            "forward_association":"chassis",
+            "reverse_association":"inventory"
         }
     ]
 }

--- a/host-bmc/dbus/led_group.cpp
+++ b/host-bmc/dbus/led_group.cpp
@@ -41,7 +41,13 @@ bool LEDGroup::asserted(bool value)
                 hostEffecterParser->getPldmPDR(), entity.entity_type,
                 entity.entity_instance_num, entity.entity_container_id,
                 PLDM_STATE_SET_IDENTIFY_STATE, false);
-
+            std::cerr << "Setting the led on : [ " << objectPath << "] ,[ "
+                      << entity.entity_type << " , "
+                      << entity.entity_instance_num << " , "
+                      << entity.entity_container_id << " ] , effecter ID : [ "
+                      << effecterId << " ] , current value : [ "
+                      << std::boolalpha << asserted() << " ] new value : [ "
+                      << value << " ] " << std::endl;
             hostEffecterParser->sendSetStateEffecterStates(
                 mctpEid, effecterId, 1, stateField,
                 std::bind(std::mem_fn(&pldm::dbus::LEDGroup::updateAsserted),

--- a/host-bmc/dbus/led_group.hpp
+++ b/host-bmc/dbus/led_group.hpp
@@ -33,7 +33,8 @@ class LEDGroup : public AssertedIntf
              pldm::host_effecters::HostEffecterParser* hostEffecterParser,
              const pldm_entity entity, uint8_t mctpEid) :
         AssertedIntf(bus, objPath.c_str(), AssertedIntf::action::defer_emit),
-        hostEffecterParser(hostEffecterParser), entity(entity), mctpEid(mctpEid)
+        hostEffecterParser(hostEffecterParser), entity(entity),
+        mctpEid(mctpEid), objectPath(objPath)
     {
         // Emit deferred signal.
         emit_object_added();
@@ -63,6 +64,8 @@ class LEDGroup : public AssertedIntf
     const pldm_entity entity;
 
     uint8_t mctpEid;
+
+    std::filesystem::path objectPath;
 
     bool isTriggerStateEffecterStates = false;
 };

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -395,6 +395,16 @@ int HostPDRHandler::handleStateSensorEvent(
                 auto ledGroupPath = updateLedGroupPath(entity.first);
                 if (!ledGroupPath.empty())
                 {
+                    std::cout
+                        << "led state event for [ " << ledGroupPath << " ] , [ "
+                        << node_entity.entity_type << " ,"
+                        << node_entity.entity_instance_num << " ,"
+                        << node_entity.entity_container_id
+                        << " ] , current value : [ " << std::boolalpha
+                        << CustomDBus::getCustomDBus().getAsserted(ledGroupPath)
+                        << " ] new value : [ "
+                        << bool(state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED)
+                        << " ]\n";
                     CustomDBus::getCustomDBus().setAsserted(
                         ledGroupPath, node_entity,
                         state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED,
@@ -1743,6 +1753,8 @@ void HostPDRHandler::createDbusObjects()
                 break;
             case PLDM_ENTITY_IO_MODULE:
                 CustomDBus::getCustomDBus().implementFabricAdapter(
+                    entity.first);
+                CustomDBus::getCustomDBus().implementPCIeDeviceInterface(
                     entity.first);
                 break;
             case 32954:

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -234,7 +234,8 @@ class PCIeInfoHandler : public FileHandler
                                   uint8_t parentLinkId);
     virtual void parseSecondaryLink(
         uint8_t linkType, const io_slot_location_t& ioSlotLocationCode,
-        const localport_t& localPortLocation, const uint32_t& linkId,
+        const localport_t& localPortLocation,
+        const remoteport_t& remotePortLocation, const uint32_t& linkId,
         const std::string& linkStatus, uint8_t linkSpeed, int64_t linkWidth);
     virtual void setTopologyOnSlotAndAdapter(
         uint8_t linkType,
@@ -251,6 +252,9 @@ class PCIeInfoHandler : public FileHandler
         getMexObjectFromLocationCode(const std::string& locationCode,
                                      uint16_t entityType);
     virtual std::string getAdapterFromSlot(const std::string& mexSlotObject);
+
+    virtual std::pair<std::string, std::string>
+        getMexSlotandAdapter(const std::filesystem::path& connector);
 
     virtual std::string
         getDownStreamChassis(const std::string& slotOrConnecterPath);


### PR DESCRIPTION
This PR would contain the below changes:
1. Every mex fan out module will be now under a logical pcie slot.
2. Every fanout module is now both a fabric adapter & also a pcie device
3. The newly added logical pcie slots(with oem slot type) is associated
   to the mex chassis.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>