### PR TITLE
PLDM: Change the max value of hb_ioadapter_enlarged_capacity

### DIFF
--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -100,7 +100,7 @@
       {
          "attribute_name" : "hb_ioadapter_enlarged_capacity",
          "lower_bound" : 0,
-         "upper_bound" : 255,
+         "upper_bound" : 21,
          "scalar_increment" : 1,
          "default_value" : 0,
          "helpText" : "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
@@ -109,7 +109,7 @@
       {
          "attribute_name" : "hb_ioadapter_enlarged_capacity_current",
          "lower_bound" : 0,
-         "upper_bound" : 255,
+         "upper_bound" : 21,
          "scalar_increment" : 1,
          "default_value" : 0,
          "readOnly" : true,


### PR DESCRIPTION
This commit is to change the range of values for
IO Enlarged Capacity value to be set on the GUI from
max PCI slots of Rainier system to the max value across
different platforms(rainier/everest)

Defect: SW552828

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>