### PR TITLE
oem_ibm: Add new memory region sizes

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -223,14 +223,14 @@
         },
         {
             "attribute_name": "hb_memory_region_size",
-            "possible_values": ["128MB", "256MB"],
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
             "default_values": ["256MB"],
             "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
             "displayName": "Memory Region Size (pending)"
         },
         {
             "attribute_name": "hb_memory_region_size_current",
-            "possible_values": ["128MB", "256MB"],
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
             "default_values": ["256MB"],
             "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
             "displayName": "Memory Region Size (current)",


### PR DESCRIPTION
Add the newly supported values of memory region aka "Logical Memory Block" size under the bios attribute hb_memory_region_size.

Fixes: LI 02N requirement

Change-Id: I4f35a647e829d64abfa6dd59b2b1070a47a37a20
Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>