### PR TITLE
Modify Dump offload to use Thread

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -60,6 +60,7 @@ class Handler : public oem_platform::Handler
                         hostOff = true;
                         setEventReceiverCnt = 0;
                         disableWatchDogTimer();
+                        pldm::responder::utils::clearDumpSocketWriteStatus();
                     }
                     else if (propVal ==
                              "xyz.openbmc_project.State.Host.HostState.Running")

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -6,8 +6,26 @@ namespace pldm
 {
 namespace responder
 {
+
+enum SocketWriteStatus
+{
+    Completed,
+    InProgress,
+    Free,
+    Error,
+    NotReady
+};
+
 namespace utils
 {
+
+/** @brief Clear Dump Socket Write Status
+ *  This function clears all the dump socket write status to "Free" during
+ *  reset reload operation or when host is coming down to off state.
+ *
+ *  @return   None
+ */
+ void clearDumpSocketWriteStatus();
 
 /** @brief Setup UNIX socket
  *  This function creates listening socket in non-blocking mode and allows only
@@ -28,11 +46,9 @@ int setupUnixSocket(const std::string& socketInterface);
  *  @param[in] sock - unix socket
  *  @param[in] buf -  data buffer
  *  @param[in] blockSize - size of data to write
- *  @return   on success retruns  0
- *            on failure returns -1
-
+ *  @return    void
  */
-int writeToUnixSocket(const int sock, const char* buf,
+void writeToUnixSocket(const int sock, const char* buf,
                       const uint64_t blockSize);
 } // namespace utils
 } // namespace responder


### PR DESCRIPTION
Currently while offloading a Dump pldmd writes on unix sockets 1M chunks When network is slow write to unix socket takes few mins which keeps pldmd busy with write() calls in a loop

This is implemented as discussed

PHYP sends the first 1MB chunk - BMC does the DMA operation, spin off's the thread and then return a PLDM_SUCCESS (after phyp gets the PLDM_SUCCESS they will unmap the TCE ) PHYP sends the second 1MB chuck - BMC would check the offload status and return PLDM_NOT_READY until the offload status is free Tested By:

1.Offload system dump
2.Offload system dump in slow networks speed