### PR TITLE
PLDM Topology : PCIe Link Reset support

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -79,6 +79,15 @@ bool CustomDBus::getOperationalStatus(const std::string& path) const
     return false;
 }
 
+size_t CustomDBus::getBusId(const std::string& path) const
+{
+    if (pcieSlot.find(path) != pcieSlot.end())
+    {
+        return pcieSlot.at(path)->busId();
+    }
+    return 0;
+}
+
 void CustomDBus::implementCableInterface(const std::string& path)
 {
     if (!cable.contains(path))
@@ -144,13 +153,16 @@ void CustomDBus::setSlotProperties(const std::string& path,
         pcieSlot.at(path)->linkStatus(linkStatus);
     }
 }
-void CustomDBus::setlinkreset(const std::string& path, bool value)
+void CustomDBus::setlinkreset(
+    const std::string& path, bool value,
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+    uint8_t mctpEid)
 {
     if (!link.contains(path))
     {
-        link.emplace(
-            path, std::make_unique<Itemlink>(pldm::utils::DBusHandler::getBus(),
-                                             path.c_str()));
+        link.emplace(path, std::make_unique<Link>(
+                               pldm::utils::DBusHandler::getBus(), path.c_str(),
+                               hostEffecterParser, mctpEid));
     }
     link.at(path)->linkReset(value);
 }

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -110,6 +110,11 @@ class CustomDBus
      */
     void updateItemPresentStatus(const std::string& path, bool isPresent);
 
+    /** @brief get Bus ID
+     *  @param[in] path - The object path
+     */
+    size_t getBusId(const std::string& path) const;
+
     /** @brief Implement CpuCore Interface
      *  @param[in] path - The object path
      *
@@ -294,7 +299,10 @@ class CustomDBus
     void setSlotType(const std::string& path, const std::string& slotType);
 
     /** set reset link value*/
-    void setlinkreset(const std::string& path, bool value);
+    void setlinkreset(
+        const std::string& path, bool value,
+        pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+        uint8_t instanceId);
 
   private:
     std::unordered_map<ObjectPath, std::unique_ptr<LocationCode>> location;
@@ -326,7 +334,7 @@ class CustomDBus
     std::unordered_map<ObjectPath, std::unique_ptr<PCIeDevice>> pcieDevice;
     std::unordered_map<ObjectPath, std::unique_ptr<Cable>> cable;
     std::unordered_map<ObjectPath, std::unique_ptr<Asset>> asset;
-    std::unordered_map<ObjectPath, std::unique_ptr<Itemlink>> link;
+    std::unordered_map<ObjectPath, std::unique_ptr<Link>> link;
 };
 
 } // namespace dbus

--- a/host-bmc/dbus/linkreset.cpp
+++ b/host-bmc/dbus/linkreset.cpp
@@ -1,17 +1,91 @@
 #include "linkreset.hpp"
 
