### PR TITLE
PLDM: Changes to persist the HB PDRs in the repo before merging

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -458,13 +458,21 @@ int HostPDRHandler::handleStateSensorEvent(
     return PLDM_SUCCESS;
 }
 
-void HostPDRHandler::mergeEntityAssociations(const std::vector<uint8_t>& pdr)
+void HostPDRHandler::mergeEntityAssociations(
+    const std::vector<uint8_t>& pdr, [[maybe_unused]] const uint32_t& size,
+    [[maybe_unused]] const uint32_t& record_handle)
 {
     size_t numEntities{};
     pldm_entity* entities = nullptr;
     bool merged = false;
     auto entityPdr = reinterpret_cast<pldm_pdr_entity_association*>(
         const_cast<uint8_t*>(pdr.data()) + sizeof(pldm_pdr_hdr));
+
+    if (oemPlatformHandler && oemPlatformHandler->isHBRange(record_handle))
+    {
+        // Adding the HostBoot range PDRs to the repo before merging it
+        pldm_pdr_add(repo, pdr.data(), size, record_handle, true, 0xFFFF);
+    }
 
     pldm_entity_association_pdr_extract(pdr.data(), pdr.size(), &numEntities,
                                         &entities);
@@ -764,7 +772,7 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
 
             if (pdrHdr->type == PLDM_PDR_ENTITY_ASSOCIATION)
             {
-                this->mergeEntityAssociations(pdr);
+                this->mergeEntityAssociations(pdr, respCount, rh);
                 merged = true;
             }
             else

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -224,8 +224,13 @@ class HostPDRHandler
      *  @details A merge operation involves adding a pldm_entity under the
      *  appropriate parent, and updating container ids.
      *  @param[in] pdr - entity association pdr
+     *  @param[in] size - size of input PDR record in bytes
+     *  @param[in] record_handle - record handle of the PDR
      */
-    void mergeEntityAssociations(const std::vector<uint8_t>& pdr);
+    void
+        mergeEntityAssociations(const std::vector<uint8_t>& pdr,
+                                [[maybe_unused]] const uint32_t& size,
+                                [[maybe_unused]] const uint32_t& record_handle);
 
     /** @brief process the Host's PDR and add to BMC's PDR repo
      *  @param[in] eid - MCTP id of Host

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -156,6 +156,14 @@ class Handler : public CmdHandler
      */
     virtual void setSurvTimer(uint8_t tid, bool value) = 0;
 
+    /** @brief To check if record handle is in HostBoot range
+     *
+     *  @param[in] record_handle - record handle of the PDR
+     *
+     *  @return true or false
+     */
+    virtual bool isHBRange(const uint32_t& record_handle) = 0;
+
     virtual ~Handler() = default;
 
   protected:

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1923,6 +1923,16 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
     }
 }
 
+bool pldm::responder::oem_ibm_platform::Handler::isHBRange(
+    const uint32_t& record_handle)
+{
+    if (record_handle >= 0x01000000 && record_handle < 0x01FFFFFF)
+    {
+        return true;
+    }
+    return false;
+}
+
 } // namespace oem_ibm_platform
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -471,6 +471,13 @@ class Handler : public oem_platform::Handler
      */
     void triggerHostEffecter(bool value, std::string path);
 
+    /** @brief method to check if the record handle is within the HostBoot range
+     *  or not
+     *
+     *  @param[in] record_handle - record handle of the pdr
+     */
+    bool isHBRange(const uint32_t& record_handle);
+
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object


### PR DESCRIPTION
This commit persists the HB range PDRs in the repo before they are merged. This change was needed as PHYP would not send down BMC the entity Association PDRs of HB after a R/R as the PDRs will be in BMC range of record handles. Due to this the pldm ebmcModel in the PHYP was not updated properly.

This commit also prevents adding duplicate terminus locator PDRs to the repo.

Tested on both Rainier and Everest systems:
Multiple poweron and poweroff
Multiple Reset Reloads

Fixes: SW553100

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>