### PR TITLE
Support New record to the backplane vpd for hostboot to consume

### DIFF
--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -47,6 +47,7 @@ if get_option('oem-ibm').enabled()
     '../oem/ibm/libpldmresponder/inband_code_update.cpp',
     '../oem/ibm/requester/dbus_to_file_handler.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_progress_src.cpp',
+    '../oem/ibm/libpldmresponder/file_io_type_vpd.cpp',
   ]
 endif
 

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -2,6 +2,9 @@
 
 #include "file_io_by_type.hpp"
 
+#include <libpldm/base.h>
+#include <libpldm/file_io.h>
+
 #include "common/utils.hpp"
 #include "file_io_type_cert.hpp"
 #include "file_io_type_dump.hpp"
@@ -11,8 +14,6 @@
 #include "file_io_type_vpd.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
-#include <libpldm/base.h>
-#include <libpldm/file_io.h>
 #include <stdint.h>
 #include <unistd.h>
 

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -2,17 +2,17 @@
 
 #include "file_io_by_type.hpp"
 
-#include "libpldm/base.h"
-#include "libpldm/file_io.h"
-
 #include "common/utils.hpp"
 #include "file_io_type_cert.hpp"
 #include "file_io_type_dump.hpp"
 #include "file_io_type_lid.hpp"
 #include "file_io_type_pel.hpp"
 #include "file_io_type_progress_src.hpp"
+#include "file_io_type_vpd.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
+#include <libpldm/base.h>
+#include <libpldm/file_io.h>
 #include <stdint.h>
 #include <unistd.h>
 
@@ -164,6 +164,10 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
         {
             return std::make_unique<LidHandler>(fileHandle, false,
                                                 PLDM_FILE_TYPE_LID_RUNNING);
+        }
+        case PLDM_FILE_TYPE_VPD_KEYWORD:
+        {
+            return std::make_unique<keywordHandler>(fileHandle, fileType);
         }
         default:
         {

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
@@ -1,0 +1,98 @@
+#include "file_io_type_vpd.hpp"
+
+#include "libpldm/base.h"
+#include "libpldm/file_io.h"
+
+#include "common/utils.hpp"
+
+#include <stdint.h>
+
+#include <iostream>
+
+typedef uint8_t byte;
+
+namespace pldm
+{
+namespace responder
+{
+int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
+                         oem_platform::Handler* /*oemPlatformHandler*/)
+{
+    const char* keywrdObjPath =
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm0";
+    const char* keywrdPropName = "PD_D";
+    const char* keywrdInterface = "com.ibm.ipzvpd.VPRI";
+
+    std::variant<std::vector<byte>> keywrd;
+
+    try
+    {
+        auto& bus = DBusHandler::getBus();
+        auto service = pldm::utils::DBusHandler().getService(keywrdObjPath,
+                                                             keywrdInterface);
+        auto method =
+            bus.new_method_call(service.c_str(), keywrdObjPath,
+                                "org.freedesktop.DBus.Properties", "Get");
+        method.append(keywrdInterface, keywrdPropName);
+        auto reply = bus.call(method);
+        reply.read(keywrd);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Get keyword error from dbus interface : "
+                  << keywrdInterface << " ERROR= " << e.what() << std::endl;
+    }
+
+    auto keywrdSize = std::get<std::vector<byte>>(keywrd).size();
+
+    if (length < keywrdSize)
+    {
+        return PLDM_ERROR_INVALID_DATA;
+    }
+
+    namespace fs = std::filesystem;
+    constexpr auto keywrdDirPath = "/tmp/pldm/";
+    constexpr auto keywrdFilePath = "/tmp/pldm/vpdKeywrd.bin";
+
+    if (!fs::exists(keywrdDirPath))
+    {
+        fs::create_directories(keywrdDirPath);
+        fs::permissions(keywrdDirPath,
+                        fs::perms::others_read | fs::perms::owner_write);
+    }
+
+    std::ofstream keywrdFile("vpdKeywrd.bin");
+    keywrdFile.open(keywrdFilePath, std::ios::out | std::ofstream::binary);
+    if (!keywrdFile)
+    {
+        std::cerr << "VPD keyword file open error: " << keywrdFilePath
+                  << " errno: " << errno << std::endl;
+        pldm::utils::reportError(
+            "xyz.openbmc_project.PLDM.Error.readKeywordHandler.keywordFileOpenError",
+            pldm::PelSeverity::ERROR);
+        return PLDM_ERROR;
+    }
+    keywrdFile.write((const char*)std::get<std::vector<byte>>(keywrd).data(),
+                     keywrdSize);
+    if (keywrdFile.bad())
+    {
+        std::cerr << "Error while writing to file: " << keywrdFilePath
+                  << std::endl;
+    }
+    keywrdFile.close();
+
+    auto rc = readFile(keywrdFilePath, offset, keywrdSize, response);
+    fs::remove(keywrdFilePath);
+    if (rc)
+    {
+        std::cerr << "Read error for keyword file with size: " << keywrdSize
+                  << std::endl;
+        pldm::utils::reportError(
+            "xyz.openbmc_project.PLDM.Error.readKeywordHandler.keywordFileReadError",
+            pldm::PelSeverity::ERROR);
+        return PLDM_ERROR;
+    }
+    return PLDM_SUCCESS;
+}
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "file_io_by_type.hpp"
+
+namespace pldm
+{
+namespace responder
+{
+using vpdFileType = uint16_t;
+/** @class keywordFileHandler
+ *
+ *  @brief Inherits and implements FileHandler. This class is used
+ *  to read #D keyword file
+ */
+class keywordHandler : public FileHandler
+{
+  public:
+    /** @brief Handler constructor
+     */
+    keywordHandler(uint32_t fileHandle, uint16_t fileType) :
+        FileHandler(fileHandle), vpdFileType(fileType)
+    {}
+    virtual int writeFromMemory(uint32_t /*offset*/, uint32_t /*length*/,
+                                uint64_t /*address*/,
+                                oem_platform::Handler* /*oemPlatformHandler*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t& /*length*/,
+                               uint64_t /*address*/,
+                               oem_platform::Handler* /*oemPlatformHandler*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+    virtual int read(uint32_t offset, uint32_t& length, Response& response,
+                     oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual int write(const char* /*buffer*/, uint32_t /*offset*/,
+                      uint32_t& /*length*/,
+                      oem_platform::Handler* /*oemPlatformHandler*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+    virtual int fileAck(uint8_t /*fileStatus*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+    virtual int newFileAvailable(uint64_t /*length*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+    /** @brief keywordHandler destructor
+     */
+    ~keywordHandler()
+    {}
+
+  private:
+    uint16_t vpdFileType; //!< type of the VPD file
+};
+} // namespace responder
+} // namespace pldm


### PR DESCRIPTION
This commit is to support a new VPD record called PSPD that contains few keywords called #D and VM. Since these keywords are typically larger in size (4K bytes) than what is managed by PLDM, we are adding a file into which these keywords will be extracted. This keyword file is transferred to the HB PLDM layer with a readFileByType request from HB.

Signed-off-by: Varsha Kaverappa <vkaverap@in.ibm.com>