### PR TITLE
pldmresponder: Fix sensor state of enclosure fault/identify led

### DIFF
--- a/libpldmresponder/platform_state_sensor.hpp
+++ b/libpldmresponder/platform_state_sensor.hpp
@@ -44,6 +44,21 @@ uint8_t getStateSensorEventState(
 
         for (const auto& stateValue : stateToDbusValue)
         {
+            // This special condition added to handle the "||" keyword
+            // present in the property value string
+            if (dbusMapping.propertyType == "string")
+            {
+                std::string statValSecStr =
+                    std::get<std::string>(stateValue.second);
+                std::string proValStr = std::get<std::string>(propertyValue);
+
+                if ((std::strstr(statValSecStr.c_str(), "||")) &&
+                    (std::strstr(statValSecStr.c_str(), proValStr.c_str())))
+                {
+                    return stateValue.first;
+                }
+            }
+
             if (stateValue.second == propertyValue)
             {
                 return stateValue.first;


### PR DESCRIPTION
PLDM sensor state of the enclosure fault/identify led is not
displayed correctly when its On/Blink. Added special handling of
sensor state when the property value contains logical OR operator.

Tested: Tested the sensor values of enclosure fault/identify by
setting On, Off and Blink values.

Fixes: SW552922

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: Ie65217a0dfec393da1e3de26a7a6416860037bdc