### PR TITLE
oem-ibm: FRU: Add UTIL entry

### DIFF
--- a/oem/ibm/configurations/fru/Motherboard_UTIL.json
+++ b/oem/ibm/configurations/fru/Motherboard_UTIL.json
@@ -1,0 +1,33 @@
+{
+    "record_details": {
+        "fru_record_type": 254,
+        "fru_encoding_type": 1,
+        "dbus_interface_name": "xyz.openbmc_project.Inventory.Item.Board.Motherboard"
+    },
+    "fru_fields": [
+        {
+            "fru_field_type": 2,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.UTIL",
+                "property_name": "RT",
+                "property_type": "bytearray"
+            }
+        },
+        {
+            "fru_field_type": 18,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.UTIL",
+                "property_name": "F5",
+                "property_type": "bytearray"
+            }
+        },
+        {
+            "fru_field_type": 19,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.UTIL",
+                "property_name": "F6",
+                "property_type": "bytearray"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add UTIL that has RT,F5,F6 entry to existing FRU configuration.

Resolves: https://github.com/ibm-openbmc/dev/issues/3616

Tested: use pldmtool GetFRURecordTableMetadata cmd to verify the output.

Signed-off-by: George Liu <liuxiwei@inspur.com>