### PR TITLE
Change PLDM power supply bios attribute to get present instead of functional.

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -697,8 +697,8 @@
         "displayName": "Power Supply 0 is functional",
         "dbus": {
             "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
-            "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-            "property_name": "Functional",
+            "interface": "xyz.openbmc_project.Inventory.Item",
+            "property_name": "Present",
             "property_type": "bool",
             "property_values": [true, false]
         }
@@ -711,8 +711,8 @@
         "displayName": "Power Supply 1 is functional",
         "dbus": {
             "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
-            "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-            "property_name": "Functional",
+            "interface": "xyz.openbmc_project.Inventory.Item",
+            "property_name": "Present",
             "property_type": "bool",
             "property_values": [true, false]
         }
@@ -725,8 +725,8 @@
         "displayName": "Power Supply 2 is functional",
         "dbus": {
             "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
-            "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-            "property_name": "Functional",
+            "interface": "xyz.openbmc_project.Inventory.Item",
+            "property_name": "Present",
             "property_type": "bool",
             "property_values": [true, false]
         }
@@ -739,8 +739,8 @@
         "displayName": "Power Supply 3 is functional",
         "dbus": {
             "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
-            "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-            "property_name": "Functional",
+            "interface": "xyz.openbmc_project.Inventory.Item",
+            "property_name": "Present",
             "property_type": "bool",
             "property_values": [true, false]
         }


### PR DESCRIPTION
BMC present means function.
Change-Id: I4bb8985c43f54dadf85a92c96cc81a402cfaa4a5
Change-Id: I32f4075adbc7182ddb128176031287b0b0169c19
Signed-off-by: Sheldon Bailey <baileysh@us.ibm.com>