### PR TITLE
Delete PLDM Mex cache for every IPL

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -240,6 +240,28 @@ Response Handler::getPDR(const pldm_msg* request, size_t payloadLength)
         pldm::serialize::Serialize::getSerialize().reSerialize(types);
     }
 
+    if (clearMexObj && hostPDRHandler)
+    {
+        clearMexObj = false;
+
+        // Deleting Fru Dbus Objects and persisted details
+        std::vector<uint16_t> types = {
+            PLDM_ENTITY_SYSTEM_CHASSIS,
+            PLDM_ENTITY_POWER_SUPPLY,
+            PLDM_ENTITY_FAN,
+            PLDM_ENTITY_SYS_BOARD,
+            PLDM_ENTITY_POWER_CONVERTER,
+            PLDM_ENTITY_SLOT,
+            PLDM_ENTITY_CONNECTOR,
+            PLDM_ENTITY_MODULE,
+            PLDM_ENTITY_CARD,
+            PLDM_ENTITY_IO_MODULE,
+            PLDM_ENTITY_SLOT | 0x8000,
+        };
+        pldm::dbus::CustomDBus::getCustomDBus().removeDBus(types);
+        pldm::serialize::Serialize::getSerialize().reSerialize(types);
+    }
+
     uint32_t recordHandle{};
     uint32_t dataTransferHandle{};
     uint8_t transferOpFlag{};


### PR DESCRIPTION
Received incorrect PCIe topology information because of the wrong PLDM Cache, so deleting the PLDM cache for every IPL.

Unit tested below scenarios:
            - PowerOn and PowerOff
            - ResetReload

Fixes SW558000

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>