### PR TITLE
BIOS: Stop sending the events to host if the bios value is unchanged

### DIFF
--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -942,8 +942,17 @@ void BIOSConfig::constructPendingAttribute(
             continue;
         }
 
+        const auto [attrType, readonlyStatus, displayName, description,
+                    menuPath, currentValue, defaultValue, option] =
+            baseBIOSTableMaps.at(attributeName);
+
         entry->attr_handle = htole16(handler);
-        listOfHandles.emplace_back(htole16(handler));
+
+        // Need to verify that the current value has really changed
+        if (attributeType == attrType && attributevalue != currentValue)
+        {
+            listOfHandles.emplace_back(htole16(handler));
+        }
 
         (*iter)->generateAttributeEntry(attributevalue, attrValueEntry);
 


### PR DESCRIPTION
In the current state, PLDM sends the event to host for every attribute
change (irrespective of if whether if the value is even changed).
This commit is for fixing that behavior.

Tested:
1.
busctl set-property xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager PendingAttributes a{s\(sv\)} 1 "pvm_default_os_type" "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration" s "Linux"

2.
busctl set-property xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager PendingAttributes a{s\(sv\)} 1 "pvm_default_os_type" "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration" s "Linux"
pldmd[673]: The bios property value has not changed, attributeName = pvm_default_os_type

Signed-off-by: George Liu <liuxiwei@inspur.com>
Change-Id: I5e9e135d2ecf8811ad5f4e4d6e85529e5ba1ca09