### PR TITLE
Listen for ifacesAdded for BIOS attribute props

### DIFF
--- a/libpldmresponder/bios_config.hpp
+++ b/libpldmresponder/bios_config.hpp
@@ -158,6 +158,9 @@ class BIOSConfig
     using propName = std::string;
     using DbusChObjProperties = std::map<propName, pldm::utils::PropertyValue>;
 
+    using ifaceName = std::string;
+    using DbusIfacesAdded = std::map<ifaceName, DbusChObjProperties>;
+
     // vector to catch the D-Bus property change signals for BIOS attributes
     std::vector<std::unique_ptr<sdbusplus::bus::match::match>> biosAttrMatch;
 
@@ -199,6 +202,24 @@ class BIOSConfig
                             msg.read(iface, props);
                             processBiosAttrChangeNotification(props,
                                                               biosAttrIndex);
+                        }));
+
+                biosAttrMatch.push_back(
+                    std::make_unique<sdbusplus::bus::match::match>(
+                        pldm::utils::DBusHandler::getBus(),
+                        interfacesAdded() + argNpath(0, dBusMap->objectPath),
+                        [this, biosAttrIndex, interface = dBusMap->interface](
+                            sdbusplus::message::message& msg) {
+                            sdbusplus::message::object_path path;
+                            DbusIfacesAdded interfaces;
+
+                            msg.read(path, interfaces);
+                            auto ifaceIt = interfaces.find(interface);
+                            if (ifaceIt != interfaces.end())
+                            {
+                                processBiosAttrChangeNotification(
+                                    ifaceIt->second, biosAttrIndex);
+                            }
                         }));
             }
         }


### PR DESCRIPTION
PLDM was just watching for PropertiesChanged signals on the D-Bus properties that back BIOS attributes.  Just doing that can miss properties on interfaces that get added after PLDM starts and then never change after that, because they would just send a single InterfacesAdded signal.

Close that hole by also adding an InterfacesAdded match along with the PropertiesChanged match.

Change-Id: Iab6679b0c99d049bd5f11e6508f784b2e8eb9349