### PR TITLE
Adding Enum to support boot progresscode changes

### DIFF
--- a/configurations/events/stateSensorPdrs.json
+++ b/configurations/events/stateSensorPdrs.json
@@ -56,7 +56,7 @@
             "entityInstance": 1,
             "sensorOffset": 0,
             "stateSetId": 196,
-            "event_states": [3, 5, 22, 26],
+            "event_states": [3, 5, 20, 22, 26],
             "dbus": {
                 "object_path": "/xyz/openbmc_project/state/host0",
                 "interface": "xyz.openbmc_project.State.Boot.Progress",
@@ -65,6 +65,7 @@
                 "property_values": [
                     "xyz.openbmc_project.State.Boot.Progress.ProgressStages.MemoryInit",
                     "xyz.openbmc_project.State.Boot.Progress.ProgressStages.SecondaryProcInit",
+                    "xyz.openbmc_project.State.Boot.Progress.ProgressStages.OSStart",
                     "xyz.openbmc_project.State.Boot.Progress.ProgressStages.BusInit",
                     "xyz.openbmc_project.State.Boot.Progress.ProgressStages.PrimaryProcInit"
                 ]

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -15,13 +15,10 @@ using namespace pldm::utils;
 
 namespace pldmtool
 {
-
 namespace platform
 {
-
 namespace
 {
-
 using namespace pldmtool::helper;
 
 static const std::map<uint8_t, std::string> sensorPresState{
@@ -464,7 +461,8 @@ class GetPDR : public CommandInterface
         {PLDM_STATE_SET_BOOT_PROG_STATE_BASE_BOARD_INITIALIZATION,
          "Baseboard Initialization"},
         {PLDM_STATE_SET_BOOT_PROG_STATE_PRIMARY_PROC_INITIALIZATION,
-         "Primary Processor Initialization"}};
+         "Primary Processor Initialization"},
+        {PLDM_STATE_SET_BOOT_PROG_STATE_OSSTART, "OSStart"}};
 
     static inline const std::map<uint8_t, std::string> setOpFaultStatus{
         {PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS_NORMAL, "Normal"},


### PR DESCRIPTION
Adding support for new bootprogress state

Adding new bootprogress state which indicate system firmware
or BIOS is starting the operating system at the point of time.

This new bootprogress state is taken from
PLDM stateset(DSP0249) design spec and stateset id is 196.

Signed-off-by: Kamalkumar Patel <kamalkumar.patel@ibm.com>