### PR TITLE
PLDM: Update lower_bound of ipv6_prefix_length to 0

### DIFF
--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -20,7 +20,7 @@
         },
         {
             "attribute_name": "vmi_if0_ipv6_prefix_length",
-            "lower_bound": 1,
+            "lower_bound": 0,
             "upper_bound": 128,
             "scalar_increment": 1,
             "default_value": 128,
@@ -29,7 +29,7 @@
         },
         {
             "attribute_name": "vmi_if1_ipv6_prefix_length",
-            "lower_bound": 1,
+            "lower_bound": 0,
             "upper_bound": 128,
             "scalar_increment": 1,
             "default_value": 128,


### PR DESCRIPTION
This change updates the lower_bound value of
vmi_if0_ipv6_prefix_length and vmi_if1_ipv6_prefix_length
to 0 from 1.

Upstream commit : https://gerrit.openbmc.org/c/openbmc/pldm/+/62470

Tested by:

curl -k -H "X-Auth-Token: $bmc_token" -XPATCH -D patch.txt -d '{"IPv6StaticAddresses": [{"Address": "2002:903:15f:325:123:123:123:124","PrefixLength": 0}]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1


curl -k -H "X-Auth-Token: $bmc_token" -X GET -D patch1.txt https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
{
  "@[odata.id](http://odata.id/)": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_8_0.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": false
  },
  "DHCPv6": {
    "OperatingMode": "Disabled"
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [
    {
      "Address": "[0.0.0.0](http://0.0.0.0/)",
      "AddressOrigin": "Static",
      "Gateway": "[0.0.0.0](http://0.0.0.0/)",
      "SubnetMask": "[0.0.0.0](http://0.0.0.0/)"
    }
  ],
  "IPv4StaticAddresses": [
    {
      "Address": "[0.0.0.0](http://0.0.0.0/)",
      "AddressOrigin": "Static",
      "Gateway": "[0.0.0.0](http://0.0.0.0/)",
      "SubnetMask": "[0.0.0.0](http://0.0.0.0/)"
    }
  ],
  "IPv6AddressPolicyTable": [],
  "IPv6Addresses": [
    {
      "Address": "2002:903:15f:325:123:123:123:124",
      "AddressOrigin": "Static",
      "PrefixLength": 0
    }
  ],
  "IPv6DefaultGateway": "::",
  "IPv6StaticAddresses": [
    {
      "Address": "2002:903:15f:325:123:123:123:124",
      "PrefixLength": 0
    }
  ],
  "Id": "eth1",
  "InterfaceEnabled": false,
  "Name": "Hypervisor Ethernet Interface",
  "StatelessAddressAutoConfig": {
    "IPv6AutoConfigEnabled": false
  }