### PR TITLE
Adding PLDM bios power supply attributes

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -688,7 +688,62 @@
         "helpText" : "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
         "displayName" : "pvm_create_default_lpar (current)",
          "readOnly":true
+     },
+     {
+        "attribute_name": "hb_power_PS0_functional",
+        "possible_values": ["Enabled", "Disabled"],
+        "default_values": ["Disabled"],
+        "helpText": "Specifies if Power Supply 0 is functional or not. (Enabled is Functional)",
+        "displayName": "Power Supply 0 is functional",
+        "dbus": {
+            "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+            "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+            "property_name": "Functional",
+            "property_type": "bool",
+            "property_values": [true, false]
+        }
+     },
+     {
+        "attribute_name": "hb_power_PS1_functional",
+        "possible_values": ["Enabled", "Disabled"],
+        "default_values": ["Disabled"],
+        "helpText": "Specifies if Power Supply 1 is functional or not. (Enabled is Functional)",
+        "displayName": "Power Supply 1 is functional",
+        "dbus": {
+            "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+            "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+            "property_name": "Functional",
+            "property_type": "bool",
+            "property_values": [true, false]
+        }
+     },
+     {
+        "attribute_name": "hb_power_PS2_functional",
+        "possible_values": ["Enabled", "Disabled"],
+        "default_values": ["Disabled"],
+        "helpText": "Specifies if Power Supply 2 is functional or not. (Enabled is Functional)",
+        "displayName": "Power Supply 2 is functional",
+        "dbus": {
+            "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+            "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+            "property_name": "Functional",
+            "property_type": "bool",
+            "property_values": [true, false]
+        }
+     },
+     {
+        "attribute_name": "hb_power_PS3_functional",
+        "possible_values": ["Enabled", "Disabled"],
+        "default_values": ["Disabled"],
+        "helpText": "Specifies if Power Supply 3 is functional or not. (Enabled is Functional)",
+        "displayName": "Power Supply 3 is functional",
+        "dbus": {
+            "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+            "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+            "property_name": "Functional",
+            "property_type": "bool",
+            "property_values": [true, false]
+        }
      }
