### PR TITLE
Removing topology and cable files before refresh

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -47,6 +47,7 @@ std::unordered_map<linkId_t, linkType_t> PCIeInfoHandler::linkTypeInfo;
 PCIeInfoHandler::PCIeInfoHandler(uint32_t fileHandle, uint16_t fileType) :
     FileHandler(fileHandle), infoType(fileType)
 {
+    deleteTopologyFiles();
     receivedFiles.emplace(infoType, false);
 }
 int PCIeInfoHandler::writeFromMemory(
@@ -1103,6 +1104,25 @@ int PCIeInfoHandler::newFileAvailableWithMetaData(uint64_t /*length*/,
                                                   uint32_t /*metaDataValue4*/)
 {
     return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+}
+
+void PCIeInfoHandler::deleteTopologyFiles()
+{
+    if (receivedFiles.empty())
+    {
+        try
+        {
+            for (auto& path : fs::directory_iterator(pciePath))
+            {
+                fs::remove_all(path);
+            }
+        }
+        catch (const fs::filesystem_error& err)
+        {
+            std::cerr << "Topology file deletion failed " << pciePath << " : "
+                      << err.what() << "\n";
+        }
+    }
 }
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -285,6 +285,12 @@ class PCIeInfoHandler : public FileHandler
     static std::vector<std::string> cables;
     static std::vector<std::pair<linkId_t, linkId_t>> needPostProcessing;
     static std::unordered_map<linkId_t, linkType_t> linkTypeInfo;
+
+    /** @brief Deletes the topology and cable data
+     *
+     *  @param[return] void
+     */
+    void deleteTopologyFiles();
 };
 
 } // namespace responder


### PR DESCRIPTION
Topology/cables data received from host is written in a file by BMC. Data received after refresh is appended to the same file causes stale data fetched during DBus Object update.

Removing the topology file and cable attributes file just before receiving refreshed data so that latest data gets saved in the file.

Fixes: PE00DPCM

Tested:
Fetching/Refreshing Topology data:
  All the links/data were populated correctly.
  Topology and cable files were deleted and created on every refresh.

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>