### PR TITLE
Don't discard the nvme drive presence

### DIFF
--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -460,27 +460,21 @@ void findPortObjects(const std::string& cardObjPath,
 
 bool checkFruPresence(const char* objPath)
 {
-    // if we enter here with port or nvme objects then we need to find the
+    // if we enter here with port, then we need to find the
     // parent and see if the pcie card or the drive bp is present. if so then
-    // the port or the nvme slot is considered as present. this is so because
+    // the port is considered as present. this is so because
     // the ports do not have "Present" property
-    std::string nvme("nvme");
     std::string pcieAdapter("pcie_card");
     std::string portStr("cxp_");
     std::string newObjPath = objPath;
     bool isPresent = true;
-    /*if (newObjPath.find(nvme) != std::string::npos)
-    {
-        return true;
-    }
-    else*/
+
     if ((newObjPath.find(pcieAdapter) != std::string::npos) &&
         !checkIfIBMCableCard(newObjPath))
     {
         return true; // industry std cards
     }
-    else if (newObjPath.find(portStr) != std::string::npos ||
-             newObjPath.find(nvme) != std::string::npos)
+    else if (newObjPath.find(portStr) != std::string::npos)
     {
         newObjPath = pldm::utils::findParent(objPath);
     }


### PR DESCRIPTION
There was a time where we were not able to find the
presence of the nvme drives on IBM systems,to work
around that pldm was looking at the parent of the drive
which is the nvme slot to figure out the presence of the
drive.

Now that we had code in platform-fru-detect which can
detect the presence of nvme drives over nvme-MI, the
workaround that we put to look for drives parent presence
is no longer needed. This PR is an attempt to fix that.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>