### PR TITLE
oem: ibm: fileTable: Add lid files for peltool parsing

### DIFF
--- a/oem/ibm/configurations/fileTable.json
+++ b/oem/ibm/configurations/fileTable.json
@@ -204,6 +204,18 @@
         "file_traits": 1
     },
     {
+        "path": "/usr/local/share/hostfw/running/81e0068f.lid,/var/lib/phosphor-software-manager/hostfw/running/81e0068f.lid",
+        "file_traits": 1
+    },
+    {
+        "path": "/usr/local/share/hostfw/running/81e00690.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00690.lid",
+        "file_traits": 1
+    },
+    {
+        "path": "/usr/local/share/hostfw/running/81e00691.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00691.lid",
+        "file_traits": 1
+    },
+    {
         "path": "/usr/local/share/hostfw/running/81e00692.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00692.lid",
         "file_traits": 1
     },


### PR DESCRIPTION
These lid files contain debug strings to be parsed by the OpenPower peltool and display error information:
```
https://github.com/openbmc/phosphor-logging/tree/master/extensions/openpower-pels
```

Change-Id: I1bef79d4b1e4d94333d7949bd712d0c301c24f94