### PR TITLE
Discard attribute persisted value

### DIFF
--- a/libpldmresponder/bios_enum_attribute.cpp
+++ b/libpldmresponder/bios_enum_attribute.cpp
@@ -216,7 +216,18 @@ void BIOSEnumAttribute::constructEntry(
         if (attributeValue.index() == 1)
         {
             auto currValue = std::get<std::string>(attributeValue);
-            currValueIndices[0] = getValueIndex(currValue, possibleValues);
+            try
+            {
+                currValueIndices[0] = getValueIndex(currValue, possibleValues);
+            }
+            catch (std::invalid_argument const& ex)
+            {
+                std::cerr << "Enum Value " << currValue
+                          << " is not one of the possible values. Error: "
+                          << ex.what() << " for Attribute " << name << '\n';
+                currValueIndices[0] =
+                    getValueIndex(defaultValue, possibleValues);
+            }
         }
         else
         {

--- a/libpldmresponder/bios_integer_attribute.cpp
+++ b/libpldmresponder/bios_integer_attribute.cpp
@@ -135,6 +135,15 @@ void BIOSIntegerAttribute::constructEntry(
         currentValue = getAttrValue();
     }
 
+    if (currentValue < (int64_t)integerInfo.lowerBound ||
+        currentValue > (int64_t)integerInfo.upperBound)
+    {
+        std::cerr << "Setting to default value " << integerInfo.defaultValue
+                  << " For Attribute " << name
+                  << " Received value: " << currentValue << std::endl;
+        currentValue = integerInfo.defaultValue;
+    }
+
     table::attribute_value::constructIntegerEntry(attrValueTable, attrHandle,
                                                   attrType, currentValue);
 }

--- a/libpldmresponder/bios_string_attribute.cpp
+++ b/libpldmresponder/bios_string_attribute.cpp
@@ -126,6 +126,14 @@ void BIOSStringAttribute::constructEntry(
         currStr = getAttrValue();
     }
 
+    if (currStr.size() < stringInfo.minLength ||
+        currStr.size() > stringInfo.maxLength)
+    {
+        std::cerr << "Setting to default. Received string size "
+                  << currStr.size() << " For Attribute " << name << std::endl;
+        currStr = stringInfo.defString;
+    }
+
     table::attribute_value::constructStringEntry(attrValueTable, attrHandle,
                                                  attrType, currStr);
 }


### PR DESCRIPTION
Discard the persisted attribute value if the bios attribute value doesn't fall in the range provided by the current firmware level. In current implementation we restore the persisted attribute value without validation for string and integer attributes and in case of enum attributes we just throw error and don't add the attribute in the table if it fails.
This causes multiple unrecoverable errors getting logged during IPL if there is change in bios attribute details between old and new firware levels.

To fix the issue added changes to validate the persisted value before restoring it during power on.
Added the check for Integer, String and Enum attributes. Setting it to the default value if the validation of persisted value fails.

Fixes PE00DYMM

Tested:
Below are the tests performed
1. Normal Power on
2. Reset Reload
3. Modify Integer/String/Enum BIOS Attribute Value and modify attribute boundries such that attribute value falls out of range and then IPL the system and confirmed that default value is set and no unrecoverable error SRC logged

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>