### PR TITLE
Fix : PLDM-DBUS event support in PLDM

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -351,6 +351,17 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
         {
             std::cout << " value : " << std::get<bool>(value);
         }
+        if (strstr(dBusMap.objectPath.c_str(), "dimm") &&
+            (dBusMap.interface ==
+             "xyz.openbmc_project.State.Decorator.OperationalStatus"))
+        {
+            if (!std::get<bool>(value))
+            {
+                std::cerr << "Guard event on DIMM : [ "
+                          << dBusMap.objectPath.c_str() << " ] \n";
+            }
+        }
+
         setDbusValue(v);
     }
     else if (dBusMap.propertyType == "int16_t")

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -421,6 +421,13 @@ int HostPDRHandler::handleStateSensorEvent(
         if ((stateSetId[0] == PLDM_STATE_SET_HEALTH_STATE ||
              stateSetId[0] == PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS))
         {
+            if (!(state == PLDM_OPERATIONAL_NORMAL) &&
+                stateSetId[0] == PLDM_STATE_SET_HEALTH_STATE &&
+                strstr(entity.first.c_str(), "core"))
+            {
+                std::cerr << "Guard event on CORE : [" << entity.first
+                          << "] \n";
+            }
             CustomDBus::getCustomDBus().setOperationalStatus(
                 entity.first, state == PLDM_OPERATIONAL_NORMAL,
                 getParentChassis(entity.first));

--- a/libpldmresponder/event_parser.cpp
+++ b/libpldmresponder/event_parser.cpp
@@ -127,7 +127,9 @@ int StateSensorHandler::eventAction(StateSensorEntry entry,
     {
         if (kv.first.skipContainerCheck &&
             kv.first.entityType == entry.entityType &&
-            kv.first.entityInstance == entry.entityInstance)
+            kv.first.entityInstance == entry.entityInstance &&
+            kv.first.stateSetid == entry.stateSetid &&
+            kv.first.sensorOffset == entry.sensorOffset)
         {
             entry.skipContainerCheck = true;
             break;

--- a/libpldmresponder/event_parser.hpp
+++ b/libpldmresponder/event_parser.hpp
@@ -53,34 +53,17 @@ struct StateSensorEntry
     {
         if (!skipContainerCheck)
         {
-            return ((containerId < e.containerId) ||
-                    ((containerId == e.containerId) &&
-                     (entityType < e.entityType)) ||
-                    ((containerId == e.containerId) &&
-                     (entityType == e.entityType) &&
-                     (entityInstance < e.entityInstance)) ||
-                    ((containerId == e.containerId) &&
-                     (entityType == e.entityType) &&
-                     (entityInstance == e.entityInstance) &&
-                     (sensorOffset < e.sensorOffset)) ||
-                    ((containerId == e.containerId) &&
-                     (entityType == e.entityType) &&
-                     (entityInstance == e.entityInstance) &&
-                     (sensorOffset == e.sensorOffset) &&
-                     (stateSetid < e.stateSetid)));
+            return std::tie(entityType, entityInstance, containerId,
+                            sensorOffset, stateSetid) <
+                   std::tie(e.entityType, e.entityInstance, e.containerId,
+                            e.sensorOffset, e.stateSetid);
         }
         else
         {
-            return ((entityType < e.entityType) ||
-                    ((entityType == e.entityType) &&
-                     (entityInstance < e.entityInstance)) ||
-                    ((entityType == e.entityType) &&
-                     (entityInstance == e.entityInstance) &&
-                     (sensorOffset < e.sensorOffset)) ||
-                    ((entityType == e.entityType) &&
-                     (entityInstance == e.entityInstance) &&
-                     (sensorOffset == e.sensorOffset) &&
-                     (stateSetid < e.stateSetid)));
+            return std::tie(entityType, entityInstance, sensorOffset,
+                            stateSetid) <
+                   std::tie(e.entityType, e.entityInstance, e.sensorOffset,
+                            e.stateSetid);
         }
     }
 };


### PR DESCRIPTION
Current code has a bug where events for certain pldm
entities does not propage back to dbus model, this PR
is an attempt to fix that bug.

This PR would also add tracing for GUARD events for both
DIMM's and Core's

Tested By :

1. sh-5.1# guard -l
ID       | ERROR    |  Type  | Path
00000001 | 00000000 | manual | physical:sys-0/node-0/dimm-0
00000002 | 00000000 | manual | physical:sys-0/node-0/dimm-60
00000003 | 00000000 | manual | physical:sys-0/node-0/proc-0/eq-0/fc-0

Journal reported :
Jun 22 13:14:51 everjmt03bmc pldmd[32150]: Guarding CORE : ["/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/core0"]
Jun 22 13:14:51 everjmt03bmc pldmd[32150]: Guarding DIMM : [ /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm60 ]
Jun 22 13:14:51 everjmt03bmc pldmd[32150]: Guarding DIMM : [ /xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0 ]

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>