### PR TITLE
remove wants on synch targets in soft off

### DIFF
--- a/softoff/services/pldmSoftPowerOff.service
+++ b/softoff/services/pldmSoftPowerOff.service
@@ -2,7 +2,6 @@
 Description=PLDM soft power off app
 Wants=pldmd.service
 After=pldmd.service
-Wants=obmc-host-stop-pre@0.target
 Before=obmc-host-stop-pre@0.target
 Conflicts=obmc-host-startmin@0.target
 


### PR DESCRIPTION
openbmc/phosphor-state-manager#21 highlights an architecture issue with
OpenBMC's use of synchronization targets. When a service, such as
pldmSoftPowerOff.service, runs both in a standard power off
target, as well as in other paths (like the host graceful quiesce
path), there is an issue.

The service starts the synchronization targets in the quiesce path and
this causes them to already be running on the power off, resulting in
the synchronization targets not actually coordinating the power off.

The direction this commit takes OpenBMC is that if a service needs to
run outside of the standard power on or off path, then they can not
have a Wants or Requires clause in the service file.

The following commit was done a while back to address this issue:
  https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/40026

That is that we ensure the primary power on and off targets start the
synchronization targets so services requiring them can just use a
Before or After clause.

The piece that was never done was to go and fix the services which fell
into this bucket.

Tested:
- Did multiple boots, reboots, and host crash tests and saw no issues

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: I7260f4aad666acf127f9766cf27dd54f4a18ebe4