### PR TITLE
Add dbus model for fru's on splitter (#376)

### DIFF
--- a/configurations/host/host_fru_associations.json
+++ b/configurations/host/host_fru_associations.json
@@ -8,6 +8,30 @@
         },
         {
             "from_entity_type": 45,
+            "to_entity_type": 60,
+            "forward_association": "assembly",
+            "reverse_association": "inventory"
+        },
+        {
+            "from_entity_type": 45,
+            "to_entity_type": 69,
+            "forward_association": "assembly",
+            "reverse_association": "inventory"
+        },
+        {
+            "from_entity_type": 45,
+            "to_entity_type": 5,
+            "forward_association": "assembly",
+            "reverse_association": "inventory"
+        },
+        {
+            "from_entity_type": 45,
+            "to_entity_type": 90,
+            "forward_association": "assembly",
+            "reverse_association": "inventory"
+        },
+        {
+            "from_entity_type": 45,
             "to_entity_type": 93,
             "forward_association": "all_sensors",
             "reverse_association": "chassis"

--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -311,6 +311,16 @@ void CustomDBus::implementBoard(const std::string& path)
     }
 }
 
+void CustomDBus::implementPanelInterface(const std::string& path)
+{
+    if (panel.find(path) == panel.end())
+    {
+        panel.emplace(
+            path, std::make_unique<Panel>(pldm::utils::DBusHandler::getBus(),
+                                          path.c_str()));
+    }
+}
+
 void CustomDBus::implementObjectEnableIface(const std::string& path, bool value)
 {
     if (_enabledStatus.find(path) == _enabledStatus.end())
@@ -594,6 +604,10 @@ void CustomDBus::deleteObject(const std::string& path)
     if (link.contains(path))
     {
         link.erase(link.find(path));
+    }
+    if (panel.contains(path))
+    {
+        panel.erase(panel.find(path));
     }
 }
 

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -23,6 +23,7 @@
 #include "location_code.hpp"
 #include "motherboard.hpp"
 #include "operational_status.hpp"
+#include "panel.hpp"
 #include "pcie_device.hpp"
 #include "pcie_slot.hpp"
 #include "pcie_topology.hpp"
@@ -155,6 +156,8 @@ class CustomDBus
     void implementCableInterface(const std::string& path);
 
     void implementAssetInterface(const std::string& path);
+
+    void implementPanelInterface(const std::string& path);
     /**
      * @brief Implement the xyz.openbmc_project.Object.Enable interface
      *
@@ -335,6 +338,7 @@ class CustomDBus
     std::unordered_map<ObjectPath, std::unique_ptr<Cable>> cable;
     std::unordered_map<ObjectPath, std::unique_ptr<Asset>> asset;
     std::unordered_map<ObjectPath, std::unique_ptr<Link>> link;
+    std::unordered_map<ObjectPath, std::unique_ptr<Panel>> panel;
 };
 
 } // namespace dbus

--- a/host-bmc/dbus/panel.hpp
+++ b/host-bmc/dbus/panel.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "serialize.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <xyz/openbmc_project/Inventory/Item/Panel/server.hpp>
+
+#include <string>
+
+namespace pldm
+{
+namespace dbus
+{
+using ItemPanel = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Panel>;
+
+class Panel : public ItemPanel
+{
+  public:
+    Panel() = delete;
+    ~Panel() = default;
+    Panel(const Panel&) = delete;
+    Panel& operator=(const Panel&) = delete;
+    Panel(Panel&&) = default;
+    Panel& operator=(Panel&&) = default;
+
+    Panel(sdbusplus::bus::bus& bus, const std::string& objPath) :
+        ItemPanel(bus, objPath.c_str()), path(objPath)
+    {
+        pldm::serialize::Serialize::getSerialize().serialize(path, "Panel");
+    }
+
+  private:
+    std::string path;
+};
+
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1806,6 +1806,10 @@ void HostPDRHandler::createDbusObjects()
                 CustomDBus::getCustomDBus().implementPowerSupplyInterface(
                     entity.first);
                 break;
+            case PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD:
+                CustomDBus::getCustomDBus().implementPanelInterface(
+                    entity.first);
+                break;
             case PLDM_ENTITY_FAN:
                 CustomDBus::getCustomDBus().implementFanInterface(entity.first);
                 break;
@@ -1826,6 +1830,9 @@ void HostPDRHandler::createDbusObjects()
                 CustomDBus::getCustomDBus().implementConnecterInterface(
                     entity.first);
                 break;
+            case PLDM_ENTITY_COOLING_DEVICE:
+            case PLDM_ENTITY_EXTERNAL_ENVIRONMENT:
+            case PLDM_ENTITY_BOARD:
             case PLDM_ENTITY_MODULE:
                 CustomDBus::getCustomDBus().implementBoard(entity.first);
                 break;

--- a/host-bmc/utils.hpp
+++ b/host-bmc/utils.hpp
@@ -25,7 +25,7 @@ using ObjectPathMaps = std::map<ObjectPath, pldm_entity_node*>;
 
 const std::map<EntityType, EntityName> entityMaps = {
     {PLDM_ENTITY_SYSTEM_CHASSIS, "chassis"},
-    {PLDM_ENTITY_BOARD, "io_board"},
+    {PLDM_ENTITY_BOARD, "board"},
     {PLDM_ENTITY_SYS_BOARD, "motherboard"},
     {PLDM_ENTITY_POWER_SUPPLY, "powersupply"},
     {PLDM_ENTITY_PROC, "cpu"},
@@ -40,6 +40,9 @@ const std::map<EntityType, EntityName> entityMaps = {
     {PLDM_ENTITY_CONNECTOR, "connector"},
     {PLDM_ENTITY_CARD, "adapter"},
     {PLDM_ENTITY_SOCKET, "socket"},
+    {PLDM_ENTITY_EXTERNAL_ENVIRONMENT, "temp_sensor"},
+    {PLDM_ENTITY_COOLING_DEVICE, "cooling_device"},
+    {PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD, "panel"},
     {PLDM_ENTITY_SLOT | 0x8000, "logical_slot"}};
 
 namespace hostbmc

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -256,6 +256,10 @@ Response Handler::getPDR(const pldm_msg* request, size_t payloadLength)
             PLDM_ENTITY_IO_MODULE,
             PLDM_ENTITY_SLOT | 0x8000,
             PLDM_ENTITY_SYS_BOARD,
+            PLDM_ENTITY_BOARD,
+            PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD,
+            PLDM_ENTITY_COOLING_DEVICE,
+            PLDM_ENTITY_EXTERNAL_ENVIRONMENT,
             PLDM_ENTITY_SYSTEM_CHASSIS,
         };
         hostPDRHandler->deleteDbusObjects(types);


### PR DESCRIPTION
This PR adds the following dbus models for the fru's on splitter drawer:
1. ESM Module(PLDM_ENTITY_BOARD) is modelled as Item.Board and the necessary association definitions are added to the associations json file ,so that ESM could be listed as a redfish assembly.
2. LED Panel Board(PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD) is modelled as Item.Panel and the necessary association definitions are added to the associations json file, so that the LED Board could be listed as a redfish assembly.
3. Temperature Sensor(PLDM_ENTITY_EXTERNAL_ENVIRONMENT) is modelled as Item.board and the necessary association definitions are added to the associations json file, so that the Temperature sensor could be listed as a redfish assembly.

Tested By:
1. Powered on the Splitter & found the ESM and also LED Board in the assembly section in the Inventory & LED's page in the bmc GUI.