### PR TITLE
oem-ibm: Fix the everest processor led sensor mappings

### DIFF
--- a/oem/ibm/configurations/pdr/ibm,everest/11.json
+++ b/oem/ibm/configurations/pdr/ibm,everest/11.json
@@ -355,7 +355,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c61_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu3_c61_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -374,7 +374,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c14_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -393,7 +393,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c19_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -412,7 +412,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu3_c56_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",

--- a/oem/ibm/configurations/pdr/ibm,everest/4.json
+++ b/oem/ibm/configurations/pdr/ibm,everest/4.json
@@ -358,7 +358,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c61_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu3_c61_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -377,7 +377,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c14_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -396,7 +396,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c19_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -415,7 +415,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu3_c56_identify",
+                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_identify",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -2964,7 +2964,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu0_c61_fault",
+                "path": "/xyz/openbmc_project/led/groups/cpu3_c61_fault",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -2983,7 +2983,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu1_c14_fault",
+                "path": "/xyz/openbmc_project/led/groups/cpu0_c14_fault",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -3002,7 +3002,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu2_c19_fault",
+                "path": "/xyz/openbmc_project/led/groups/cpu1_c19_fault",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",
@@ -3021,7 +3021,7 @@
                 "states" : [1,2]
             },
             "dbus" : {
-                "path": "/xyz/openbmc_project/led/groups/cpu3_c56_fault",
+                "path": "/xyz/openbmc_project/led/groups/cpu2_c56_fault",
                 "interface": "xyz.openbmc_project.Led.Group",
                 "property_name": "Asserted",
                 "property_type": "bool",


### PR DESCRIPTION
This commit fixes the issue of wrong dbus mapping of identify and
fault processor leds in the everest system.

Fixes: SW552819

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: Iafc0ee751864c3d8ababf1184afadb6dd3a433b6