-
-  ]
+   ]
 }

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -1,5 +1,4 @@
 {
-<<<<<<< HEAD
    "entries":[
       {
          "attribute_name" : "vmi_if0_ipv4_prefix_length",

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -1,4 +1,5 @@
 {
+<<<<<<< HEAD
    "entries":[
       {
          "attribute_name" : "vmi_if0_ipv4_prefix_length",
@@ -167,6 +168,70 @@
          "readOnly" : true,
          "helpText" : "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
          "displayName" : "Requested Core Freq MHZ (current)"
+      },
+      {
+         "attribute_name": "hb_power_PS0_input_voltage",
+         "lower_bound": 0,
+         "upper_bound": 65535,
+         "scalar_increment": 1,
+         "default_value": 0,
+         "readOnly": true,
+         "helpText": "Specifies power supply 0 input power voltage(volts)",
+         "displayName": "Power Supply 0 input Voltage",
+         "dbus": {
+               "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+               "interface": "xyz.openbmc_project.Sensor.Value",
+               "property_type": "double",
+               "property_name": "Value"
+         }
+      },
+      {
+         "attribute_name": "hb_power_PS1_input_voltage",
+         "lower_bound": 0,
+         "upper_bound": 65535,
+         "scalar_increment": 1,
+         "default_value": 0,
+         "readOnly": true,
+         "helpText": "Specifies power supply 1 input power voltage(volts)",
+         "displayName": "Power Supply 1 input Voltage",
+         "dbus": {
+               "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+               "interface": "xyz.openbmc_project.Sensor.Value",
+               "property_type": "double",
+               "property_name": "Value"
+         }
+      },
+      {
+         "attribute_name": "hb_power_PS2_input_voltage",
+         "lower_bound": 0,
+         "upper_bound": 65535,
+         "scalar_increment": 1,
+         "default_value": 0,
+         "readOnly": true,
+         "helpText": "Specifies power supply 2 input power voltage(volts)",
+         "displayName": "Power Supply 2 input Voltage",
+         "dbus": {
+               "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+               "interface": "xyz.openbmc_project.Sensor.Value",
+               "property_type": "double",
+               "property_name": "Value"
+         }
+      },
+      {
+         "attribute_name": "hb_power_PS3_input_voltage",
+         "lower_bound": 0,
+         "upper_bound": 65535,
+         "scalar_increment": 1,
+         "default_value": 0,
+         "readOnly": true,
+         "helpText": "Specifies power supply 3 input power voltage(volts)",
+         "displayName": "Power Supply 3 input Voltage",
+         "dbus": {
+               "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+               "interface": "xyz.openbmc_project.Sensor.Value",
+               "property_type": "double",
+               "property_name": "Value"
+         }
       }
-   ]
+    ]
 }

--- a/oem/ibm/configurations/bios/string_attrs.json
+++ b/oem/ibm/configurations/bios/string_attrs.json
@@ -16,6 +16,7 @@
                "property_name" : "AssetTag",
                "property_type" : "string"
             }
+<<<<<<< HEAD
       },
       {
          "attribute_name" : "vmi_hostname",
@@ -97,6 +98,70 @@
          "default_string" : "",
          "helpText" : "Provides the host a mapping of the lid IDs to human readable names.",
          "displayName" : "Hostboot Lid IDs"
+      },
+      {
+          "attribute_name": "hb_power_PS0_model",
+          "string_type": "ASCII",
+          "minimum_string_length": 0,
+          "maximum_string_length": 4,
+          "default_string_length": 4,
+          "default_string": "0000",
+          "helpText": "Specifies the power supply 0 model CCIN in hex.",
+          "displayName": "Power Supply 0 Model",
+          "dbus": {
+            "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+            "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+            "property_type": "string",
+            "property_name": "Model"
+          }
+      },
+      {
+          "attribute_name": "hb_power_PS1_model",
+          "string_type": "ASCII",
+          "minimum_string_length": 0,
+          "maximum_string_length": 4,
+          "default_string_length": 4,
+          "default_string": "0000",
+          "helpText": "Specifies the power supply 1 model CCIN in hex.",
+          "displayName": "Power Supply 1 Model",
+          "dbus": {
+            "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+            "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+            "property_type": "string",
+            "property_name": "Model"
+          }
+      },
+      {
+          "attribute_name": "hb_power_PS2_model",
+          "string_type": "ASCII",
+          "minimum_string_length": 0,
+          "maximum_string_length": 4,
+          "default_string_length": 4,
+          "default_string": "0000",
+          "helpText": "Specifies the power supply 2 model CCIN in hex.",
+          "displayName": "Power Supply 2 Model",
+          "dbus": {
+            "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+            "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+            "property_type": "string",
+            "property_name": "Model"
+          }
+      },
+      {
+          "attribute_name": "hb_power_PS3_model",
+          "string_type": "ASCII",
+          "minimum_string_length": 0,
+          "maximum_string_length": 4,
+          "default_string_length": 4,
+          "default_string": "0000",
+          "helpText": "Specifies the power supply 3 model CCIN in hex.",
+          "displayName": "Power Supply 3 Model",
+          "dbus": {
+            "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+            "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+            "property_type": "string",
+            "property_name": "Model"
+          }
       }
     ]
 }

--- a/oem/ibm/configurations/bios/string_attrs.json
+++ b/oem/ibm/configurations/bios/string_attrs.json
@@ -16,7 +16,6 @@
                "property_name" : "AssetTag",
                "property_type" : "string"
             }
-<<<<<<< HEAD
       },
       {
          "attribute_name" : "vmi_hostname",


### PR DESCRIPTION
Pull request: https://github.com/ibm-openbmc/pldm/pull/383
Upstream: https://gerrit.openbmc.org/c/openbmc/pldm/+/61015/15
Fixes: 421850 : PLDM flooding trace log on BMC.
Port to: FW1030.20