+#include "libpldm/entity.h"
+#include "libpldm/state_set.h"
+#include "libpldm/states.h"
+
 namespace pldm
 {
 namespace dbus
 {
 
-bool link::linkReset(bool value)
+bool Link::linkReset(bool value)
 {
+    std::cerr << "CustomDBus: Got a link reset on: " << path << std::endl;
+    std::vector<set_effecter_state_field> stateField;
+
+    if (value ==
+        sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset())
+    {
+        stateField.push_back({PLDM_NO_CHANGE, 0});
+        return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset(
+            value);
+    }
+    else
+    {
+        stateField.push_back({PLDM_REQUEST_SET, PLDM_RESETTING});
+    }
+
+    if (value && hostEffecterParser)
+    {
+        uint16_t effecterID = getEffecterID();
+
+        if (effecterID == 0)
+        {
+            return false;
+        }
+
+        std::cerr
+            << "CustomDBus: Sending a effecter call to host with effecter id: "
+            << effecterID << std::endl;
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctpEid, effecterID, 1, stateField, nullptr, value);
+        std::cerr << "Link reset on path : " << path
+                  << " is successful setting it back to false" << std::endl;
+        return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset(
+            false);
+    }
     return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset(
         value);
 }
 
-bool link::linkReset() const
+uint16_t Link::getEffecterID()
+{
+    uint16_t effecterID = 0;
+
+    pldm::pdr::EntityType entityType = PLDM_ENTITY_PCI_EXPRESS_BUS | 0x8000;
+    auto stateEffecterPDRs = pldm::utils::findStateEffecterPDR(
+        mctpEid, entityType, static_cast<uint16_t>(PLDM_STATE_SET_AVAILABILITY),
+        hostEffecterParser->getPldmPDR());
+
+    if (stateEffecterPDRs.empty())
+    {
+        std::cerr
+            << "PCIe LinkReset: The state set PDR can not be found, entityType = "
+            << entityType << std::endl;
+        return effecterID;
+    }
+
+    uint32_t entityInstance = 0;
+#ifdef OEM_IBM
+    entityInstance = pldm::responder::utils::getLinkResetInstanceNumber(path);
+#endif
+
+    std::cerr << "CustomDBus: BusID of the link is: " << entityInstance
+              << std::endl;
+    for (auto& rep : stateEffecterPDRs)
+    {
+        auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(rep.data());
+        if (entityInstance == (uint32_t)pdr->entity_instance)
+        {
+            effecterID = pdr->effecter_id;
+            break;
+        }
+    }
+    return effecterID;
+}
+
+bool Link::linkReset() const
 {
     return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset();
 }

--- a/host-bmc/dbus/linkreset.hpp
+++ b/host-bmc/dbus/linkreset.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "../dbus_to_host_effecters.hpp"
 #include "serialize.hpp"
+
+#ifdef OEM_IBM
+#include "oem/ibm/libpldmresponder/utils.hpp"
+#endif
 
 #include <com/ibm/Control/Host/PCIeLink/server.hpp>
 #include <sdbusplus/bus.hpp>
@@ -17,18 +22,21 @@ namespace dbus
 using Itemlink = sdbusplus::server::object::object<
     sdbusplus::com::ibm::Control::Host::server::PCIeLink>;
 
-class link : public Itemlink
+class Link : public Itemlink
 {
   public:
-    link() = delete;
-    ~link() = default;
-    link(const link&) = delete;
-    link& operator=(const link&) = delete;
-    link(link&&) = default;
-    link& operator=(link&&) = default;
+    Link() = delete;
+    ~Link() = default;
+    Link(const Link&) = delete;
+    Link& operator=(const Link&) = delete;
+    Link(Link&&) = default;
+    Link& operator=(Link&&) = default;
 
-    link(sdbusplus::bus::bus& bus, const std::string& objPath) :
-        Itemlink(bus, objPath.c_str()), path(objPath)
+    Link(sdbusplus::bus::bus& bus, const std::string& objPath,
+         pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+         uint8_t mctpEid) :
+        Itemlink(bus, objPath.c_str()),
+        path(objPath), hostEffecterParser(hostEffecterParser), mctpEid(mctpEid)
     {
         // no need to save this in pldm memory
     }
@@ -39,8 +47,16 @@ class link : public Itemlink
     /** Get link reset state */
     bool linkReset() const override;
 
+    uint16_t getEffecterID();
+
   private:
     std::string path;
+
+    /** @brief Pointer to host effecter parser */
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser;
+
+    /** mctp endpoint id */
+    uint8_t mctpEid;
 };
 
 } // namespace dbus

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1729,7 +1729,8 @@ void HostPDRHandler::createDbusObjects()
             case PLDM_ENTITY_SLOT:
                 CustomDBus::getCustomDBus().implementPCIeSlotInterface(
                     entity.first);
