### PR TITLE
PLDM: Some more missed changes in 1050.

### DIFF
--- a/configurations/events/stateSensorPdrs.json
+++ b/configurations/events/stateSensorPdrs.json
@@ -71,7 +71,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 0,
             "sensorOffset": 0,
@@ -85,7 +84,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 1,
             "sensorOffset": 0,
@@ -99,7 +97,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 2,
             "sensorOffset": 0,
@@ -113,7 +110,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 3,
             "sensorOffset": 0,
@@ -127,7 +123,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 4,
             "sensorOffset": 0,
@@ -141,7 +136,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 5,
             "sensorOffset": 0,
@@ -155,7 +149,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 6,
             "sensorOffset": 0,
@@ -169,7 +162,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 7,
             "sensorOffset": 0,
@@ -183,7 +175,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 8,
             "sensorOffset": 0,
@@ -197,7 +188,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 9,
             "sensorOffset": 0,
@@ -211,7 +201,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 10,
             "sensorOffset": 0,
@@ -225,7 +214,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 11,
             "sensorOffset": 0,
@@ -239,7 +227,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 12,
             "sensorOffset": 0,
@@ -253,7 +240,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 13,
             "sensorOffset": 0,
@@ -267,7 +253,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 14,
             "sensorOffset": 0,
@@ -281,7 +266,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 15,
             "sensorOffset": 0,
@@ -295,7 +279,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 16,
             "sensorOffset": 0,
@@ -309,7 +292,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 17,
             "sensorOffset": 0,
@@ -323,7 +305,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 18,
             "sensorOffset": 0,
@@ -337,7 +318,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 19,
             "sensorOffset": 0,
@@ -351,7 +331,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 20,
             "sensorOffset": 0,
@@ -365,7 +344,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 21,
             "sensorOffset": 0,
@@ -379,7 +357,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 22,
             "sensorOffset": 0,
@@ -393,7 +370,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 23,
             "sensorOffset": 0,
@@ -407,7 +383,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 24,
             "sensorOffset": 0,
@@ -421,7 +396,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 25,
             "sensorOffset": 0,
@@ -435,7 +409,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 26,
             "sensorOffset": 0,
@@ -449,7 +422,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 27,
             "sensorOffset": 0,
@@ -463,7 +435,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 28,
             "sensorOffset": 0,
@@ -477,7 +448,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 29,
             "sensorOffset": 0,
@@ -491,7 +461,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 30,
             "sensorOffset": 0,
@@ -505,7 +474,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 31,
             "sensorOffset": 0,
@@ -520,7 +488,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 32,
             "sensorOffset": 0,
@@ -535,7 +502,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 33,
             "sensorOffset": 0,
@@ -550,7 +516,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 34,
             "sensorOffset": 0,
@@ -565,7 +530,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 35,
             "sensorOffset": 0,
@@ -580,7 +544,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 36,
             "sensorOffset": 0,
@@ -595,7 +558,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 37,
             "sensorOffset": 0,
@@ -610,7 +572,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 38,
             "sensorOffset": 0,
@@ -625,7 +586,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 39,
             "sensorOffset": 0,
@@ -640,7 +600,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 40,
             "sensorOffset": 0,
@@ -655,7 +614,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 41,
             "sensorOffset": 0,
@@ -670,7 +628,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 42,
             "sensorOffset": 0,
@@ -685,7 +642,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 43,
             "sensorOffset": 0,
@@ -700,7 +656,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 44,
             "sensorOffset": 0,
@@ -715,7 +670,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 45,
             "sensorOffset": 0,
@@ -730,7 +684,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 46,
             "sensorOffset": 0,
@@ -745,7 +698,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 47,
             "sensorOffset": 0,
@@ -760,7 +712,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 48,
             "sensorOffset": 0,
@@ -775,7 +726,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 49,
             "sensorOffset": 0,
@@ -790,7 +740,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 50,
             "sensorOffset": 0,
@@ -805,7 +754,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 51,
             "sensorOffset": 0,
@@ -820,7 +768,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 52,
             "sensorOffset": 0,
@@ -835,7 +782,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 53,
             "sensorOffset": 0,
@@ -850,7 +796,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 54,
             "sensorOffset": 0,
@@ -865,7 +810,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 55,
             "sensorOffset": 0,
@@ -880,7 +824,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 56,
             "sensorOffset": 0,
@@ -895,7 +838,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 57,
             "sensorOffset": 0,
@@ -910,7 +852,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 58,
             "sensorOffset": 0,
@@ -925,7 +866,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 59,
             "sensorOffset": 0,
@@ -940,7 +880,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 60,
             "sensorOffset": 0,
@@ -955,7 +894,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 61,
             "sensorOffset": 0,
@@ -970,7 +908,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 62,
             "sensorOffset": 0,
@@ -985,7 +922,6 @@
             }
         },
         {
-            "containerID": 3,
             "entityType": 66,
             "entityInstance": 63,
             "sensorOffset": 0,


### PR DESCRIPTION
This change was made in 1030 to skip the usage of container id for dimms in the state sensor events json file so that correct dimm will get deconfigued after applying a gauard operation.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>