### PR TITLE
oem-ibm: Support of new PSPD VPD record

### DIFF
--- a/oem/ibm/configurations/fru/Motherboard_PSPD.json
+++ b/oem/ibm/configurations/fru/Motherboard_PSPD.json
@@ -1,0 +1,41 @@
+{
+    "record_details": {
+        "fru_record_type": 254,
+        "fru_encoding_type": 1,
+        "dbus_interface_name": "xyz.openbmc_project.Inventory.Item.Board.Motherboard"
+    },
+    "fru_fields": [
+        {
+            "fru_field_type": 2,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.PSPD",
+                "property_name": "RT",
+                "property_type": "bytearray"
+            }
+        },
+        {
+            "fru_field_type": 3,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.PSPD",
+                "property_name": "PF",
+                "property_type": "bytearray"
+            }
+        },
+        {
+            "fru_field_type": 4,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.PSPD",
+                "property_name": "VM",
+                "property_type": "bytearray"
+            }
+        },
+        {
+            "fru_field_type": 5,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.PSPD",
+                "property_name": "VZ",
+                "property_type": "bytearray"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This commit supports the new VPD record called PSPD under the backplane FRU vpd. Keywords RT, PF, VM and VZ are added under the PSPD VPD record so that host can consume. Change is being added as part of LI OMX new Bonnell system support.

Fixes: Jira Story PFEBMC-16

Change-Id: Id2b357719970c3bd4c52732da467af307e48e183
Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>