### PR TITLE
oem-ibm dump offload :Unmap the DMA memory in error path

### DIFF
--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -127,6 +127,7 @@ void writeToUnixSocket(const int sock, const char* buf,
     const std::lock_guard<std::mutex> lock(lockMutex);
     if (socketWriteStatus == Error)
     {
+        munmap((void*)buf, blockSize);
         return;
     }
     socketWriteStatus = InProgress;
@@ -152,6 +153,7 @@ void writeToUnixSocket(const int sock, const char* buf,
                       << std::endl;
             close(sock);
             socketWriteStatus = Error;
+            munmap((void*)buf, blockSize);
             return;
         }
         if (retval == 0)
@@ -177,6 +179,7 @@ void writeToUnixSocket(const int sock, const char* buf,
                           << std::endl;
                 close(sock);
                 socketWriteStatus = Error;
+                munmap((void*)buf, blockSize);
                 return;
             }
         }


### PR DESCRIPTION
DMA unmap is missing in error path causing DMA leak.
This commit fixes this DMA unmap issue in socket error handling.


This PR fixes https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553672