### PR TITLE
Fixes the missing fault led indicator sensors

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -578,6 +578,9 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                 return rc;
             }
 
+            std::cout << "pldmPDRRepositoryChgEvent eventDataOperation : "
+                      << (unsigned)eventDataOperation << std::endl;
+
             if (eventDataOperation == PLDM_RECORDS_ADDED ||
                 eventDataOperation == PLDM_RECORDS_DELETED)
             {

--- a/oem/ibm/configurations/pdr/ibm,everest/4.json
+++ b/oem/ibm/configurations/pdr/ibm,everest/4.json
@@ -2852,7 +2852,7 @@
         }]
     },
     {
-        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot/pcie_card8/cxp_bot",
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/cxp_bot",
         "sensors" : [{
             "set" : {
                 "id" : 10,
@@ -2869,7 +2869,7 @@
         }]
     },
     {
-        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot/pcie_card8/cxp_top",
+        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8/cxp_top",
         "sensors" : [{
             "set" : {
                 "id" : 10,

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1771,9 +1771,6 @@ void pldm::responder::oem_ibm_platform::Handler::startStopTimer(bool value)
 void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
                                                               bool value)
 {
-    std::cout << "setSurvTimer:hostOff=" << (bool)hostOff
-              << " hostTransitioningToOff=" << (bool)hostTransitioningToOff
-              << " tid=" << (uint16_t)tid << std::endl;
     if ((hostOff == true) || (hostTransitioningToOff == true) ||
         (tid != HYPERVISOR_TID))
     {


### PR DESCRIPTION
This commit fixes the issue of missing fault led indicator sensors
for the cable card ports (pcie slot 8). The sensors were not
getting generated due to the incorrect inventory paths.

Tested the changes in an everest system.

Fixes: SW552427

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I5fb43d9780fedd06cb407884d85b9e10b4dee1ef