### PR TITLE
Adding max settable value for boot counter effecter

### DIFF
--- a/configurations/pdr/11.json
+++ b/configurations/pdr/11.json
@@ -4407,6 +4407,7 @@
                     "effecter_resolutioninit": 1,
                     "effecter_data_size": 0,
                     "range_field_format": 3,
+                    "max_set_table": 3,
                     "dbus": {
                         "path": "/xyz/openbmc_project/state/host0",
                         "interface": "xyz.openbmc_project.Control.Boot.RebootAttempts",


### PR DESCRIPTION
This commit adds the maximum settable value for the boot counter numeric effecter. 
The value is set to the current default value as per the PDI -
https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/xyz/openbmc_project/Control/Boot/RebootAttempts.interface.yaml