### PR TITLE
Add support for previous state in the event messages

### DIFF
--- a/host-bmc/dbus_to_event_handler.cpp
+++ b/host-bmc/dbus_to_event_handler.cpp
@@ -6,7 +6,6 @@
 
 namespace pldm
 {
-
 using namespace pldm::dbus_api;
 using namespace pldm::responder;
 using namespace pldm::responder::pdr;
@@ -98,13 +97,14 @@ void DbusToPLDMEvent::sendStateSensorEvent(SensorId sensorId,
     {
         std::vector<uint8_t> sensorEventDataVec{};
         sensorEventDataVec.resize(sensorEventSize);
+        uint8_t previousState = PLDM_SENSOR_UNKNOWN;
         auto eventData = reinterpret_cast<struct pldm_sensor_event_data*>(
             sensorEventDataVec.data());
         eventData->sensor_id = sensorId;
         eventData->sensor_event_class_type = PLDM_STATE_SENSOR_STATE;
         eventData->event_class[0] = offset;
         eventData->event_class[1] = PLDM_SENSOR_UNKNOWN;
-        eventData->event_class[2] = PLDM_SENSOR_UNKNOWN;
+        eventData->event_class[2] = previousState;
 
         const auto& dbusMapping = dbusMappings[offset];
         const auto& dbusValueMapping = dbusValMaps[offset];
@@ -112,8 +112,8 @@ void DbusToPLDMEvent::sendStateSensorEvent(SensorId sensorId,
             pldm::utils::DBusHandler::getBus(),
             propertiesChanged(dbusMapping.objectPath.c_str(),
                               dbusMapping.interface.c_str()),
-            [this, sensorEventDataVec, dbusValueMapping,
-             dbusMapping](auto& msg) mutable {
+            [this, sensorEventDataVec, previousState, dbusValueMapping,
+             dbusMapping, sensorId, offset](auto& msg) mutable {
                 DbusChangedProps props{};
                 std::string intf;
                 msg.read(intf, props);
@@ -154,15 +154,22 @@ void DbusToPLDMEvent::sendStateSensorEvent(SensorId sensorId,
                             reinterpret_cast<struct pldm_sensor_event_data*>(
                                 sensorEventDataVec.data());
                         eventData->event_class[1] = itr.first;
-                        eventData->event_class[2] = itr.first;
+                        eventData->event_class[2] = previousState;
                         this->sendEventMsg(PLDM_SENSOR_EVENT,
                                            sensorEventDataVec);
+                        sensorCacheMap[sensorId][offset] = previousState;
+                        previousState = itr.first;
                         break;
                     }
                 }
             });
         stateSensorMatchs.emplace_back(std::move(stateSensorMatch));
     }
+}
+
+const stateSensorCacheMaps& DbusToPLDMEvent::getSensorCache()
+{
+    return sensorCacheMap;
 }
 
 void DbusToPLDMEvent::listenSensorEvent(const pdr_utils::Repo& repo,

--- a/host-bmc/dbus_to_event_handler.hpp
+++ b/host-bmc/dbus_to_event_handler.hpp
@@ -10,7 +10,6 @@
 
 namespace pldm
 {
-
 using SensorId = uint16_t;
 /*using DbusObjMaps =
     std::map<SensorId, std::tuple<pldm::responder::pdr_utils::DbusMappings,
@@ -18,6 +17,8 @@ using SensorId = uint16_t;
 using sensorEvent = std::function<void(
     SensorId sensorId,
     const pldm::responder::pdr_utils::DbusObjMaps& dbusMaps)>;
+using stateSensorCacheMaps =
+    std::map<pldm::pdr::SensorID, pldm::responder::pdr_utils::EventStates>;
 
 namespace state_sensor
 {
@@ -54,6 +55,9 @@ class DbusToPLDMEvent
         const pldm::responder::pdr_utils::Repo& repo,
         const pldm::responder::pdr_utils::DbusObjMaps& dbusMaps);
 
+    /** @brief get the sensor state cache */
+    const stateSensorCacheMaps& getSensorCache();
+
     /** @brief Send state sensor event msg when a D-Bus property changes
      *  @param[in] sensorId - sensor id
      */
@@ -86,6 +90,9 @@ class DbusToPLDMEvent
 
     /** @brief PLDM request handler */
     pldm::requester::Handler<pldm::requester::Request>* handler;
+
+    /** @brief sensor cache */
+    stateSensorCacheMaps sensorCacheMap;
 };
 
 } // namespace state_sensor

--- a/libpldmresponder/pdr_utils.hpp
+++ b/libpldmresponder/pdr_utils.hpp
@@ -23,13 +23,10 @@ namespace fs = std::filesystem;
 
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace pdr_utils
 {
-
 /** @struct Type ID associated with pdr
  *
  */
@@ -82,6 +79,7 @@ using StatestoDbusVal = std::map<State, pldm::utils::PropertyValue>;
 using DbusMappings = std::vector<pldm::utils::DBusMapping>;
 using DbusValMaps = std::vector<StatestoDbusVal>;
 using DbusObjMaps = std::map<EffecterId, std::tuple<DbusMappings, DbusValMaps>>;
+using EventStates = std::vector<uint8_t>;
 
 /** @brief Parse PDR JSON file and output Json object
  *

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -29,7 +29,6 @@ namespace responder
 {
 namespace platform
 {
-
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
 
@@ -795,9 +794,9 @@ Response Handler::getStateSensorReadings(const pldm_msg* request,
     else
     {
         rc = platform_state_sensor::getStateSensorReadingsHandler<
-            pldm::utils::DBusHandler, Handler>(dBusIntf, *this, sensorId,
-                                               sensorRearmCount, comSensorCnt,
-                                               stateField);
+            pldm::utils::DBusHandler, Handler>(
+            dBusIntf, *this, sensorId, sensorRearmCount, comSensorCnt,
+            stateField, dbusToPLDMEventHandler->getSensorCache());
     }
 
     if (rc != PLDM_SUCCESS)

--- a/libpldmresponder/test/libpldmresponder_platform_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_platform_test.cpp
@@ -1,5 +1,6 @@
 #include "common/test/mocked_utils.hpp"
 #include "common/utils.hpp"
+#include "host-bmc/dbus_to_event_handler.hpp"
 #include "libpldmresponder/event_parser.hpp"
 #include "libpldmresponder/pdr.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
@@ -613,15 +614,17 @@ TEST(getStateSensorReadingsHandler, testGoodRequest)
                                        StrEq("xyz.openbmc_project.Foo.Bar")))
         .WillOnce(Return(
             PropertyValue(std::string("xyz.openbmc_project.Foo.Bar.V0"))));
-
+    EventStates cache = {PLDM_SENSOR_NORMAL};
+    pldm::stateSensorCacheMaps sensorCache;
+    sensorCache.emplace(0x1, cache);
     auto rc = platform_state_sensor::getStateSensorReadingsHandler<
         MockdBusHandler, Handler>(handlerObj, handler, 0x1, sensorRearmCnt,
-                                  compSensorCnt, stateField);
+                                  compSensorCnt, stateField, sensorCache);
     ASSERT_EQ(rc, 0);
     ASSERT_EQ(compSensorCnt, 1);
     ASSERT_EQ(stateField[0].sensor_op_state, PLDM_SENSOR_UNAVAILABLE);
     ASSERT_EQ(stateField[0].present_state, PLDM_SENSOR_UNKNOWN);
-    ASSERT_EQ(stateField[0].previous_state, PLDM_SENSOR_UNKNOWN);
+    ASSERT_EQ(stateField[0].previous_state, PLDM_SENSOR_NORMAL);
     ASSERT_EQ(stateField[0].event_state, PLDM_SENSOR_UNKNOWN);
 
     pldm_pdr_destroy(inPDRRepo);
@@ -655,9 +658,12 @@ TEST(getStateSensorReadingsHandler, testBadRequest)
     uint8_t sensorRearmCnt = 3;
 
     MockdBusHandler handlerObj;
+    EventStates cache = {PLDM_SENSOR_NORMAL};
+    pldm::stateSensorCacheMaps sensorCache;
+    sensorCache.emplace(0x1, cache);
     auto rc = platform_state_sensor::getStateSensorReadingsHandler<
         MockdBusHandler, Handler>(handlerObj, handler, 0x1, sensorRearmCnt,
-                                  compSensorCnt, stateField);
+                                  compSensorCnt, stateField, sensorCache);
     ASSERT_EQ(rc, PLDM_PLATFORM_REARM_UNAVAILABLE_IN_PRESENT_STATE);
 
     pldm_pdr_destroy(inPDRRepo);


### PR DESCRIPTION
In the current state, any sensor event from the bmc pldm
stack would have the same value for both the previous state
and the event state. This commit would fix that behaviour
by caching the previous state.

This commit would also add the previous state support for the
state sensor reading reply as well.

Tested By :
1. Change the value of sensor using busctl for example dimm8 identify
to false
Tx: 81 02 0a 01 00 00 4d 00 01 00 [ 01 00 ]

Note that the very first event for every sensor would have the previous
state as PLDM_SENSOR_UNKNOWN [0]

In the above example : [ event state : 01 , previous state : 00 ]

2. Change the value of dimm8 identify to true
Tx: 81 02 0a 01 00 00 4d 00 01 00 [ 02 01 ]

[ event state : 02 , previous state : 01 ]

3. Change the value of dimm8 identify to false
Tx: 81 02 0a 01 00 00 4d 00 01 00 [ 01 02 ]
Event state : 01 , previous state: 02

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
Change-Id: Ie4f452e1d27029ccc3846eb6bd882d48dda5d34c