### PR TITLE
oem-ibm dump offload :Avoid Unmap of DMA on EINTR error  

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -97,7 +97,16 @@ int DMA::transferHostDataToSocket(int fd, uint32_t length, uint64_t address)
         std::cerr
             << "transferHostDataToSocket : Failed to execute the DMA operation, RC="
             << rc << " ADDRESS=" << address << " LENGTH=" << length << "\n";
-        munmap(vgaMemDump, pageAlignedLength);
+        if (rc != -EINTR)
+        {
+            munmap(vgaMemDump, pageAlignedLength);
+        }
+        else
+        {
+            std::cerr
+                << "transferHostDataToSocket : Received interrupt during dump DMA transfer. Skipping Unmap"
+                << std::endl;
+        }
         return rc;
     }
 


### PR DESCRIPTION
These changes will handle the case where host crashes in the
middle of outofband DMA transfer during system dump offload.

When the host crashes during the DMA transfer,
PLDM receives EINTR(interrupt) and it unmaps the memory.
XDMA driver doesn't know that the operation is interrupted,
it still thinks that operation is in progress.
munmap will hang if xdma driver thinks the operation is in progress.