### PR TITLE
Fix lanesInUse to be an int64_t value

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -187,7 +187,7 @@ void CustomDBus::implementPCIeDeviceInterface(const std::string& path)
     }
 }
 
-void CustomDBus::setPCIeDeviceProps(const std::string& path, size_t lanesInuse,
+void CustomDBus::setPCIeDeviceProps(const std::string& path, int64_t lanesInuse,
                                     const std::string& value)
 {
     Generations generationsInuse =

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -285,7 +285,7 @@ class CustomDBus
                            const std::string& linkState);
 
     /** @brief set pcie device properties */
-    void setPCIeDeviceProps(const std::string& path, size_t lanesInuse,
+    void setPCIeDeviceProps(const std::string& path, int64_t lanesInuse,
                             const std::string& value);
 
     /** @brief set cable attributes */

--- a/host-bmc/dbus/linkreset.cpp
+++ b/host-bmc/dbus/linkreset.cpp
@@ -11,7 +11,6 @@ namespace dbus
 
 bool Link::linkReset(bool value)
 {
-    std::cerr << "CustomDBus: Got a link reset on: " << path << std::endl;
     std::vector<set_effecter_state_field> stateField;
 
     if (value ==
@@ -28,6 +27,7 @@ bool Link::linkReset(bool value)
 
     if (value && hostEffecterParser)
     {
+        std::cerr << "Got a link reset request on : " << path << std::endl;
         uint16_t effecterID = getEffecterID();
 
         if (effecterID == 0)
@@ -36,7 +36,7 @@ bool Link::linkReset(bool value)
         }
 
         std::cerr
-            << "CustomDBus: Sending a effecter call to host with effecter id: "
+            << "[link reset] : Sending a effecter call to host with effecter id: "
             << effecterID << std::endl;
         hostEffecterParser->sendSetStateEffecterStates(
             mctpEid, effecterID, 1, stateField, nullptr, value);


### PR DESCRIPTION
lanesInUse is recently changed to int64_t from size_t to
be able to show the unknown case (using -1 value). There
are certain parts of pldm code that have not completed the
migration and the value is implicitly being converted to an
unsigned number. This would fix the behavior.

This PR would also fix some traces in pcie linkreset.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>