### PR TITLE
Fix support for link with Unknown Type

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -284,6 +284,7 @@ class PCIeInfoHandler : public FileHandler
         mexObjectMap;
     static std::vector<std::string> cables;
     static std::vector<std::pair<linkId_t, linkId_t>> needPostProcessing;
+    static std::unordered_map<linkId_t, linkType_t> linkTypeInfo;
 };
 
 } // namespace responder

--- a/tools/visualize-pdr/pldm_visualise_pdrs.py
+++ b/tools/visualize-pdr/pldm_visualise_pdrs.py
@@ -106,9 +106,9 @@ def draw_entity_associations(pdr, counter):
             dot.node(hashlib.md5((childnode + cid)
                                  .encode()).hexdigest(), childnode)
 
-            if[hashlib.md5((parentnode +
+            if [hashlib.md5((parentnode +
                             str(value["containerEntityContainerID"]))
-                           .encode()).hexdigest(),
+                            .encode()).hexdigest(),
                hashlib.md5((childnode + cid)
                            .encode()).hexdigest()] not in edge_list:
                 edge_list.append([hashlib.md5((parentnode +


### PR DESCRIPTION
In the current state pldm would just drop the link that
has the link type as Unknown, the intent behind this PR
would be to add in necessary support in pldm so that we
store the last link type of a link and use for setting
the topology information.

Tested By:
1. Power on the host, make sure we are at Standby.
2. Get topology information and make sure all the links
   are populated correctly.
3. Inject the error on a link using phyp macros 5 times untill the
link is dead
xmwritereg -mmio -drc 20000010 -offset C00 -length 8 -asb -data 8000000000000000
xmtest -slotErrorRecovery 21010010 19
4. Refresh the topology page and make sure the link is
populated and with accurate information.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>