### PR TITLE
DumpOffload: Clear SocketWriteStatus when Host poweroff

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -114,6 +114,7 @@ class Handler : public oem_platform::Handler
                         setEventReceiverCnt = 0;
                         disableWatchDogTimer();
                         pldm::responder::utils::clearLicenseStatus();
+                        pldm::responder::utils::clearDumpSocketWriteStatus();
                     }
                     else if (propVal ==
                              "xyz.openbmc_project.State.Host.HostState.Running")

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -192,6 +192,12 @@ void writeToUnixSocket(const int sock, const char* buf,
     return;
 }
 
+void clearDumpSocketWriteStatus()
+{
+    socketWriteStatus = Free;
+    return;
+}
+
 Json convertBinFileToJson(const fs::path& path)
 {
     std::ifstream file(path, std::ios::in | std::ios::binary);

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -82,6 +82,14 @@ void convertJsonToBinaryFile(const Json& jsonData, const fs::path& path);
  */
 void clearLicenseStatus();
 
+/** @brief Clear Dump Socket Write Status
+ *  This function clears all the dump socket write status to "Free" during
+ *  reset reload operation or when host is coming down to off state.
+ *
+ *  @return   None
+ */
+void clearDumpSocketWriteStatus();
+
 /** @brief Create or update the d-bus license data
  *  This function creates or updates the d-bus license details. If the input
  *  input flag is 1, then new license data will be created and if the the input


### PR DESCRIPTION
This commit clears SocketWriteStatus to "Free" when host power off which avoids any wrong dump offload socket write status in error cases

This PR fixes race condition of status values across back to back MPIPLs when dump offload abruptly interrupted by power off https://w3.rchland.ibm.com/projects/bestquest/?defect=SW558457