### PR TITLE
Release the oldest instance id when all the instance ids are exhausted

### DIFF
--- a/pldmd/instance_id.cpp
+++ b/pldmd/instance_id.cpp
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include "instance_id.hpp"
 
 #include <stdexcept>
@@ -15,10 +17,61 @@ uint8_t InstanceId::next()
 
     if (idx == id.size())
     {
-        throw std::runtime_error("No free instance ids");
+        // check all the instance ids and free up the one
+        // that is acquired oldest
+        std::cerr << "all the Instance ids are exhausted \n";
+
+        auto instance = returnOldestId();
+        if (instance.has_value())
+        {
+            idx = instance.value();
+            // forcefully release the instance id
+            markFree(idx);
+        }
+        else
+        {
+            throw std::runtime_error(
+                "Instance Id older than instance id expiration time could not be found");
+        }
     }
 
     id.set(idx);
+    timestamp[idx] = std::chrono::system_clock::now();
+    return idx;
+}
+
+std::optional<uint8_t> InstanceId::returnOldestId()
+{
+    uint8_t idx = 0;
+    bool skipInstance = true;
+    auto now = std::chrono::system_clock::now();
+    std::chrono::duration<double> elapsedtime{};
+
+    for (const auto& [instanceId, timepoint] : timestamp)
+    {
+        std::chrono::duration<double> instanceTime = now - timepoint;
+        if (instanceTime >
+            std::chrono::seconds(INSTANCE_ID_EXPIRATION_INTERVAL))
+        {
+            skipInstance = false;
+        }
+        if (instanceTime > elapsedtime)
+        {
+            elapsedtime = instanceTime;
+            idx = instanceId;
+        }
+    }
+    if (skipInstance)
+    {
+        std::cerr
+            << "None of the instance id's are older then the pldm instance id expiration time\n";
+        return std::nullopt;
+    }
+    const std::time_t t_c =
+        std::chrono::system_clock::to_time_t(timestamp[idx]);
+    std::cerr << "Forcefully releasing Instance ID :" << (unsigned)idx
+              << " Last used at timestamp : "
+              << std::put_time(std::localtime(&t_c), "%F %T\n") << std::flush;
     return idx;
 }
 

--- a/pldmd/instance_id.hpp
+++ b/pldmd/instance_id.hpp
@@ -1,6 +1,12 @@
 #pragma once
 
 #include <bitset>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <optional>
 
 namespace pldm
 {
@@ -18,16 +24,25 @@ class InstanceId
      */
     uint8_t next();
 
+    /** @brief Get the oldest instance id based on timestamp
+     *  @return - Oldest PLDM instance id or nullopt
+     */
+    std::optional<uint8_t> returnOldestId();
+
     /** @brief Mark an instance id as unused
      *  @param[in] instanceId - PLDM instance id to be freed
      */
     void markFree(uint8_t instanceId)
     {
         id.set(instanceId, false);
+        // Clear the time stamp associated with the instance id
+        timestamp.erase(instanceId);
     }
 
   private:
     std::bitset<maxInstanceIds> id;
+    std::map<uint8_t, std::chrono::time_point<std::chrono::system_clock>>
+        timestamp;
 };
 
 } // namespace pldm


### PR DESCRIPTION
With this commit PLDM will :
1. Keep the timestamps for every instance id.
2. When all the instance ids are exhuasted , then pldm will
   look at the oldest instance id and release it.
3. pldm will only crash if none of the instance id's are older
   than the instance_id_expiration time.


Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>