### PR TITLE
Revert "[FileIO]Do not initiate DMA OP if the hoststate is off (#280)"

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -323,14 +323,11 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
         return response;
     }
 
-    oem_ibm_platform::Handler* oemIbmPlatformHandler =
-        reinterpret_cast<oem_ibm_platform::Handler*>(oemPlatformHandler);
     using namespace dma;
     DMA intf;
     return transferAll<DMA>(&intf, PLDM_READ_FILE_INTO_MEMORY, value.fsPath,
                             offset, length, address, true,
-                            request->hdr.instance_id,
-                            oemIbmPlatformHandler->getBootProgressState());
+                            request->hdr.instance_id);
 }
 
 Response Handler::writeFileFromMemory(const pldm_msg* request,
@@ -403,14 +400,11 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
         return response;
     }
 
-    oem_ibm_platform::Handler* oemIbmPlatformHandler =
-        reinterpret_cast<oem_ibm_platform::Handler*>(oemPlatformHandler);
     using namespace dma;
     DMA intf;
     return transferAll<DMA>(&intf, PLDM_WRITE_FILE_FROM_MEMORY, value.fsPath,
                             offset, length, address, false,
-                            request->hdr.instance_id,
-                            oemIbmPlatformHandler->getBootProgressState());
+                            request->hdr.instance_id);
 }
 
 Response Handler::getFileTable(const pldm_msg* request, size_t payloadLength)
@@ -653,20 +647,6 @@ Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
                                            responsePtr);
         return response;
     }
-
-    oem_ibm_platform::Handler* oemIbmPlatformHandler =
-        reinterpret_cast<oem_ibm_platform::Handler*>(oemPlatformHandler);
-    if (!oemIbmPlatformHandler->getBootProgressState())
-    {
-        std::cerr
-            << "Host is in off state, declining DMA operation for [fileType, Read/Write] [ "
-            << fileType << " , " << static_cast<uint16_t>(cmd) << "]"
-            << std::endl;
-        encode_rw_file_by_type_memory_resp(request->hdr.instance_id, cmd,
-                                           PLDM_ERROR, 0, responsePtr);
-        return response;
-    }
-
     if ((length == 0) || (length % dma::minSize))
     {
         std::cerr << "Length is not a multiple of DMA minSize, LENGTH="

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -95,21 +95,11 @@ class DMA
 template <class DMAInterface>
 Response transferAll(DMAInterface* intf, uint8_t command, fs::path& path,
                      uint32_t offset, uint32_t length, uint64_t address,
-                     bool upstream, uint8_t instanceId,
-                     bool bootProgressComplete)
+                     bool upstream, uint8_t instanceId)
 {
     uint32_t origLength = length;
     Response response(sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_RESP_BYTES, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
-
-    if (!bootProgressComplete)
-    {
-        std::cerr << "declining DMA operation for command " << (uint16_t)command
-                  << std::endl;
-        encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
-                                   responsePtr);
-        return response;
-    }
 
     int flags{};
     if (upstream)


### PR DESCRIPTION
This reverts commit a3dd6293628a145464f4ca38b97d454d16871e4c.

This caused unexpected issues with the host being unable to flush its
NVRAM to the BMC during the graceful shutdown.

Fixes SW553535

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>