### PR TITLE
oem-ibm: Remove redundant calls to get Activation status

### DIFF
--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -330,8 +330,6 @@ void CodeUpdate::setVersions()
 
                     try
                     {
-                        auto propVal = dBusIntf->getDbusPropertyVariant(
-                            imageObjPath, "Activation", imageInterface);
                         nonRunningVersion = path.str;
 
                         if (isCodeUpdateInProgress())


### PR DESCRIPTION
Remove redundant calls to get Activation status property, This call times out which is a "get property" dbus call which result is not being used in the code.

DEFECT: PE00F24K

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>