### PR TITLE
PLDM: Changes to persist the HB PDRs in the repo before merging

### DIFF
--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -222,8 +222,11 @@ class HostPDRHandler
      *  @details A merge operation involves adding a pldm_entity under the
      *  appropriate parent, and updating container ids.
      *  @param[in] pdr - entity association pdr
+     *  @param[in] size - size of input PDR record in bytes
+     *  @param[in] record_handle - record handle of the PDR
      */
-    void mergeEntityAssociations(const std::vector<uint8_t>& pdr);
+    void mergeEntityAssociations(const std::vector<uint8_t>& pdr, uint32_t size,
+                                 uint32_t record_handle);
 
     /** @brief process the Host's PDR and add to BMC's PDR repo
      *  @param[in] eid - MCTP id of Host

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -156,6 +156,14 @@ class Handler : public CmdHandler
      */
     virtual void setSurvTimer(uint8_t tid, bool value) = 0;
 
+    /** @brief To check if record handle is in HostBoot range
+     *
+     *  @param[in] record_handle - record handle of the PDR
+     *
+     *  @return true or false
+     */
+    virtual bool isHBRange(uint32_t record_handle) = 0;
+
     virtual ~Handler() = default;
 
   protected:

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -635,6 +635,7 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                 {
                     pldm_pdr_remove_pdrs_by_terminus_handle(terminusHandle,
                                                             pdrRepo.getPdr());
+                    hostPDRHandler->tlPDRInfo.erase(terminusHandle);
                 }
             }
         }

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1923,6 +1923,15 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
     }
 }
 
+bool pldm::responder::oem_ibm_platform::Handler::isHBRange(
+    uint32_t record_handle)
+{
+    if (record_handle >= 0x01000000 && record_handle < 0x01FFFFFF)
+    {
+        return true;
+    }
+    return false;
+}
 } // namespace oem_ibm_platform
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -471,6 +471,13 @@ class Handler : public oem_platform::Handler
      */
     void triggerHostEffecter(bool value, std::string path);
 
+    /** @brief method to check if the record handle is within the HostBoot range
+     * or not
+     *
+     * @param[in] record_handle - record handle of the pdr
+     */
+    bool isHBRange(uint32_t record_handle);
+
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object


### PR DESCRIPTION
This commit persists the HB range PDRs in the repo before
they are merged. This change was needed as PHYP would not send
down BMC the entity Association PDRs of HB after a R/R as the
PDRs will be in BMC range of record handles. Due to this
the pldm ebmcModel in the PHYP was not updated properly.

This commit also prevents adding duplicate terminus locator
PDRs to the repo.

Tested: Multiple poweron and  poweroff
        Multiple Reset Reloads

Fixes: SW553100

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>