### PR TITLE
Removing topology and cable files before refresh

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -46,6 +46,7 @@ std::vector<std::pair<linkId_t, linkId_t>> PCIeInfoHandler::needPostProcessing;
 PCIeInfoHandler::PCIeInfoHandler(uint32_t fileHandle, uint16_t fileType) :
     FileHandler(fileHandle), infoType(fileType)
 {
+    deleteTolologyFiles();
     receivedFiles.emplace(infoType, false);
 }
 int PCIeInfoHandler::writeFromMemory(
@@ -1081,6 +1082,25 @@ int PCIeInfoHandler::newFileAvailableWithMetaData(uint64_t /*length*/,
                                                   uint32_t /*metaDataValue4*/)
 {
     return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+}
+
+void PCIeInfoHandler::deleteTolologyFiles()
+{
+    if (receivedFiles.empty())
+    {
+        try
+        {
+            for (auto& path : fs::directory_iterator(pciePath))
+            {
+                fs::remove_all(path);
+            }
+        }
+        catch (const fs::filesystem_error& err)
+        {
+            std::cerr << "Topology file deletion failed " << pciePath << " : "
+                      << err.what() << "\n";
+        }
+    }
 }
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -284,6 +284,8 @@ class PCIeInfoHandler : public FileHandler
         mexObjectMap;
     static std::vector<std::string> cables;
     static std::vector<std::pair<linkId_t, linkId_t>> needPostProcessing;
+
+    void deleteTolologyFiles();
 };
 
 } // namespace responder


### PR DESCRIPTION
Topology/cables data received from host is written in a file by BMC. Data received after refresh is appended to the same file causes stale data fetched during DBus Object update.

Removing the topology file and cable attributes file just before receiving refreshed data so that latest data gets saved in the file.

Fixes: PE00DPCM

Tested:
Fetching/Refreshing Topology data, all the links/data were populated correctly. And the topology and cable files were deleted and created on every refresh.

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>