### PR TITLE
oem-ibm: Add support of new LMB sizes

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -353,7 +353,10 @@
          "attribute_name":"hb_memory_region_size",
          "possible_values":[
             "128MB",
-            "256MB"
+            "256MB",
+            "1024MB",
+            "2046MB",
+            "4098MB"
          ],
          "default_values":[
             "256MB"
@@ -365,7 +368,10 @@
          "attribute_name":"hb_memory_region_size_current",
          "possible_values":[
             "128MB",
-            "256MB"
+            "256MB",
+            "1024MB",
+            "2046MB",
+            "4098MB"
          ],
          "default_values":[
             "256MB"


### PR DESCRIPTION
Add the newly supported values of logic memory block size under
the bios attribute hb_memory_region_size.

Fixes: LI 02N requirement

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I12d990440f4c006dab0d303594fb9f99d2df28b0