### PR TITLE
Adds Proc Favor Aggressive Prefetch to the BMC BIOS

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -526,6 +526,30 @@
            }
       },
       {
+         "attribute_name":"hb_proc_favor_aggressive_prefetch",
+         "possible_values":[
+            "Disabled",
+            "Enabled"
+         ],
+         "default_values":[
+            "Disabled"
+         ],
+         "helpText" : "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+         "displayName" : "Proc Favor Aggressive Prefetch (pending)"
+      },
+      {
+         "attribute_name":"hb_proc_favor_aggressive_prefetch_current",
+         "possible_values":[
+            "Disabled",
+            "Enabled"
+         ],
+         "default_values":[
+            "Disabled"
+         ],
+         "helpText" : "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+         "displayName" : "Proc Favor Aggressive Prefetch (current)"
+      },
+      {
          "attribute_name":"pvm_boot_initiator",
          "possible_values":[
              "User",


### PR DESCRIPTION
This commit adds Proc Favor Aggressive Prefetch, as an enumeration, to the BMC BIOS.

Add boths a current value and a pending value.

The enumeration fields are Enabled and Disabled.  The default is Disabled.

RTC: 339426
Change-Id: I1bf40275cc22ae81011d19e7be31d92c2d508f0f
Signed-off-by: Deb McLemore <debmc@us.ibm.com>
Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>

Conflicts:
	oem/ibm/configurations/bios/enum_attrs.json