### PR TITLE
Remove PEL creation in watchdog path

### DIFF
--- a/libpldmresponder/base.cpp
+++ b/libpldmresponder/base.cpp
@@ -216,9 +216,6 @@ void Handler::processSetEventReceiver(
             std::cerr << "Failed to decode setEventReceiver command response,"
                       << " rc=" << rc << "cc=" << (unsigned)completionCode
                       << "\n";
-            pldm::utils::reportError(
-                "xyz.openbmc_project.bmc.pldm.InternalFailure",
-                pldm::PelSeverity::ERROR);
         }
     };
     rc = handler->registerRequest(


### PR DESCRIPTION
This commit removes the creation of PEL
in the host watchdog path when host boot
replies with ENABLE_METHOD_NOT_SUPPORTED.