### PR TITLE
PLDM: Combining multiple repository change events

### DIFF
--- a/libpldm/tests/libpldm_pdr_test.cpp
+++ b/libpldm/tests/libpldm_pdr_test.cpp
@@ -263,7 +263,8 @@ TEST(PDRAccess, testGet)
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in));
     EXPECT_EQ(nextRecHdl, 0u);
-    // EXPECT_EQ(memcmp(outData, in.data(), sizeof(in)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in.data() + 1, sizeof(in) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
 
     auto hdl2 = pldm_pdr_find_record(repo, 1, &outData, &size, &nextRecHdl);
@@ -271,7 +272,8 @@ TEST(PDRAccess, testGet)
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in));
     EXPECT_EQ(nextRecHdl, 0u);
-    // EXPECT_EQ(memcmp(outData, in.data(), sizeof(in)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in.data() + 1, sizeof(in) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl2->record_handle);
     outData = nullptr;
 
     hdl = pldm_pdr_find_record(repo, htole32(0xdeaddead), &outData, &size,
@@ -293,37 +295,47 @@ TEST(PDRAccess, testGet)
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4u);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo), sizeof(in2) * 4);
     hdl = pldm_pdr_find_record(repo, 0, &outData, &size, &nextRecHdl);
+
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in));
     EXPECT_EQ(nextRecHdl, 2u);
-    // EXPECT_EQ(memcmp(outData, in.data(), sizeof(in)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in.data() + 1, sizeof(in) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
+
     hdl2 = pldm_pdr_find_record(repo, 1, &outData, &size, &nextRecHdl);
     EXPECT_EQ(hdl, hdl2);
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in));
     EXPECT_EQ(nextRecHdl, 2u);
-    // EXPECT_EQ(memcmp(outData, in.data(), sizeof(in)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in.data() + 1, sizeof(in) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl2->record_handle);
     outData = nullptr;
+
     hdl = pldm_pdr_find_record(repo, 2, &outData, &size, &nextRecHdl);
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in2));
     EXPECT_EQ(nextRecHdl, 3u);
-    // EXPECT_EQ(memcmp(outData, in2.data(), sizeof(in2)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in2.data() + 1, sizeof(in2) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
+
     hdl = pldm_pdr_find_record(repo, 3, &outData, &size, &nextRecHdl);
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(pldm_pdr_record_is_remote(hdl), false);
     EXPECT_EQ(size, sizeof(in2));
     EXPECT_EQ(nextRecHdl, 4u);
-    // EXPECT_EQ(memcmp(outData, in2.data(), sizeof(in2)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in2.data() + 1, sizeof(in2) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
+
     hdl = pldm_pdr_find_record(repo, 4, &outData, &size, &nextRecHdl);
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(pldm_pdr_record_is_remote(hdl), true);
     EXPECT_EQ(size, sizeof(in2));
     EXPECT_EQ(nextRecHdl, 0u);
-    // EXPECT_EQ(memcmp(outData, in2.data(), sizeof(in2)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in2.data() + 1, sizeof(in2) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
 
     pldm_pdr_destroy(repo);
@@ -345,7 +357,8 @@ TEST(PDRAccess, testGetNext)
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in));
     EXPECT_EQ(nextRecHdl, 0u);
-    // EXPECT_EQ(memcmp(outData, in.data(), sizeof(in)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in.data() + 1, sizeof(in) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
 
     std::array<uint32_t, 10> in2{1000, 3450, 30,  60,     890,
@@ -362,19 +375,24 @@ TEST(PDRAccess, testGetNext)
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in2));
     EXPECT_EQ(nextRecHdl, 3u);
-    // EXPECT_EQ(memcmp(outData, in2.data(), sizeof(in2)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in2.data() + 1, sizeof(in2) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
+
     hdl = pldm_pdr_get_next_record(repo, hdl, &outData, &size, &nextRecHdl);
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in2));
     EXPECT_EQ(nextRecHdl, 4u);
-    // EXPECT_EQ(memcmp(outData, in2.data(), sizeof(in2)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in2.data() + 1, sizeof(in2) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
+
     hdl = pldm_pdr_get_next_record(repo, hdl, &outData, &size, &nextRecHdl);
     EXPECT_NE(hdl, nullptr);
     EXPECT_EQ(size, sizeof(in2));
     EXPECT_EQ(nextRecHdl, 0u);
-    // EXPECT_EQ(memcmp(outData, in2.data(), sizeof(in2)), -1);
+    EXPECT_EQ(memcmp(outData + 4, in2.data() + 1, sizeof(in2) - 4), 0);
+    EXPECT_EQ(reinterpret_cast<uint32_t*>(outData)[0], hdl->record_handle);
     outData = nullptr;
 
     pldm_pdr_destroy(repo);

--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -177,6 +177,8 @@ void Handler::setFruPresence(const std::string& adapterObjPath)
 
 void Handler::setFirmwareUAK(std::vector<uint8_t> data)
 {
+    std::cout << "Got a SetFRURecordTable cmd from host to set the firmware UAK"
+              << std::endl;
     static constexpr auto uakObjPath = "/com/ibm/VPD/Manager";
     static constexpr auto uakInterface = "com.ibm.VPD.Manager";
 


### PR DESCRIPTION
This commit fixes:
1. PLDM Test cases fixed
- pldm_pdr_find_record test cases are fixed

2. Combining multiple repository change events
- When the FRU is concurrently added/removed, PLDM would
add/remove all the Sensors/Effecters/Fru Records
attached to the FRU and also the the necessary
entity association PDR's would be modified.
For the PDRs changes Removed/Added/Modified
is informed to Host through mutiple repository change events.
sending multiple Remove/Add/Modify events to PHYP
causes high traffic to PHYP in small amount of time.
In CMC exchange case PHYP triggers multiple slot
enable/disable effecter which is causing multiple
repository change events to PHYP. As PHYP's queue size is 32
its not able to handle all respository change events
received within seconds. To reduce the repository change events
generated from BMC, combining multiple events based on
eventData operation.

Fixes PE00DJH0 from BMC side

Tested:
Followed the steps:
Removed both MEX PSUs
Removed MEX CMC card
Install MEX CMC card
Install back both MEX PSUs
Test Passed with no pels logged

Signed-off-by: Kamalkumar <kamalkumar.patel@ibm.com>