### PR TITLE
Adding bios attributes for RPD feature

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -493,6 +493,41 @@
             "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
             "displayName": "pvm_create_default_lpar (current)",
             "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_gard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "GARD on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
         }
     ]
 }

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -185,6 +185,15 @@
             "readOnly": true,
             "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
             "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
         }
     ]
 }


### PR DESCRIPTION
- Adding bios attributes for runtime processor diagnostics
feature which allow HOST to consume bios attribute at
runtime and after that it's depend on HOST decision to
apply immediately  or next IPL cycle.