### PR TITLE
[PLDMFileIO]Do not initiate DMA OP if host is in off state

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -314,11 +314,14 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
         return response;
     }
 
+    oem_ibm_platform::Handler* oemIbmPlatformHandler =
+        reinterpret_cast<oem_ibm_platform::Handler*>(oemPlatformHandler);
     using namespace dma;
     DMA intf;
     return transferAll<DMA>(&intf, PLDM_READ_FILE_INTO_MEMORY, value.fsPath,
                             offset, length, address, true,
-                            request->hdr.instance_id);
+                            request->hdr.instance_id,
+                            oemIbmPlatformHandler->getBootProgressState());
 }
 
 Response Handler::writeFileFromMemory(const pldm_msg* request,
@@ -391,11 +394,14 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
         return response;
     }
 
+    oem_ibm_platform::Handler* oemIbmPlatformHandler =
+        reinterpret_cast<oem_ibm_platform::Handler*>(oemPlatformHandler);
     using namespace dma;
     DMA intf;
     return transferAll<DMA>(&intf, PLDM_WRITE_FILE_FROM_MEMORY, value.fsPath,
                             offset, length, address, false,
-                            request->hdr.instance_id);
+                            request->hdr.instance_id,
+                            oemIbmPlatformHandler->getBootProgressState());
 }
 
 Response Handler::getFileTable(const pldm_msg* request, size_t payloadLength)
@@ -638,6 +644,20 @@ Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
                                            responsePtr);
         return response;
     }
+
+    oem_ibm_platform::Handler* oemIbmPlatformHandler =
+        reinterpret_cast<oem_ibm_platform::Handler*>(oemPlatformHandler);
+    if (!oemIbmPlatformHandler->getBootProgressState())
+    {
+        std::cerr
+            << "Host is in off state, declining DMA operation for [fileType, Read/Write] [ "
+            << fileType << " , " << static_cast<uint16_t>(cmd) << "]"
+            << std::endl;
+        encode_rw_file_by_type_memory_resp(request->hdr.instance_id, cmd,
+                                           PLDM_ERROR, 0, responsePtr);
+        return response;
+    }
+
     if ((length == 0) || (length % dma::minSize))
     {
         std::cerr << "Length is not a multiple of DMA minSize, LENGTH="

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -95,11 +95,21 @@ class DMA
 template <class DMAInterface>
 Response transferAll(DMAInterface* intf, uint8_t command, fs::path& path,
                      uint32_t offset, uint32_t length, uint64_t address,
-                     bool upstream, uint8_t instanceId)
+                     bool upstream, uint8_t instanceId,
+                     bool bootProgressComplete)
 {
     uint32_t origLength = length;
     Response response(sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_RESP_BYTES, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+
+    if (!bootProgressComplete)
+    {
+        std::cerr << "declining DMA operation for command " << (uint16_t)command
+                  << std::endl;
+        encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
+                                   responsePtr);
+        return response;
+    }
 
     int flags{};
     if (upstream)

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -129,6 +129,43 @@ class Handler : public oem_platform::Handler
                     }
                 }
             });
+        constexpr auto hostPath = "/xyz/openbmc_project/state/host0";
+        constexpr auto hostBootProgressInterface =
+            "xyz.openbmc_project.State.Boot.Progress";
+        constexpr auto hostBootProgressProperty = "BootProgress";
+
+        try
+        {
+            auto propVal = pldm::utils::DBusHandler().getDbusPropertyVariant(
+                hostPath, hostBootProgressProperty, hostBootProgressInterface);
+            bootProgressState = std::get<std::string>(propVal);
+        }
+        catch (const sdbusplus::exception::exception& e)
+        {
+            /* Execption is expected to happen in the case when state manager is
+             * started after pldm, this is expected to happen in reboot case
+             * where host is considred to be up. As host is up pldm is expected
+             * to send attribute update event to host so this is not and error
+             * case */
+            bootProgressState =
+                "xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified";
+        }
+
+        bootProgressMatch = std::make_unique<sdbusplus::bus::match::match>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged("/xyz/openbmc_project/state/host0",
+                              "xyz.openbmc_project.State.Boot.Progress"),
+            [this](sdbusplus::message::message& msg) {
+                pldm::utils::DbusChangedProps props{};
+                std::string intf;
+                msg.read(intf, props);
+                const auto itr = props.find("BootProgress");
+                if (itr != props.end())
+                {
+                    pldm::utils::PropertyValue value = itr->second;
+                    bootProgressState = std::get<std::string>(value);
+                }
+            });
         updateBIOSMatch = std::make_unique<sdbusplus::bus::match::match>(
             pldm::utils::DBusHandler::getBus(),
             propertiesChanged("/xyz/openbmc_project/bios_config/manager",
@@ -471,6 +508,46 @@ class Handler : public oem_platform::Handler
      */
     void triggerHostEffecter(bool value, std::string path);
 
+    /** @brief Allows/Deny DMA operation based on boot progress state and Host
+     * State. DMA is allowed if BootProgressStage is one of the following
+     * SystemInitComplete
+     * OSRunning
+     * SecondaryProcInit
+     * OSStart
+     * SystemSetup
+     * DMA is also allowed in Boot Progress State Unspecified only if
+     * host state is TransitioningToOff
+     *
+     *  @param[out] bool - true is returned if DMA operation is allowed
+     *                     false means DMA is declined
+     */
+    bool getBootProgressState()
+    {
+        if ((bootProgressState != "xyz.openbmc_project.State.Boot.Progress."
+                                  "ProgressStages.SystemInitComplete") &&
+            (bootProgressState != "xyz.openbmc_project.State.Boot.Progress."
+                                  "ProgressStages.OSRunning") &&
+            (bootProgressState != "xyz.openbmc_project.State.Boot.Progress."
+                                  "ProgressStages.SecondaryProcInit") &&
+            (bootProgressState != "xyz.openbmc_project.State.Boot.Progress."
+                                  "ProgressStages.OSStart") &&
+            (bootProgressState != "xyz.openbmc_project.State.Boot.Progress."
+                                  "ProgressStages.SystemSetup"))
+        {
+            if (bootProgressState ==
+                    "xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified" &&
+                hostTransitioningToOff == true)
+            {
+                return true;
+            }
+            std::cerr << "BootProgress State [" << bootProgressState
+                      << "]. HostTransitioningToOff [" << hostTransitioningToOff
+                      << "]. hostOff [" << hostOff << "]" << std::endl;
+            return false;
+        }
+        return true;
+    }
+
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object
@@ -541,6 +618,8 @@ class Handler : public oem_platform::Handler
 
     /** @brief vector of DBus property changed signal match for linkReset*/
     std::vector<std::unique_ptr<sdbusplus::bus::match::match>> matches;
+
+    std::string bootProgressState;
 
     bool hostOff = true;
 


### PR DESCRIPTION
This is commit fixes the PLDM hang happened during DMA operation.

If the BMC had operations queued up in DMA engine and host goes to
off/transitioning to off state,operations are “stuck” and
pldmd hangs on ongoing operation.
Now we are not initiating any DMA transfer if host state is
off/transitioning to off.

Tested:
Tested using below steps
 1. busctl command to change the hoststate to offbusctl set-property
     xyz.openbmc_project.State.Host /xyz/openbmc_project/state/host0
     xyz.openbmc_project.State.Host  CurrentHostState s
     "xyz.openbmc_project.State.Host.HostState.Off"
 2. Initiate DMA operation using curl command or using topology file transfer
 3. Looking at the traces confirmed that DMA is not initiated

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>