### PR TITLE
Fix pldm crash due to previous events

### DIFF
--- a/host-bmc/dbus_to_event_handler.cpp
+++ b/host-bmc/dbus_to_event_handler.cpp
@@ -154,11 +154,20 @@ void DbusToPLDMEvent::sendStateSensorEvent(SensorId sensorId,
                             reinterpret_cast<struct pldm_sensor_event_data*>(
                                 sensorEventDataVec.data());
                         eventData->event_class[1] = itr.first;
+                        if (sensorCacheMap.contains(sensorId) &&
+                            sensorCacheMap[sensorId][offset] !=
+                                PLDM_SENSOR_UNKNOWN)
+                        {
+                            previousState = sensorCacheMap[sensorId][offset];
+                        }
+                        else
+                        {
+                            previousState = itr.first;
+                        }
                         eventData->event_class[2] = previousState;
                         this->sendEventMsg(PLDM_SENSOR_EVENT,
                                            sensorEventDataVec);
-                        sensorCacheMap[sensorId][offset] = previousState;
-                        previousState = itr.first;
+                        updateSensorCacheMaps(sensorId, offset, previousState);
                         break;
                     }
                 }

--- a/host-bmc/dbus_to_event_handler.hpp
+++ b/host-bmc/dbus_to_event_handler.hpp
@@ -58,6 +58,13 @@ class DbusToPLDMEvent
     /** @brief get the sensor state cache */
     const stateSensorCacheMaps& getSensorCache();
 
+    void updateSensorCacheMaps(pldm::pdr::SensorID sensorId, size_t sensorRearm,
+                               uint8_t previousState)
+    {
+        // update the sensor cache
+        sensorCacheMap[sensorId][sensorRearm] = previousState;
+    }
+
     /** @brief Send state sensor event msg when a D-Bus property changes
      *  @param[in] sensorId - sensor id
      */

--- a/libpldmresponder/pdr_utils.hpp
+++ b/libpldmresponder/pdr_utils.hpp
@@ -79,7 +79,7 @@ using StatestoDbusVal = std::map<State, pldm::utils::PropertyValue>;
 using DbusMappings = std::vector<pldm::utils::DBusMapping>;
 using DbusValMaps = std::vector<StatestoDbusVal>;
 using DbusObjMaps = std::map<EffecterId, std::tuple<DbusMappings, DbusValMaps>>;
-using EventStates = std::vector<uint8_t>;
+using EventStates = std::array<uint8_t, 8>;
 
 /** @brief Parse PDR JSON file and output Json object
  *

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -445,6 +445,13 @@ class Handler : public CmdHandler
         return fruHandler->getAssociateEntityMap();
     }
 
+    inline void updateSensorCache(pldm::pdr::SensorID sensorId,
+                                  size_t sensorRearm, uint8_t value)
+    {
+        dbusToPLDMEventHandler->updateSensorCacheMaps(sensorId, sensorRearm,
+                                                      value);
+    }
+
     /** @brief process the actions that needs to be performed after a GetPDR
      *         call is received
      *  @param[in] source - sdeventplus event source

--- a/libpldmresponder/platform_state_sensor.hpp
+++ b/libpldmresponder/platform_state_sensor.hpp
@@ -159,14 +159,9 @@ int getStateSensorReadingsHandler(
         {
             sensorCacheforSensor = sensorCache.at(sensorId);
         }
-        else
-        {
-            std::cerr << "Sensor Cache not available for sensor ID : "
-                      << sensorId << std::endl;
-        }
 
         stateField.clear();
-        for (size_t i = 0; i < sensorRearmCnt; i++)
+        for (std::size_t i{0}; i < sensorRearmCnt; i++)
         {
             auto& dbusMapping = dbusMappings[i];
 
@@ -174,11 +169,23 @@ int getStateSensorReadingsHandler(
                 dBusIntf, dbusValMaps[i], dbusMapping);
 
             uint8_t previousState = PLDM_SENSOR_UNKNOWN;
-            if (!sensorCacheforSensor.empty() &&
-                i <= sensorCacheforSensor.size())
+
+            // if sensor cache is empty, then its the first
+            // get_state_sensor_reading on this sensor, set the previous state
+            // as the current state
+
+            if (sensorCacheforSensor.at(i) == PLDM_SENSOR_UNKNOWN)
             {
+                previousState = sensorEvent;
+                handler.updateSensorCache(sensorId, i, previousState);
+            }
+            else
+            {
+                // sensor cache is not empty, so get the previous state from
+                // the sensor cache
                 previousState = sensorCacheforSensor[i];
             }
+
             uint8_t opState = PLDM_SENSOR_ENABLED;
             if (sensorEvent == PLDM_SENSOR_UNKNOWN)
             {


### PR DESCRIPTION
The crash is due to accessing the vector events for composite sensors.Fixed it by using a predefined array that is initialised with 0.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>