### PR TITLE
oem-ibm:bios: Remove PblBootLid in the help text for pvm_rpa_boot_mode.

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -241,7 +241,7 @@
          "default_values":[
             "Normal"
          ],
-         "helpText" : "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list, PblBootLid(PBL : Petitboot Boot Loader): The partition boots from the petitboot bootloader.",
+         "helpText" : "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
          "displayName" : "AIX/Linux Partition Boot Mode"
       },
       {


### PR DESCRIPTION
Signed-off-by: Sridevi Ramesh <sridevra@in.ibm.com>