### PR TITLE
PLDM: Host lamp test asserted property not getting reset after lamp test finished.

### DIFF
--- a/oem/ibm/host-bmc/host_lamp_test.cpp
+++ b/oem/ibm/host-bmc/host_lamp_test.cpp
@@ -70,8 +70,7 @@ bool HostLampTest::asserted(bool value)
                 "Get Effecter ID failed, effecter = 0");
         }
     }
-
-    return value;
+    return sdbusplus::xyz::openbmc_project::Led::server::Group::asserted(value);
 }
 
 uint16_t HostLampTest::getEffecterID()


### PR DESCRIPTION
This commit contain:
- lamptest should complete in 4 min and after that asserted property of host and
  LED manager will be reset to false. but only LED manager asserted property
  was getting reset to false but host asserted property was remain true which is fixed
  with this fix.

- Fix of defect SW557624