### PR TITLE
fix for instance ID exhaustion when HBRT is not up

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1098,6 +1098,7 @@ void HostPDRHandler::_setHostSensorState()
                         }
                         ++sensorIndex;
                         _setHostSensorState();
+                        return;
                     }
                     std::array<get_sensor_state_field, 8> stateField{};
                     uint8_t completionCode = 0;
@@ -1121,6 +1122,7 @@ void HostPDRHandler::_setHostSensorState()
                         }
                         ++sensorIndex;
                         _setHostSensorState();
+                        return;
                     }
 
                     uint8_t eventState;


### PR DESCRIPTION
This commit fixes the issue where the instance ID was
getting exhausted when HBRT was not up and we query the
HBRT sensors.

Fixes - SW553214

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>