-                CustomDBus::getCustomDBus().setlinkreset(entity.first, false);
+                CustomDBus::getCustomDBus().setlinkreset(
+                    entity.first, false, hostEffecterParser, mctp_eid);
                 break;
             case PLDM_ENTITY_CONNECTOR:
                 CustomDBus::getCustomDBus().implementConnecterInterface(

--- a/host-bmc/test/meson.build
+++ b/host-bmc/test/meson.build
@@ -24,8 +24,13 @@ test_sources = [
   '../dbus/pcie_topology.cpp',
   '../dbus/cable.cpp',
   '../dbus/asset.cpp',
-  '../dbus/pcie_device.cpp'
+  '../dbus/pcie_device.cpp',
+  '../dbus/linkreset.cpp'
 ]
+
+if get_option('oem-ibm').enabled()
+    test_sources += '../../oem/ibm/libpldmresponder/utils.cpp'
+    endif
 
 tests = [
   'dbus_to_host_effecter_test',

--- a/libpldm/states.h
+++ b/libpldm/states.h
@@ -20,6 +20,12 @@ enum pldm_system_power_states {
 	PLDM_OFF_SOFT_GRACEFUL = 9,
 };
 
+/** @brief PLDM enums for availability states
+ */
+enum pldm_availability_states {
+	PLDM_RESETTING = 9,
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -46,6 +46,7 @@ sources = [
   '../host-bmc/dbus/software_version.cpp',
   '../host-bmc/dbus/deserialize.cpp',
   '../host-bmc/dbus/pcie_topology.cpp',
+  '../host-bmc/dbus/linkreset.cpp',
   'event_parser.cpp'
 ]
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -91,6 +91,8 @@ class Handler : public oem_platform::Handler
         pldm::responder::utils::hostPCIETopologyIntf(mctp_eid,
                                                      hostEffecterParser);
 
+        createMatches();
+
         using namespace sdbusplus::bus::match::rules;
         hostOffMatch = std::make_unique<sdbusplus::bus::match::match>(
             pldm::utils::DBusHandler::getBus(),
@@ -454,6 +456,21 @@ class Handler : public oem_platform::Handler
      *                    running or not*/
     void setSurvTimer(uint8_t tid, bool value);
 
+    /** @brief method to fetch the properties changed
+     *
+     *  @param[in] chProperties - list of properties which have changed
+     *  @param[in] objPath - path on which property is changed
+     */
+    void propertyChanged(const DbusChangedProps& chProperties,
+                         std::string objPath);
+
+    /** @brief method to trigger host effecter
+     *
+     *  @param[in] value - value to set
+     *  @param[in] path - path for which the effecter is set
+     */
+    void triggerHostEffecter(bool value, std::string path);
+
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object
@@ -522,6 +539,9 @@ class Handler : public oem_platform::Handler
     /** @brief Timer used for monitoring surveillance pings from host */
     sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
 
+    /** @brief vector of DBus property changed signal match for linkReset*/
+    std::vector<std::unique_ptr<sdbusplus::bus::match::match>> matches;
+
     bool hostOff = true;
 
     bool hostTransitioningToOff = true;
@@ -533,6 +553,10 @@ class Handler : public oem_platform::Handler
     HostEffecterInstanceMap instanceMap;
 
     bool update = true; // to indicate if update is done
+
+    /** @brief method to create matches for the proeprty changed signal for link
+     * reset on all slot paths */
+    void createMatches();
 };
 
 /** @brief Method to encode code update event msg

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -559,6 +559,38 @@ std::string getObjectPathByLocationCode(const std::string& locationCode,
     return path;
 }
 
+uint32_t getLinkResetInstanceNumber(std::string& path)
+{
+    uint32_t id = pldm::dbus::CustomDBus::getCustomDBus().getBusId(path);
+    return id;
+}
+
+void findSlotObjects(const std::string& boardObjPath,
+                     std::vector<std::string>& slotObjects)
+{
+    static constexpr auto MAPPER_BUSNAME = "xyz.openbmc_project.ObjectMapper";
+    static constexpr auto MAPPER_PATH = "/xyz/openbmc_project/object_mapper";
+    static constexpr auto MAPPER_INTERFACE = "xyz.openbmc_project.ObjectMapper";
+    static constexpr auto slotInterface =
+        "xyz.openbmc_project.Inventory.Item.PCIeSlot";
+
+    auto& bus = pldm::utils::DBusHandler::getBus();
+    try
+    {
+        auto method = bus.new_method_call(MAPPER_BUSNAME, MAPPER_PATH,
+                                          MAPPER_INTERFACE, "GetSubTreePaths");
+        method.append(boardObjPath);
+        method.append(0);
+        method.append(std::vector<std::string>({slotInterface}));
+        auto reply = bus.call(method);
+        reply.read(slotObjects);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "no cec slots under motherboard" << boardObjPath << "\n";
+    }
+}
+
 } // namespace utils
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -147,6 +147,13 @@ std::string getObjectPathByLocationCode(const std::string& locationCode,
 std::pair<std::string, std::string>
     getSlotAndAdapter(const std::string& portLocationCode);
 
+/** @brief method to get the BusId based on the path */
+uint32_t getLinkResetInstanceNumber(std::string& path);
+
+/** @brief method to find slot objects */
+void findSlotObjects(const std::string& boardObjPath,
+                     std::vector<std::string>& slotObjects);
+
 } // namespace utils
 } // namespace responder
 } // namespace pldm


### PR DESCRIPTION
This commit implements the link reset feature support
for both primary and secondary links.
When the link reset property is set to true, a host
stste effecter is triggered.

Tested using busctl commands.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>