### PR TITLE
scheduled_host_transition: new object path

### DIFF
--- a/configurations/pdr/11.json
+++ b/configurations/pdr/11.json
@@ -142,7 +142,7 @@
                     "effecter_data_size": 4,
                     "range_field_format": 4,
                     "dbus": {
-                        "path": "/xyz/openbmc_project/state/host0",
+                        "path": "/xyz/openbmc_project/scheduled/host0",
                         "interface": "xyz.openbmc_project.State.ScheduledHostTransition",
                         "property_name": "ScheduledTime",
                         "property_type": "uint64_t"


### PR DESCRIPTION
The D-Bus path for the ScheduledTime property had to change. The details of this can be found over in the change:

  https://gerrit.openbmc.org/c/openbmc/phosphor-state-manager/+/61361

Update PLDM to utilize this new object path.


Change-Id: I89fdb603730ea3569db03d136a31fef0988cd5bb