### PR TITLE
PLDM:Clear the modified event flags during host off

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -186,6 +186,8 @@ HostPDRHandler::HostPDRHandler(
                     this->mergedHostParents = false;
                     this->objMapIndex = objPathMap.begin();
                     this->sensorIndex = stateSensorPDRs.begin();
+                    this->isHostPdrModified = false;
+                    this->modifiedCounter = 0;
                     fruRecordSetPDRs.clear();
 
                     // After a power off , the remote notes will be deleted


### PR DESCRIPTION
Clear the modified PDR event flags during the
host off.

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>