### PR TITLE
Adding bios attributes for VMI Support

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -130,6 +130,14 @@
             "displayName": "HMC managed System"
         },
         {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_rtad",
             "possible_values": ["Disabled", "Enabled"],
             "default_values": ["Disabled"],


### PR DESCRIPTION
Adding host controlled VMI support bios attribute
for HMC Enablement Control for eBMC based systems.