### PR TITLE
Change in VMI Bios attribute enum

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -37,14 +37,14 @@
         },
         {
             "attribute_name": "vmi_if0_ipv6_method",
-            "possible_values": ["IPv6Static", "IPv6DHCP", "SLAAC"],
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
             "default_values": ["IPv6Static"],
             "helpText": "vmi_if0_ipv6_method",
             "displayName": "vmi_if0_ipv6_method"
         },
         {
             "attribute_name": "vmi_if1_ipv6_method",
-            "possible_values": ["IPv6Static", "IPv6DHCP", "SLAAC"],
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
             "default_values": ["IPv6Static"],
             "helpText": "vmi_if1_ipv6_method",
             "displayName": "vmi_if1_ipv6_method"


### PR DESCRIPTION
This commit changes one of the enums defined for ipv6 "method" attribute.
The current values are: IPv6Static, IPv6DHCP, SLAAC. "SLAAC" is now changed to: "IPv6SLAAC", w.r.t the other values.

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=449841

Upstream:
https://gerrit.openbmc.org/c/openbmc/pldm/+/61888

Change-Id: I3df4db803c6a7df7d9c5af2e7ba7438a0e360e3c