### PR TITLE
Fix a bug in libpldmresponder

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -784,7 +784,7 @@ Response Handler::getStateSensorReadings(const pldm_msg* request,
     bitfield8_t sensorRearm{};
     uint8_t reserved{};
 
-    if (payloadLength != PLDM_GET_SENSOR_READING_REQ_BYTES)
+    if (payloadLength != PLDM_GET_STATE_SENSOR_READINGS_REQ_BYTES)
     {
         return ccOnlyResponse(request, PLDM_ERROR_INVALID_LENGTH);
     }


### PR DESCRIPTION
This commit fixes the bug in the getStateSensorReading command handler. We need to check the correct request bytes for getStateSensorReading command (Section 20.2 in DSP0248) and not getSensorReading command (Section 18.2 in DSP0248).

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>