### PR TITLE
Clear PLDM cache during poweron

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -6,6 +6,7 @@
 #include "libpldm/requester/pldm.h"
 #include "libpldm/state_set.h"
 #ifdef OEM_IBM
+#include "oem/ibm/libpldm/entity.h"
 #include "oem/ibm/libpldm/fru.h"
 #include "oem/ibm/libpldm/pdr_oem_ibm.h"
 #endif
@@ -1792,12 +1793,21 @@ void HostPDRHandler::createDbusObjects()
 
         switch (node.entity_type)
         {
-            case 32903:
+#ifdef OEM_IBM
+            case PLDM_OEM_ENTITY_CPU_CORE:
                 CustomDBus::getCustomDBus().implementCpuCoreInterface(
                     entity.first);
                 CustomDBus::getCustomDBus().implementObjectEnableIface(
                     entity.first, false);
                 break;
+            case PLDM_OEM_ENTITY_SLOT:
+                CustomDBus::getCustomDBus().implementPCIeSlotInterface(
+                    entity.first);
+                CustomDBus::getCustomDBus().setSlotType(
+                    entity.first,
+                    "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OEM");
+                break;
+#endif
             case PLDM_ENTITY_SYSTEM_CHASSIS:
                 CustomDBus::getCustomDBus().implementChassisInterface(
                     entity.first);
@@ -1840,13 +1850,6 @@ void HostPDRHandler::createDbusObjects()
                     entity.first);
                 CustomDBus::getCustomDBus().implementPCIeDeviceInterface(
                     entity.first);
-                break;
-            case 32954:
-                CustomDBus::getCustomDBus().implementPCIeSlotInterface(
-                    entity.first);
-                CustomDBus::getCustomDBus().setSlotType(
-                    entity.first,
-                    "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OEM");
                 break;
             default:
                 break;

--- a/oem/ibm/libpldm/entity.h
+++ b/oem/ibm/libpldm/entity.h
@@ -1,0 +1,16 @@
+#ifndef OEM_IBM_ENTITY_H
+#define OEM_IBM_ENTITY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+enum pldm_oem_entity_id_codes {
+	PLDM_OEM_ENTITY_CPU_CORE = 32903,
+	PLDM_OEM_ENTITY_SLOT = 32954,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OEM_IBM_FRU_H */


### PR DESCRIPTION
Received incorrect PCIe topology information because of the wrong PLDM Cache,
so deleting the PLDM cache for every IPL.

Unit tested below scenarios:
            - PowerOn and PowerOff
            - ResetReload

Fixes: SW558000

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>