### PR TITLE
Remove Mex Dbus objects and persisted details during IPL

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -586,6 +586,16 @@ void CustomDBus::deleteObject(const std::string& path)
     {
         asset.erase(asset.find(path));
     }
+
+    if (pcieDevice.contains(path))
+    {
+        pcieDevice.erase(pcieDevice.find(path));
+    }
+
+    if (link.contains(path))
+    {
+        link.erase(link.find(path));
+    }
 }
 
 void CustomDBus::removeDBus(const std::vector<uint16_t> types)

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -199,6 +199,12 @@ class HostPDRHandler
     /** @brief map that captures various terminus information **/
     TLPDRMap tlPDRInfo;
 
+    /** @brief Delete DBUS objects
+     *
+     *  @param[in] types  - entity type
+     */
+    void deleteDbusObjects(const std::vector<uint16_t> types);
+
   private:
     /** @brief set the FRU presence based on the host off signal
      */

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -240,6 +240,28 @@ Response Handler::getPDR(const pldm_msg* request, size_t payloadLength)
         pldm::serialize::Serialize::getSerialize().reSerialize(types);
     }
 
+    if (clearMexObj && hostPDRHandler)
+    {
+        clearMexObj = false;
+
+        // Deleting Fru Dbus Objects and persisted details
+        std::vector<uint16_t> types = {
+            PLDM_ENTITY_POWER_SUPPLY,
+            PLDM_ENTITY_FAN,
+            PLDM_ENTITY_POWER_CONVERTER,
+            PLDM_ENTITY_CONNECTOR,
+            PLDM_ENTITY_MODULE,
+            PLDM_ENTITY_CARD,
+            PLDM_ENTITY_SLOT,
+            PLDM_ENTITY_IO_MODULE,
+            PLDM_ENTITY_SLOT | 0x8000,
+            PLDM_ENTITY_SYS_BOARD,
+            PLDM_ENTITY_SYSTEM_CHASSIS,
+        };
+        hostPDRHandler->deleteDbusObjects(types);
+        pldm::serialize::Serialize::getSerialize().reSerialize(types);
+    }
+
     uint32_t recordHandle{};
     uint32_t dataTransferHandle{};
     uint8_t transferOpFlag{};


### PR DESCRIPTION
Received incorrect PCIe topology information because of the wrong PLDM Cache, so deleting the PLDM cache for every IPL.

Unit tested below scenarios:
- PowerOn and PowerOff
- ResetReload

Fixes SW558000

Signed-off-by: ArchanaKakani <archana.kakani@ibm.com>