### PR TITLE
Adding PLDM bios power supply attributes

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -528,6 +528,62 @@
             "default_values": ["Automatic"],
             "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
             "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is functional or not. (Enabled is Functional)",
+            "displayName": "Power Supply 0 is functional",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is functional or not. (Enabled is Functional)",
+            "displayName": "Power Supply 1 is functional",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is functional or not. (Enabled is Functional)",
+            "displayName": "Power Supply 2 is functional",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is functional or not. (Enabled is Functional)",
+            "displayName": "Power Supply 3 is functional",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property_name": "Functional",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
         }
     ]
 }

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -221,7 +221,7 @@
             "helpText": "Specifies power supply 1 input power voltage(volts)",
             "displayName": "Power Supply 1 input Voltage",
             "dbus": {
-                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
                 "interface": "xyz.openbmc_project.Sensor.Value",
                 "property_type": "double",
                 "property_name": "Value"
@@ -237,7 +237,7 @@
             "helpText": "Specifies power supply 2 input power voltage(volts)",
             "displayName": "Power Supply 2 input Voltage",
             "dbus": {
-                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
                 "interface": "xyz.openbmc_project.Sensor.Value",
                 "property_type": "double",
                 "property_name": "Value"
@@ -253,7 +253,7 @@
             "helpText": "Specifies power supply 3 input power voltage(volts)",
             "displayName": "Power Supply 3 input Voltage",
             "dbus": {
-                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
                 "interface": "xyz.openbmc_project.Sensor.Value",
                 "property_type": "double",
                 "property_name": "Value"

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -194,6 +194,70 @@
             "default_value": 0,
             "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
             "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input power voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input power voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input power voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input power voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
         }
     ]
 }

--- a/oem/ibm/configurations/bios/string_attrs.json
+++ b/oem/ibm/configurations/bios/string_attrs.json
@@ -136,6 +136,70 @@
             "default_string": "",
             "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
             "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
         }
     ]
 }


### PR DESCRIPTION
Pull request: https://github.com/ibm-openbmc/pldm/pull/381
Upstream: https://gerrit.openbmc.org/c/openbmc/pldm/+/61015/15
Fixes: 421850 : PLDM flooding trace log on BMC.
Port to: FW1050