### PR TITLE
Modify Mex PSU associations

### DIFF
--- a/configurations/host/host_fru_associations.json
+++ b/configurations/host/host_fru_associations.json
@@ -33,8 +33,8 @@
         {
             "from_entity_type": 45,
             "to_entity_type": 93,
-            "forward_association": "all_sensors",
-            "reverse_association": "chassis"
+            "forward_association": "cooled_by",
+            "reverse_association": "cooling"
         },
         {
             "from_entity_type": 45,
@@ -57,8 +57,8 @@
         {
             "from_entity_type": 120,
             "to_entity_type": 45,
-            "forward_association": "chassis",
-            "reverse_association": "inventory"
+            "forward_association": "powering",
+            "reverse_association": "powered_by"
         },
         {
             "from_entity_type": 186,

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -35,6 +35,8 @@ using Json = nlohmann::json;
 namespace fs = std::filesystem;
 using namespace pldm::dbus;
 constexpr auto fruJson = "host_frus.json";
+constexpr auto ledFwdAssociation = "identifying";
+constexpr auto ledReverseAssociation = "identified_by";
 const Json emptyJson{};
 const std::vector<Json> emptyJsonList{};
 
@@ -1557,8 +1559,8 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
                     state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED,
                     hostEffecterParser, mctpEid);
                 std::vector<std::tuple<std::string, std::string, std::string>>
-                    associations{{"identify_led_group",
-                                  "identify_inventory_object", ledGroupPath}};
+                    associations{{ledFwdAssociation, ledReverseAssociation,
+                                  ledGroupPath}};
                 CustomDBus::getCustomDBus().setAssociations(path, associations);
             }
         }


### PR DESCRIPTION
PDI has new association names(powering, powered_by) for PSUs. So making the changes in PLDM so that redfish client shall be able to access it.

Tested:
Fetched PowerSupplies under MEX using redfish GET query. Received the expected response.