### PR TITLE
oem_ibm: Fix SAI led notify issue

### DIFF
--- a/oem/ibm/configurations/pdr/ibm,bonnell/4.json
+++ b/oem/ibm/configurations/pdr/ibm,bonnell/4.json
@@ -28,6 +28,28 @@
                     ]
                 },
                 {
+                    "type": 24581,
+                    "instance": 1,
+                    "container": 1,
+                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 10,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system",
+                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                                "property_name": "Functional",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
                     "sensors": [
                         {

--- a/oem/ibm/configurations/pdr/ibm,everest/4.json
+++ b/oem/ibm/configurations/pdr/ibm,everest/4.json
@@ -28,6 +28,28 @@
                     ]
                 },
                 {
+                    "type": 24581,
+                    "instance": 1,
+                    "container": 1,
+                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 10,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system",
+                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                                "property_name": "Functional",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/bmc",
                     "sensors": [
                         {

--- a/oem/ibm/configurations/pdr/ibm,rainier-1s4u/4.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-1s4u/4.json
@@ -28,6 +28,28 @@
                     ]
                 },
                 {
+                    "type": 24581,
+                    "instance": 1,
+                    "container": 1,
+                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 10,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system",
+                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                                "property_name": "Functional",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                     "sensors": [
                         {

--- a/oem/ibm/configurations/pdr/ibm,rainier-2u/4.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-2u/4.json
@@ -28,6 +28,28 @@
                     ]
                 },
                 {
+                    "type": 24581,
+                    "instance": 1,
+                    "container": 1,
+                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 10,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system",
+                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                                "property_name": "Functional",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                     "sensors": [
                         {

--- a/oem/ibm/configurations/pdr/ibm,rainier-4u/4.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-4u/4.json
@@ -28,6 +28,28 @@
                     ]
                 },
                 {
+                    "type": 24581,
+                    "instance": 1,
+                    "container": 1,
+                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 10,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system",
+                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                                "property_name": "Functional",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                     "sensors": [
                         {


### PR DESCRIPTION
Physical SAI (System Attention Indicator) led state was not getting notified to PHYP. This commit models the physical SAI led sensor so that whenever any change in the state happens, PLDM sends the sensor state change event to PHYP.

Fixes the defect: SW559304/STGDefect395326

Tested below scenarios:
1. Turning On/Off the effecters of virtual platform/partition SAI
2. Changing dbus properties of virtual platform/partition SAI
3. Turn off real SAI led using effecter

Change-Id: I6b2b54d3844eb90f42b7d3c0e8d7fab04c8d45c3
Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>