### PR TITLE
Add VMI IPv6 BIOS attributes

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -61,6 +61,32 @@
          "displayName" : "vmi_if1_ipv4_method"
       },
       {
+         "attribute_name":"vmi_if0_ipv6_method",
+         "possible_values":[
+            "IPv6Static",
+            "IPv6DHCP",
+            "SLAAC"
+         ],
+         "default_values":[
+            "IPv6Static"
+         ],
+         "helpText" : "vmi_if0_ipv6_method",
+         "displayName" : "vmi_if0_ipv6_method"
+      },
+      {
+         "attribute_name":"vmi_if1_ipv6_method",
+         "possible_values":[
+            "IPv6Static",
+            "IPv6DHCP",
+            "SLAAC"
+         ],
+         "default_values":[
+            "IPv6Static"
+         ],
+         "helpText" : "vmi_if1_ipv6_method",
+         "displayName" : "vmi_if1_ipv6_method"
+      },
+      {
          "attribute_name":"hb_hyp_switch",
          "possible_values":[
             "PowerVM",

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -19,6 +19,24 @@
          "displayName" : "vmi_if1_ipv4_prefix_length"
       },
       {
+         "attribute_name" : "vmi_if0_ipv6_prefix_length",
+         "lower_bound" : 1,
+         "upper_bound" : 128,
+         "scalar_increment" : 1,
+         "default_value" : 128,
+         "helpText" : "vmi_if0_ipv6_prefix_length",
+         "displayName" : "vmi_if0_ipv6_prefix_length"
+      },
+      {
+         "attribute_name" : "vmi_if1_ipv6_prefix_length",
+         "lower_bound" : 1,
+         "upper_bound" : 128,
+         "scalar_increment" : 1,
+         "default_value" : 128,
+         "helpText" : "vmi_if1_ipv6_prefix_length",
+         "displayName" : "vmi_if1_ipv6_prefix_length"
+      },
+      {
          "attribute_name" : "hb_number_huge_pages",
          "lower_bound" : 0,
          "upper_bound" : 65535,

--- a/oem/ibm/configurations/bios/string_attrs.json
+++ b/oem/ibm/configurations/bios/string_attrs.json
@@ -68,6 +68,46 @@
          "displayName" : "vmi_if1_ipv4_ipaddr"
       },
       {
+         "attribute_name" : "vmi_if0_ipv6_gateway",
+         "string_type" : "ASCII",
+         "minimum_string_length" : 2,
+         "maximum_string_length" : 39,
+         "default_string_length" : 2,
+         "default_string" : "::",
+         "helpText" : "vmi_if0_ipv6_gateway",
+         "displayName" : "vmi_if0_ipv6_gateway"
+      },
+      {
+         "attribute_name" : "vmi_if1_ipv6_gateway",
+         "string_type" : "ASCII",
+         "minimum_string_length" : 2,
+         "maximum_string_length" : 39,
+         "default_string_length" : 2,
+         "default_string" : "::",
+         "helpText" : "vmi_if1_ipv6_gateway",
+         "displayName" : "vmi_if1_ipv6_gateway"
+      },
+      {
+         "attribute_name" : "vmi_if0_ipv6_ipaddr",
+         "string_type" : "ASCII",
+         "minimum_string_length" : 2,
+         "maximum_string_length" : 39,
+         "default_string_length" : 2,
+         "default_string" : "::",
+         "helpText" : "vmi_if0_ipv6_ipaddr",
+         "displayName" : "vmi_if0_ipv6_ipaddr"
+      },
+      {
+         "attribute_name" : "vmi_if1_ipv6_ipaddr",
+         "string_type" : "ASCII",
+         "minimum_string_length" : 2,
+         "maximum_string_length" : 39,
+         "default_string_length" : 2,
+         "default_string" : "::",
+         "helpText" : "vmi_if1_ipv6_ipaddr",
+         "displayName" : "vmi_if1_ipv6_ipaddr"
+      },
+      {
          "attribute_name" : "hb_mfg_flags",
          "string_type" : "Hex",
          "minimum_string_length" : 32,


### PR DESCRIPTION
These BIOS attributes needed for enabling IPv6 on VMI interfaces

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: I90bc815bb5aa303c9fa40be500469592ec0ffb64