### PR TITLE
PLDM: Mark all _current attributes as readonly

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -125,7 +125,8 @@
             "Disabled"
          ],
          "helpText" : "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
-         "displayName" : "pvm_stop_at_standby_current (current)"
+         "displayName" : "pvm_stop_at_standby_current (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"hb_debug_console",
@@ -215,7 +216,8 @@
             "Default"
          ],
          "helpText" : "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
-         "displayName" : "CEC Primary OS (current)"
+         "displayName" : "CEC Primary OS (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"pvm_system_operating_mode",
@@ -257,7 +259,8 @@
             "Normal"
          ],
          "helpText" : "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
-         "displayName" : "AIX/Linux Partition Boot Mode (current)"
+         "displayName" : "AIX/Linux Partition Boot Mode (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"pvm_os_boot_type",
@@ -285,7 +288,8 @@
             "D_Mode"
          ],
          "helpText" : "Specifies the current IBMi partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
-         "displayName" : "IBMi Partition Boot Mode (current)"
+         "displayName" : "IBMi Partition Boot Mode (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"pvm_vtpm",
@@ -309,7 +313,8 @@
             "Enabled"
          ],
          "helpText" : "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
-         "displayName" : "Virtual Trusted Platform Module (current)"
+         "displayName" : "Virtual Trusted Platform Module (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"pvm_sys_dump_active",
@@ -345,7 +350,8 @@
             "256MB"
          ],
          "helpText" : "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
-         "displayName" : "Memory Region Size (current)"
+         "displayName" : "Memory Region Size (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"hb_power_limit_enable",
@@ -379,7 +385,8 @@
             "Disabled"
          ],
          "helpText" : "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
-         "displayName" : "Power Limit Enable (current)"
+         "displayName" : "Power Limit Enable (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"hb_secure_ver_lockin_enabled",
@@ -415,7 +422,8 @@
             "Disabled"
          ],
          "helpText" : "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
-         "displayName" : "Memory Mirror Mode (current)"
+         "displayName" : "Memory Mirror Mode (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"hb_tpm_required",
@@ -447,7 +455,8 @@
             "Required"
          ],
          "helpText" : "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
-         "displayName" : "TPM Required Policy (current)"
+         "displayName" : "TPM Required Policy (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"hb_key_clear_request",
@@ -479,7 +488,8 @@
             "NONE"
          ],
          "helpText" : "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
-         "displayName" : "Key Clear Request (current)"
+         "displayName" : "Key Clear Request (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"hb_host_usb_enablement",
@@ -503,7 +513,8 @@
             "Enabled"
          ],
          "helpText" : "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
-         "displayName" : "Host USB Enablement (current)"
+         "displayName" : "Host USB Enablement (current)",
+         "readOnly":true
       },
       {
         "attribute_name":"pvm_auto_poweron_restart",
@@ -547,7 +558,8 @@
             "Disabled"
          ],
          "helpText" : "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
-         "displayName" : "Proc Favor Aggressive Prefetch (current)"
+         "displayName" : "Proc Favor Aggressive Prefetch (current)",
+         "readOnly":true
       },
       {
          "attribute_name":"pvm_boot_initiator",
@@ -649,7 +661,8 @@
             "Enabled"
         ],
         "helpText" : "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
-        "displayName" : "Lateral Cast Out mode (current)"
+        "displayName" : "Lateral Cast Out mode (current)",
+         "readOnly":true
      },
      {
         "attribute_name":"pvm_create_default_lpar",
@@ -673,7 +686,8 @@
            "Disabled"
         ],
         "helpText" : "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
-        "displayName" : "pvm_create_default_lpar (current)"
+        "displayName" : "pvm_create_default_lpar (current)",
+         "readOnly":true
      }
 
   ]

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -33,6 +33,7 @@
          "upper_bound" : 65535,
          "scalar_increment" : 1,
          "default_value" : 0,
+         "readOnly" : true,
          "helpText" : "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
          "displayName" : "Number Huge Pages (current)"
       },
@@ -51,6 +52,7 @@
          "upper_bound" : 255,
          "scalar_increment" : 1,
          "default_value" : 0,
+         "readOnly" : true,
          "helpText" : "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
          "displayName" : "Huge Page Size (current)"
       },
@@ -69,6 +71,7 @@
          "upper_bound" : 255,
          "scalar_increment" : 1,
          "default_value" : 0,
+         "readOnly" : true,
          "helpText" : "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
          "displayName" : "Field Core Override (current)"
       },
@@ -161,6 +164,7 @@
          "upper_bound" : 4294967295,
          "scalar_increment" : 1,
          "default_value" : 0,
+         "readOnly" : true,
          "helpText" : "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
          "displayName" : "Requested Core Freq MHZ (current)"
       }

--- a/oem/ibm/configurations/bios/string_attrs.json
+++ b/oem/ibm/configurations/bios/string_attrs.json
@@ -85,7 +85,8 @@
          "default_string_length" : 32,
          "default_string" : "00000000000000000000000000000000",
          "helpText" : "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
-         "displayName" : "Manufacturing Flags (current)"
+         "displayName" : "Manufacturing Flags (current)",
+         "readOnly":true
       },
       {
          "attribute_name" : "hb_lid_ids",


### PR DESCRIPTION
- Attribute made as readOnly as per Defect SW557487
- List of attributes are modified as readOnly:
hb_cap_freq_mhz_request_current
hb_field_core_override_current
hb_host_usb_enablement_current
hb_huge_page_size_current
hb_key_clear_request_current
hb_lateral_cast_out_mode_current
hb_memory_mirror_mode_current
hb_memory_region_size_current
hb_mfg_flags_current
hb_number_huge_pages_current
hb_power_limit_enable_current
hb_proc_favor_aggressive_prefetch_current
hb_tpm_required_current
pvm_create_default_lpar_current
pvm_default_os_type_current
pvm_os_boot_type_current
pvm_rpa_boot_mode_current
pvm_stop_at_standby_current
pvm_vtpm_current