### PR TITLE
[FRU]Fixed issue in processing GetRecordByOption

### DIFF
--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -770,9 +770,9 @@ int FruImpl::getFRURecordByOption(std::vector<uint8_t>& fruData,
     size_t recordTableSize = table.size() - padBytes + 7;
     fruData.resize(recordTableSize, 0);
 
-    get_fru_record_by_option(table.data(), table.size() - padBytes,
-                             fruData.data(), &recordTableSize,
-                             recordSetIdentifer, recordType, fieldType);
+    get_fru_record_by_option(table.data(), table.size(), fruData.data(),
+                             &recordTableSize, recordSetIdentifer, recordType,
+                             fieldType);
 
     if (recordTableSize == 0)
     {


### PR DESCRIPTION
Issue is seen when skiboot sends GetRecordByOption command during IPL

On receipt of GetRecordOption command, PLDM traverses through fru table
and copies the records matching the Record type and record set identifier
and field type.
We are sending table size to the library function which will
return the expected records. As the wrong table size is sent to
the lib function, code crashes while traversing the fru table.

Corrected the table size sent to library function to get record by option.

Fixes SW554881

Tested:
Tested using pldmtool commands at different IPL stages.
pldmtool fru GetFRURecordByOption -i 1 -r 1 -f 0

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>