### PR TITLE
sensor-events: Fix to deconfigure the dimms correctly

### DIFF
--- a/configurations/events/stateSensorPdrs.json
+++ b/configurations/events/stateSensorPdrs.json
@@ -96,7 +96,6 @@
                        }
                 },
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 0,
 			"sensorOffset": 0,
@@ -117,7 +116,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 1,
 			"sensorOffset": 0,
@@ -138,7 +136,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 2,
 			"sensorOffset": 0,
@@ -159,7 +156,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 3,
 			"sensorOffset": 0,
@@ -180,7 +176,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 4,
 			"sensorOffset": 0,
@@ -201,7 +196,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 5,
 			"sensorOffset": 0,
@@ -222,7 +216,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 6,
 			"sensorOffset": 0,
@@ -243,7 +236,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 7,
 			"sensorOffset": 0,
@@ -264,7 +256,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 8,
 			"sensorOffset": 0,
@@ -285,7 +276,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 9,
 			"sensorOffset": 0,
@@ -306,7 +296,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 10,
 			"sensorOffset": 0,
@@ -327,7 +316,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 11,
 			"sensorOffset": 0,
@@ -348,7 +336,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 12,
 			"sensorOffset": 0,
@@ -369,7 +356,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 13,
 			"sensorOffset": 0,
@@ -390,7 +376,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 14,
 			"sensorOffset": 0,
@@ -411,7 +396,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 15,
 			"sensorOffset": 0,
@@ -432,7 +416,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 16,
 			"sensorOffset": 0,
@@ -453,7 +436,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 17,
 			"sensorOffset": 0,
@@ -474,7 +456,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 18,
 			"sensorOffset": 0,
@@ -495,7 +476,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 19,
 			"sensorOffset": 0,
@@ -516,7 +496,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 20,
 			"sensorOffset": 0,
@@ -537,7 +516,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 21,
 			"sensorOffset": 0,
@@ -558,7 +536,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 22,
 			"sensorOffset": 0,
@@ -579,7 +556,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 23,
 			"sensorOffset": 0,
@@ -600,7 +576,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 24,
 			"sensorOffset": 0,
@@ -621,7 +596,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 25,
 			"sensorOffset": 0,
@@ -642,7 +616,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 26,
 			"sensorOffset": 0,
@@ -663,7 +636,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 27,
 			"sensorOffset": 0,
@@ -684,7 +656,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 28,
 			"sensorOffset": 0,
@@ -705,7 +676,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 29,
 			"sensorOffset": 0,
@@ -726,7 +696,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 30,
 			"sensorOffset": 0,
@@ -747,7 +716,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 31,
 			"sensorOffset": 0,
@@ -768,7 +736,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 32,
 			"sensorOffset": 0,
@@ -789,7 +756,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 33,
 			"sensorOffset": 0,
@@ -810,7 +776,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 34,
 			"sensorOffset": 0,
@@ -831,7 +796,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 35,
 			"sensorOffset": 0,
@@ -852,7 +816,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 36,
 			"sensorOffset": 0,
@@ -873,7 +836,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 37,
 			"sensorOffset": 0,
@@ -894,7 +856,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 38,
 			"sensorOffset": 0,
@@ -915,7 +876,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 39,
 			"sensorOffset": 0,
@@ -936,7 +896,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 40,
 			"sensorOffset": 0,
@@ -957,7 +916,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 41,
 			"sensorOffset": 0,
@@ -978,7 +936,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 42,
 			"sensorOffset": 0,
@@ -999,7 +956,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 43,
 			"sensorOffset": 0,
@@ -1020,7 +976,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 44,
 			"sensorOffset": 0,
@@ -1041,7 +996,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 45,
 			"sensorOffset": 0,
@@ -1062,7 +1016,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 46,
 			"sensorOffset": 0,
@@ -1083,7 +1036,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 47,
 			"sensorOffset": 0,
@@ -1104,7 +1056,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 48,
 			"sensorOffset": 0,
@@ -1125,7 +1076,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 49,
 			"sensorOffset": 0,
@@ -1146,7 +1096,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 50,
 			"sensorOffset": 0,
@@ -1167,7 +1116,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 51,
 			"sensorOffset": 0,
@@ -1188,7 +1136,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 52,
 			"sensorOffset": 0,
@@ -1209,7 +1156,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 53,
 			"sensorOffset": 0,
@@ -1230,7 +1176,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 54,
 			"sensorOffset": 0,
@@ -1251,7 +1196,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 55,
 			"sensorOffset": 0,
@@ -1272,7 +1216,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 56,
 			"sensorOffset": 0,
@@ -1293,7 +1236,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 57,
 			"sensorOffset": 0,
@@ -1314,7 +1256,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 58,
 			"sensorOffset": 0,
@@ -1335,7 +1276,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 59,
 			"sensorOffset": 0,
@@ -1356,7 +1296,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 60,
 			"sensorOffset": 0,
@@ -1377,7 +1316,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 61,
 			"sensorOffset": 0,
@@ -1398,7 +1336,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 62,
 			"sensorOffset": 0,
@@ -1419,7 +1356,6 @@
 			}
 		},
 		{
-			"containerID": 3,
 			"entityType": 66,
 			"entityInstance": 63,
 			"sensorOffset": 0,


### PR DESCRIPTION
This commit skips the usage of container ids for dimms in the
state sensor events json file so that correct dimm will get
deconfigued after applying a gauard operation.

Tested: Applied manual guard to ramdom dimms and observed that
correct/required dimms get deconfigured during/after the IPL.

Fixes: SW553011

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I3d205b55b7b95ab607b53e3e82d18c7e8a5f0a5e