### PR TITLE
Fix to handle PHYP hang after a MEX drawer CM

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -544,11 +544,25 @@ void HostPDRHandler::mergeEntityAssociations(
                 }
             }
 
-            // Record Handle is 0xFFFFFFFF(max value uint32_t), for merging
-            // entity association pdr to bmc range
-            pldm_entity_association_pdr_add_from_node(
-                node, repo, &entities, numEntities, true,
-                isHostUp() ? TERMINUS_HANDLE : terminus_handle, 0xFFFFFFFF);
+            // excluding adding PHYP terminus handle to PHYP’s entity
+            // association PDR to avoid deletion of entityAssociation PDRs after
+            // a refreshEntireRepo change event.
+            if (isHostUp() || (terminus_handle & 0x8000))
+            {
+                // Record Handle is 0xFFFFFFFF(max value uint32_t), for merging
+                // entity association pdr to bmc range
+                pldm_entity_association_pdr_add_from_node(
+                    node, repo, &entities, numEntities, true, TERMINUS_HANDLE,
+                    0xFFFFFFFF);
+            }
+            else
+            {
+                // Record Handle is 0xFFFFFFFF(max value uint32_t), for merging
+                // entity association pdr to bmc range
+                pldm_entity_association_pdr_add_from_node(
+                    node, repo, &entities, numEntities, true, terminus_handle,
+                    0xFFFFFFFF);
+            }
         }
     }
     free(entities);


### PR DESCRIPTION
This bug was introduced due to SW553100 changes where we started adding correct terminus handles to entity association PDRs in our repo. Due to this when we get a refreshEntireRepository repo change event from PHYP, BMC removes all the PHYP PDRs including the entity association PDRs. The BMC entity tree is untouched.

When a MEX drawer is powered on back, our code just checks the BMC entity tree for the entity and if its present we skip adding the PDR to the repo. This leads to BMC reusing some of the PDR record handles and PHYP asserts as it doesn't handle it.

Unit tested below scenarios:
        - PowerOn and PowerOff
        - ResetReload
        - CEC Hotplug and CEC CM
        - MEX CM

Fixes: SW558361

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>