### PR TITLE
PLDM: Implementing Phosphor-Logging/LG2 logging

### DIFF
--- a/common/flight_recorder.hpp
+++ b/common/flight_recorder.hpp
@@ -3,16 +3,19 @@
 #include <config.h>
 
 #include <common/utils.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace flightrecorder
 {
-
 using ReqOrResponse = bool;
 using FlightRecorderData = std::vector<uint8_t>;
 using FlightRecorderTimeStamp = std::string;
@@ -91,8 +94,8 @@ class FlightRecorder
         if (flightRecorderPolicy)
         {
             std::ofstream recorderOutputFile(flightRecorderDumpPath);
-            std::cout << "Dumping the flight recorder into : "
-                      << flightRecorderDumpPath << "\n";
+            info("Dumping the flight recorder into : {FLIGHT_REC_DUMP}",
+                 "FLIGHT_REC_DUMP", flightRecorderDumpPath);
 
             for (const auto& message : tapeRecorder)
             {
@@ -117,7 +120,7 @@ class FlightRecorder
         }
         else
         {
-            std::cerr << "Fight recorder policy is disabled\n";
+            error("Fight recorder policy is disabled");
         }
     }
 };

--- a/common/test/meson.build
+++ b/common/test/meson.build
@@ -17,6 +17,7 @@ foreach t : tests
                          libpldm_dep,
                          nlohmann_json,
                          phosphor_dbus_interfaces,
+                         phosphor_logging_dep,
                          libpldmutils,
                          sdbusplus]),
        workdir: meson.current_source_dir())

--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -7,6 +7,7 @@
 
 #include <sys/time.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <algorithm>
@@ -20,11 +21,12 @@
 #include <string>
 #include <vector>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace utils
 {
-
 constexpr auto mapperBusName = "xyz.openbmc_project.ObjectMapper";
 constexpr auto mapperPath = "/xyz/openbmc_project/object_mapper";
 constexpr auto mapperInterface = "xyz.openbmc_project.ObjectMapper";
@@ -76,8 +78,8 @@ std::vector<std::vector<uint8_t>> findStateEffecterPDR(uint8_t /*tid*/,
     }
     catch (const std::exception& e)
     {
-        std::cerr << " Failed to obtain a record. ERROR =" << e.what()
-                  << std::endl;
+        error(" Failed to obtain a record. ERROR = {ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
     }
 
     return pdrs;
@@ -130,8 +132,8 @@ std::vector<std::vector<uint8_t>> findStateSensorPDR(uint8_t /*tid*/,
     }
     catch (const std::exception& e)
     {
-        std::cerr << " Failed to obtain a record. ERROR =" << e.what()
-                  << std::endl;
+        error(" Failed to obtain a record. ERROR = {ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
     }
 
     return pdrs;
@@ -141,9 +143,11 @@ uint8_t readHostEID()
 {
     uint8_t eid{};
     std::ifstream eidFile{HOST_EID_PATH};
+
     if (!eidFile.good())
     {
-        std::cerr << "Could not open host EID file: " << HOST_EID_PATH << "\n";
+        error("Could not open host EID file: {HOST_EID_PATH}", "HOST_EID_PATH",
+              std::string(HOST_EID_PATH));
     }
     else
     {
@@ -155,8 +159,7 @@ uint8_t readHostEID()
         }
         else
         {
-            std::cerr << "Host EID file was empty"
-                      << "\n";
+            error("Host EID file was empty");
         }
     }
 
@@ -281,8 +284,9 @@ void reportError(const char* errorMsg, const Severity& sev)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to create error log, ERROR="
-                  << e.what() << "\n";
+        error(
+            "failed to make a d-bus call to create error log, ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
 }
 
@@ -323,10 +327,10 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
                 dBusMap.objectPath ==
                     "/xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0")
             {
-                std::cout << " ,service :" << service.c_str()
-                          << " , interface : " << dBusMap.interface.c_str()
-                          << " , path : " << dBusMap.objectPath.c_str()
-                          << std::endl;
+                info(
+                    " ,service :{SERV} , interface : {INTF} , path : {DBUS_OBJ_PATH}",
+                    "SERV", service.c_str(), "INTF", dBusMap.interface.c_str(),
+                    "DBUS_OBJ_PATH", dBusMap.objectPath.c_str());
             }
             method.append(dBusMap.interface.c_str(),
                           dBusMap.propertyName.c_str(), variant);
@@ -347,7 +351,7 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
             dBusMap.objectPath ==
                 "/xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0")
         {
-            std::cout << " value : " << std::get<bool>(value);
+            info(" value : {VAL}", "VAL", std::get<bool>(value));
         }
         if (strstr(dBusMap.objectPath.c_str(), "dimm") &&
             (dBusMap.interface ==
@@ -355,8 +359,8 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
         {
             if (!std::get<bool>(value))
             {
-                std::cerr << "Guard event on DIMM : [ "
-                          << dBusMap.objectPath.c_str() << " ] \n";
+                error("Guard event on DIMM : [ {DBUS_OBJ_PATH} ]",
+                      "DBUS_OBJ_PATH", dBusMap.objectPath.c_str());
             }
         }
 
@@ -404,7 +408,8 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
     }
     else
     {
-        std::cerr << "Property Type is:" << dBusMap.propertyType << std::endl;
+        error("Property Type is: {DBUS_PROP_TYP} ", "DBUS_PROP_TYP",
+              dBusMap.propertyType);
         throw std::invalid_argument("UnSpported Dbus Type");
     }
 }
@@ -482,7 +487,8 @@ PropertyValue jsonEntryToDbusVal(std::string_view type,
     }
     else
     {
-        std::cerr << "Unknown D-Bus property type, TYPE=" << type << "\n";
+        error("Unknown D-Bus property type, TYPE={DBUS_PROP_TYP}",
+              "DBUS_PROP_TYP", type);
     }
 
     return propValue;
@@ -545,8 +551,8 @@ int emitStateSensorEventSignal(uint8_t tid, uint16_t sensorId,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error emitting pldm event signal:"
-                  << "ERROR=" << e.what() << "\n";
+        error("Error emitting pldm event signal:ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
         return PLDM_ERROR;
     }
 
@@ -669,9 +675,9 @@ std::string getBiosAttrValue(const std::string& dbusAttrName)
     }
     catch (const sdbusplus::exception::SdBusError& e)
     {
-        std::cout << "Error getting the bios attribute"
-                  << "ERROR=" << e.what() << "ATTRIBUTE=" << dbusAttrName
-                  << std::endl;
+        info(
+            "Error getting the bios attribute ERROR={ERR_EXCEP} ATTRIBUTE={BIOS_ATTR}",
+            "ERR_EXCEP", e.what(), "BIOS_ATTR", dbusAttrName);
         return {};
     }
 
@@ -710,9 +716,10 @@ void setBiosAttr(const BiosAttributeList& biosAttrList)
         }
         catch (const sdbusplus::exception::SdBusError& e)
         {
-            std::cout << "Error setting the bios attribute"
-                      << "ERROR=" << e.what() << "ATTRIBUTE=" << dbusAttrName
-                      << "ATTRIBUTE VALUE=" << biosAttrStr << std::endl;
+            info(
+                "Error setting the bios attribute ERROR = {ERR_EXCEP} ATTRIBUTE= {DBUS_ATTR} ATTRIBUTE VALUE={BIOS_ATTR}",
+                "ERR_EXCEP", e.what(), "DBUS_ATTR", dbusAttrName.c_str(),
+                "BIOS_ATTR", biosAttrStr.c_str());
             return;
         }
     }
@@ -921,8 +928,9 @@ bool checkForFruPresence(const std::string& objPath)
     }
     catch (const sdbusplus::exception::SdBusError& e)
     {
-        std::cerr << "Failed to check for FRU presence for " << objPath
-                  << " ERROR =" << e.what() << std::endl;
+        error(
+            "Failed to check for FRU presence for {OBJ_PATH} ERROR = {ERR_EXCEP}",
+            "OBJ_PATH", objPath.c_str(), "ERR_EXCEP", e.what());
     }
     return isPresent;
 }

--- a/fw-update/device_updater.cpp
+++ b/fw-update/device_updater.cpp
@@ -5,14 +5,16 @@
 #include "activation.hpp"
 #include "update_manager.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <functional>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
-
 namespace fw_update
 {
-
 void DeviceUpdater::startFwUpdateFlow()
 {
     auto instanceId = updateManager->requester.getInstanceId(eid);
@@ -45,8 +47,8 @@ void DeviceUpdater::startFwUpdateFlow()
     if (rc)
     {
         updateManager->requester.markFree(eid, instanceId);
-        std::cerr << "encode_request_update_req failed, EID=" << unsigned(eid)
-                  << ", RC=" << rc << "\n";
+        error("encode_request_update_req failed, EID = {EID}, RC = {RC}", "EID",
+              unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 
@@ -55,8 +57,8 @@ void DeviceUpdater::startFwUpdateFlow()
         std::move(std::bind_front(&DeviceUpdater::requestUpdate, this)));
     if (rc)
     {
-        std::cerr << "Failed to send RequestUpdate request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error("Failed to send RequestUpdate request, EID = {EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 }
@@ -67,8 +69,8 @@ void DeviceUpdater::requestUpdate(mctp_eid_t eid, const pldm_msg* response,
     if (response == nullptr || !respMsgLen)
     {
         // Handle error scenario
-        std::cerr << "No response received for RequestUpdate, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for RequestUpdate, EID = {EID}", "EID",
+              unsigned(eid));
         return;
     }
 
@@ -80,16 +82,15 @@ void DeviceUpdater::requestUpdate(mctp_eid_t eid, const pldm_msg* response,
                                          &fdMetaDataLen, &fdWillSendPkgData);
     if (rc)
     {
-        std::cerr << "Decoding RequestUpdate response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding RequestUpdate response failed, EID = {EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return;
     }
     if (completionCode)
     {
-        std::cerr << "RequestUpdate response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "RequestUpdate response failed with error completion code, EID = {EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
 
@@ -168,8 +169,8 @@ void DeviceUpdater::sendPassCompTableRequest(size_t offset)
     if (rc)
     {
         updateManager->requester.markFree(eid, instanceId);
-        std::cerr << "encode_pass_component_table_req failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("encode_pass_component_table_req failed, EID = {EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 
@@ -179,8 +180,9 @@ void DeviceUpdater::sendPassCompTableRequest(size_t offset)
         std::move(std::bind_front(&DeviceUpdater::passCompTable, this)));
     if (rc)
     {
-        std::cerr << "Failed to send PassComponentTable request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error(
+            "Failed to send PassComponentTable request, EID = {EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 }
@@ -191,8 +193,8 @@ void DeviceUpdater::passCompTable(mctp_eid_t eid, const pldm_msg* response,
     if (response == nullptr || !respMsgLen)
     {
         // Handle error scenario
-        std::cerr << "No response received for PassComponentTable, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for PassComponentTable, EID = {EID}", "EID",
+              unsigned(eid));
         return;
     }
 
@@ -206,17 +208,17 @@ void DeviceUpdater::passCompTable(mctp_eid_t eid, const pldm_msg* response,
     if (rc)
     {
         // Handle error scenario
-        std::cerr << "Decoding PassComponentTable response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Decoding PassComponentTable response failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         return;
     }
     if (completionCode)
     {
         // Handle error scenario
-        std::cerr << "PassComponentTable response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "PassComponentTable response failed with error completion code, EID = {EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
     // Handle ComponentResponseCode
@@ -294,8 +296,8 @@ void DeviceUpdater::sendUpdateComponentRequest(size_t offset)
     if (rc)
     {
         updateManager->requester.markFree(eid, instanceId);
-        std::cerr << "encode_update_component_req failed, EID=" << unsigned(eid)
-                  << ", RC=" << rc << "\n";
+        error("encode_update_component_req failed, EID={EID}, RC = {RC}", "EID",
+              unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 
@@ -304,8 +306,8 @@ void DeviceUpdater::sendUpdateComponentRequest(size_t offset)
         std::move(std::bind_front(&DeviceUpdater::updateComponent, this)));
     if (rc)
     {
-        std::cerr << "Failed to send UpdateComponent request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error("Failed to send UpdateComponent request, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 }
@@ -316,8 +318,8 @@ void DeviceUpdater::updateComponent(mctp_eid_t eid, const pldm_msg* response,
     if (response == nullptr || !respMsgLen)
     {
         // Handle error scenario
-        std::cerr << "No response received for updateComponent, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for updateComponent, EID={EID}", "EID",
+              unsigned(eid));
         return;
     }
 
@@ -333,16 +335,15 @@ void DeviceUpdater::updateComponent(mctp_eid_t eid, const pldm_msg* response,
         &timeBeforeReqFWData);
     if (rc)
     {
-        std::cerr << "Decoding UpdateComponent response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding UpdateComponent response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return;
     }
     if (completionCode)
     {
-        std::cerr << "UpdateComponent response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "UpdateComponent response failed with error completion code, EID = {EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
 }
@@ -359,15 +360,17 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
                                                &length);
     if (rc)
     {
-        std::cerr << "Decoding RequestFirmwareData request failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Decoding RequestFirmwareData request failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         rc = encode_request_firmware_data_resp(
             request->hdr.instance_id, PLDM_ERROR_INVALID_DATA, responseMsg,
             sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding RequestFirmwareData response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding RequestFirmwareData response failed, EID = {EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -377,9 +380,8 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
     const auto& comp = compImageInfos[applicableComponents[componentIndex]];
     auto compOffset = std::get<5>(comp);
     auto compSize = std::get<6>(comp);
-    std::cerr << "offset = " << unsigned(offset)
-              << ", length = " << unsigned(length) << "\n";
-
+    error("offset = {OFFSET}, length = {LEN}", "OFFSET", unsigned(offset),
+          "LEN", unsigned(length));
     if (length < PLDM_FWUP_BASELINE_TRANSFER_SIZE || length > maxTransferSize)
     {
         rc = encode_request_firmware_data_resp(
@@ -387,8 +389,9 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
             responseMsg, sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding RequestFirmwareData response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding RequestFirmwareData response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -400,8 +403,9 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
             sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding RequestFirmwareData response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding RequestFirmwareData response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -424,8 +428,9 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
                                            sizeof(completionCode));
     if (rc)
     {
-        std::cerr << "Encoding RequestFirmwareData response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Encoding RequestFirmwareData response failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         return response;
     }
 
@@ -444,15 +449,16 @@ Response DeviceUpdater::transferComplete(const pldm_msg* request,
         decode_transfer_complete_req(request, payloadLength, &transferResult);
     if (rc)
     {
-        std::cerr << "Decoding TransferComplete request failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding TransferComplete request failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         rc = encode_transfer_complete_resp(request->hdr.instance_id,
                                            PLDM_ERROR_INVALID_DATA, responseMsg,
                                            sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding TransferComplete response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding TransferComplete response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -464,22 +470,24 @@ Response DeviceUpdater::transferComplete(const pldm_msg* request,
 
     if (transferResult == PLDM_FWUP_TRANSFER_SUCCESS)
     {
-        std::cout << "Component Transfer complete, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion << "\n";
+        info(
+            "Component Transfer complete, EID = {EID}, COMPONENT_VERSION = {COMP_VERS}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion);
     }
     else
     {
-        std::cerr << "Transfer of the component failed, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion
-                  << ", TRANSFER_RESULT=" << unsigned(transferResult) << "\n";
+        error(
+            "Transfer of the component failed, EID={EID}, COMPONENT_VERSION = {COMP_VERS}, TRANSFER_RESULT = {TRANS_RES}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion, "TRANS_RES",
+            unsigned(transferResult));
     }
 
     rc = encode_transfer_complete_resp(request->hdr.instance_id, completionCode,
                                        responseMsg, sizeof(completionCode));
     if (rc)
     {
-        std::cerr << "Encoding TransferComplete response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Encoding TransferComplete response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return response;
     }
 
@@ -497,15 +505,16 @@ Response DeviceUpdater::verifyComplete(const pldm_msg* request,
     auto rc = decode_verify_complete_req(request, payloadLength, &verifyResult);
     if (rc)
     {
-        std::cerr << "Decoding VerifyComplete request failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding VerifyComplete request failed, EID = {EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         rc = encode_verify_complete_resp(request->hdr.instance_id,
                                          PLDM_ERROR_INVALID_DATA, responseMsg,
                                          sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding VerifyComplete response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding VerifyComplete response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -517,22 +526,24 @@ Response DeviceUpdater::verifyComplete(const pldm_msg* request,
 
     if (verifyResult == PLDM_FWUP_VERIFY_SUCCESS)
     {
-        std::cout << "Component verification complete, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion << "\n";
+        info(
+            "Component verification complete, EID={EID}, COMPONENT_VERSION={COMP_VERS}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion);
     }
     else
     {
-        std::cerr << "Component verification failed, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion
-                  << ", VERIFY_RESULT=" << unsigned(verifyResult) << "\n";
+        error(
+            "Component verification failed, EID={EID}, COMPONENT_VERSION={COMP_VERS}, VERIFY_RESULT={VERIFY_RES}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion, "VERIFY_RES",
+            unsigned(verifyResult));
     }
 
     rc = encode_verify_complete_resp(request->hdr.instance_id, completionCode,
                                      responseMsg, sizeof(completionCode));
     if (rc)
     {
-        std::cerr << "Encoding VerifyComplete response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Encoding VerifyComplete response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return response;
     }
 
@@ -552,15 +563,16 @@ Response DeviceUpdater::applyComplete(const pldm_msg* request,
                                         &compActivationModification);
     if (rc)
     {
-        std::cerr << "Decoding ApplyComplete request failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding ApplyComplete request failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         rc = encode_apply_complete_resp(request->hdr.instance_id,
                                         PLDM_ERROR_INVALID_DATA, responseMsg,
                                         sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding ApplyComplete response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding ApplyComplete response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -573,23 +585,25 @@ Response DeviceUpdater::applyComplete(const pldm_msg* request,
     if (applyResult == PLDM_FWUP_APPLY_SUCCESS ||
         applyResult == PLDM_FWUP_APPLY_SUCCESS_WITH_ACTIVATION_METHOD)
     {
-        std::cout << "Component apply complete, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion << "\n";
+        info(
+            "Component apply complete, EID = {EID}, COMPONENT_VERSION = {COMP_VERS}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion);
         updateManager->updateActivationProgress();
     }
     else
     {
-        std::cerr << "Component apply failed, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion
-                  << ", APPLY_RESULT=" << unsigned(applyResult) << "\n";
+        error(
+            "Component apply failed, EID = {EID}, COMPONENT_VERSION = {COMP_VERS}, APPLY_RESULT = {APPLY_RES}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion, "APPLY_RES",
+            unsigned(applyResult));
     }
 
     rc = encode_apply_complete_resp(request->hdr.instance_id, completionCode,
                                     responseMsg, sizeof(completionCode));
     if (rc)
     {
-        std::cerr << "Encoding ApplyComplete response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Encoding ApplyComplete response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return response;
     }
 
@@ -626,8 +640,8 @@ void DeviceUpdater::sendActivateFirmwareRequest()
     if (rc)
     {
         updateManager->requester.markFree(eid, instanceId);
-        std::cerr << "encode_activate_firmware_req failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("encode_activate_firmware_req failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
     }
 
     rc = updateManager->handler.registerRequest(
@@ -635,8 +649,8 @@ void DeviceUpdater::sendActivateFirmwareRequest()
         std::move(std::bind_front(&DeviceUpdater::activateFirmware, this)));
     if (rc)
     {
-        std::cerr << "Failed to send ActivateFirmware request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error("Failed to send ActivateFirmware request, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
     }
 }
 
@@ -646,8 +660,8 @@ void DeviceUpdater::activateFirmware(mctp_eid_t eid, const pldm_msg* response,
     if (response == nullptr || !respMsgLen)
     {
         // Handle error scenario
-        std::cerr << "No response received for ActivateFirmware, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for ActivateFirmware, EID={EID}", "EID",
+              unsigned(eid));
         return;
     }
 
@@ -659,17 +673,16 @@ void DeviceUpdater::activateFirmware(mctp_eid_t eid, const pldm_msg* response,
     if (rc)
     {
         // Handle error scenario
-        std::cerr << "Decoding ActivateFirmware response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding ActivateFirmware response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return;
     }
     if (completionCode)
     {
         // Handle error scenario
-        std::cerr << "ActivateFirmware response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "ActivateFirmware response failed with error completion code, EID = {EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
 

--- a/fw-update/inventory_manager.cpp
+++ b/fw-update/inventory_manager.cpp
@@ -5,14 +5,15 @@
 #include "common/utils.hpp"
 #include "xyz/openbmc_project/Software/Version/server.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <functional>
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
-
 namespace fw_update
 {
-
 void InventoryManager::discoverFDs(const std::vector<mctp_eid_t>& eids)
 {
     for (const auto& eid : eids)
@@ -26,8 +27,9 @@ void InventoryManager::discoverFDs(const std::vector<mctp_eid_t>& eids)
         if (rc)
         {
             requester.markFree(eid, instanceId);
-            std::cerr << "encode_query_device_identifiers_req failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "encode_query_device_identifiers_req failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
             continue;
         }
 
@@ -38,8 +40,9 @@ void InventoryManager::discoverFDs(const std::vector<mctp_eid_t>& eids)
                                       this)));
         if (rc)
         {
-            std::cerr << "Failed to send QueryDeviceIdentifiers request, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n ";
+            error(
+                "Failed to send QueryDeviceIdentifiers request, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
     }
 }
@@ -50,8 +53,8 @@ void InventoryManager::queryDeviceIdentifiers(mctp_eid_t eid,
 {
     if (response == nullptr || !respMsgLen)
     {
-        std::cerr << "No response received for QueryDeviceIdentifiers, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for QueryDeviceIdentifiers, EID={EID}",
+              "EID", unsigned(eid));
         return;
     }
 
@@ -65,17 +68,17 @@ void InventoryManager::queryDeviceIdentifiers(mctp_eid_t eid,
         &descriptorCount, &descriptorPtr);
     if (rc)
     {
-        std::cerr << "Decoding QueryDeviceIdentifiers response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Decoding QueryDeviceIdentifiers response failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         return;
     }
 
     if (completionCode)
     {
-        std::cerr << "QueryDeviceIdentifiers response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "QueryDeviceIdentifiers response failed with error completion code, EID={EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
 
@@ -90,9 +93,9 @@ void InventoryManager::queryDeviceIdentifiers(mctp_eid_t eid,
             &descriptorData);
         if (rc)
         {
-            std::cerr
-                << "Decoding descriptor type, length and value failed, EID="
-                << unsigned(eid) << ", RC=" << rc << "\n ";
+            error(
+                "Decoding descriptor type, length and value failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
             return;
         }
 
@@ -114,9 +117,9 @@ void InventoryManager::queryDeviceIdentifiers(mctp_eid_t eid,
                 &vendorDefinedDescriptorData);
             if (rc)
             {
-                std::cerr
-                    << "Decoding Vendor-defined descriptor value failed, EID="
-                    << unsigned(eid) << ", RC=" << rc << "\n ";
+                error(
+                    "Decoding Vendor-defined descriptor value failed, EID={EID}, RC = {RC}",
+                    "EID", unsigned(eid), "RC", rc);
                 return;
             }
 
@@ -155,8 +158,8 @@ void InventoryManager::sendGetFirmwareParametersRequest(mctp_eid_t eid)
     if (rc)
     {
         requester.markFree(eid, instanceId);
-        std::cerr << "encode_get_firmware_parameters_req failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("encode_get_firmware_parameters_req failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return;
     }
 
@@ -167,8 +170,9 @@ void InventoryManager::sendGetFirmwareParametersRequest(mctp_eid_t eid)
             std::bind_front(&InventoryManager::getFirmwareParameters, this)));
     if (rc)
     {
-        std::cerr << "Failed to send GetFirmwareParameters request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error(
+            "Failed to send GetFirmwareParameters request, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
     }
 }
 
@@ -178,8 +182,8 @@ void InventoryManager::getFirmwareParameters(mctp_eid_t eid,
 {
     if (response == nullptr || !respMsgLen)
     {
-        std::cerr << "No response received for GetFirmwareParameters, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for GetFirmwareParameters, EID={EID}",
+              "EID", unsigned(eid));
         descriptorMap.erase(eid);
         return;
     }
@@ -194,17 +198,17 @@ void InventoryManager::getFirmwareParameters(mctp_eid_t eid,
         &pendingCompImageSetVerStr, &compParamTable);
     if (rc)
     {
-        std::cerr << "Decoding GetFirmwareParameters response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Decoding GetFirmwareParameters response failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         return;
     }
 
     if (fwParams.completion_code)
     {
-        std::cerr << "GetFirmwareParameters response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid)
-                  << ", CC=" << unsigned(fwParams.completion_code) << "\n";
+        error(
+            "GetFirmwareParameters response failed with error completion code, EID={EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(fwParams.completion_code));
         return;
     }
 
@@ -222,8 +226,9 @@ void InventoryManager::getFirmwareParameters(mctp_eid_t eid,
             &pendingCompVerStr);
         if (rc)
         {
-            std::cerr << "Decoding component parameter table entry failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Decoding component parameter table entry failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
             return;
         }
 

--- a/fw-update/package_parser.cpp
+++ b/fw-update/package_parser.cpp
@@ -5,17 +5,18 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <iostream>
 #include <memory>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace fw_update
 {
-
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
 
@@ -39,8 +40,8 @@ size_t PackageParser::parseFDIdentificationArea(
             &compImageSetVersionStr, &recordDescriptors, &fwDevicePkgData);
         if (rc)
         {
-            std::cerr << "Decoding firmware device ID record failed, RC=" << rc
-                      << "\n";
+            error("Decoding firmware device ID record failed, RC={RC}", "RC",
+                  rc);
             throw InternalFailure();
         }
 
@@ -56,9 +57,9 @@ size_t PackageParser::parseFDIdentificationArea(
                 &descriptorType, &descriptorData);
             if (rc)
             {
-                std::cerr
-                    << "Decoding descriptor type, length and value failed, RC="
-                    << rc << "\n";
+                error(
+                    "Decoding descriptor type, length and value failed, RC={RC}",
+                    "RC", rc);
                 throw InternalFailure();
             }
 
@@ -80,9 +81,9 @@ size_t PackageParser::parseFDIdentificationArea(
                     &descTitleStrType, &descTitleStr, &vendorDefinedDescData);
                 if (rc)
                 {
-                    std::cerr << "Decoding Vendor-defined descriptor value "
-                                 "failed, RC="
-                              << rc << "\n";
+                    error(
+                        "Decoding Vendor-defined descriptor value failed, RC={RC}",
+                        "RC", rc);
                     throw InternalFailure();
                 }
 
@@ -151,8 +152,8 @@ size_t PackageParser::parseCompImageInfoArea(ComponentImageCount compImageCount,
                                               &compImageInfo, &compVersion);
         if (rc)
         {
-            std::cerr << "Decoding component image information failed, RC="
-                      << rc << "\n";
+            error("Decoding component image information failed, RC={RC}", "RC",
+                  rc);
             throw InternalFailure();
         }
 
@@ -194,12 +195,12 @@ void PackageParser::validatePkgTotalSize(uintmax_t pkgSize)
 
         if (compLocOffset != calcPkgSize)
         {
-            std::cerr << "Validating the component location offset failed, "
-                         "COMP_VERSION="
-                      << std::get<static_cast<size_t>(
-                             ComponentImageInfoPos::CompVersionPos)>(
-                             componentImageInfo)
-                      << "\n";
+            error(
+                "Validating the component location offset failed, COMP_VERSION={COMP_VERS}",
+                "COMP_VERS",
+                std::get<static_cast<size_t>(
+                    ComponentImageInfoPos::CompVersionPos)>(
+                    componentImageInfo));
             throw InternalFailure();
         }
 
@@ -208,9 +209,9 @@ void PackageParser::validatePkgTotalSize(uintmax_t pkgSize)
 
     if (calcPkgSize != pkgSize)
     {
-        std::cerr
-            << "Package size does not match calculated package size, PKG_SIZE="
-            << pkgSize << " ,CALC_PKG_SIZE=" << calcPkgSize << "\n";
+        error(
+            "Package size does not match calculated package size, PKG_SIZE={PKG_SIZE}, CALC_PKG_SIZE={CALC_PKG_SIZE}",
+            "PKG_SIZE", pkgSize, "CALC_PKG_SIZE", calcPkgSize);
         throw InternalFailure();
     }
 }
@@ -220,16 +221,16 @@ void PackageParserV1::parse(const std::vector<uint8_t>& pkgHdr,
 {
     if (pkgHeaderSize != pkgHdr.size())
     {
-        std::cerr << "Package header size is invalid, PKG_HDR_SIZE="
-                  << pkgHeaderSize << "\n";
+        error("Package header size is invalid, PKG_HDR_SIZE={PKG_HDR_SIZE}",
+              "PKG_HDR_SIZE", pkgHeaderSize);
         throw InternalFailure();
     }
 
     size_t offset = sizeof(pldm_package_header_information) + pkgVersion.size();
     if (offset + sizeof(DeviceIDRecordCount) >= pkgHeaderSize)
     {
-        std::cerr << "Parsing package header failed, PKG_HDR_SIZE="
-                  << pkgHeaderSize << "\n";
+        error("Parsing package header failed, PKG_HDR_SIZE={PKG_HDR_SIZE}",
+              "PKG_HDR_SIZE", pkgHeaderSize);
         throw InternalFailure();
     }
 
@@ -239,15 +240,15 @@ void PackageParserV1::parse(const std::vector<uint8_t>& pkgHdr,
     offset = parseFDIdentificationArea(deviceIdRecCount, pkgHdr, offset);
     if (deviceIdRecCount != fwDeviceIDRecords.size())
     {
-        std::cerr
-            << "DeviceIDRecordCount entries not found, DEVICE_ID_REC_COUNT="
-            << deviceIdRecCount << "\n";
+        error(
+            "DeviceIDRecordCount entries not found, DEVICE_ID_REC_COUNT={DEVICE_ID_REC_CNT}",
+            "DEVICE_ID_REC_CNT", deviceIdRecCount);
         throw InternalFailure();
     }
     if (offset + sizeof(ComponentImageCount) >= pkgHeaderSize)
     {
-        std::cerr << "Parsing package header failed, PKG_HDR_SIZE="
-                  << pkgHeaderSize << "\n";
+        error("Parsing package header failed, PKG_HDR_SIZE={PKG_HDR_SIZE}",
+              "PKG_HDR_SIZE", pkgHeaderSize);
         throw InternalFailure();
     }
 
@@ -258,15 +259,16 @@ void PackageParserV1::parse(const std::vector<uint8_t>& pkgHdr,
     offset = parseCompImageInfoArea(compImageCount, pkgHdr, offset);
     if (compImageCount != componentImageInfos.size())
     {
-        std::cerr << "ComponentImageCount entries not found, COMP_IMAGE_COUNT="
-                  << compImageCount << "\n";
+        error(
+            "ComponentImageCount entries not found, COMP_IMAGE_COUNT={COMP_IMAGE_COUNT}",
+            "COMP_IMAGE_COUNT", compImageCount);
         throw InternalFailure();
     }
 
     if (offset + sizeof(PackageHeaderChecksum) != pkgHeaderSize)
     {
-        std::cerr << "Parsing package header failed, PKG_HDR_SIZE="
-                  << pkgHeaderSize << "\n";
+        error("Parsing package header failed, PKG_HDR_SIZE={PKG_HDR_SIZE}",
+              "PKG_HDR_SIZE", pkgHeaderSize);
         throw InternalFailure();
     }
 
@@ -276,8 +278,9 @@ void PackageParserV1::parse(const std::vector<uint8_t>& pkgHdr,
                 (pkgHdr[offset + 2] << 16) | (pkgHdr[offset + 3] << 24)));
     if (calcChecksum != checksum)
     {
-        std::cerr << "Parsing package header failed, CALC_CHECKSUM="
-                  << calcChecksum << ", PKG_HDR_CHECKSUM=" << checksum << "\n";
+        error(
+            "Parsing package header failed, CALC_CHECKSUM={CALC_CHECKSUM}, PKG_HDR_CHECKSUM={KEY1}",
+            "CALC_CHECKSUM", calcChecksum, "PKG_HDR_CHECKSUM", checksum);
         throw InternalFailure();
     }
 
@@ -297,8 +300,8 @@ std::unique_ptr<PackageParser> parsePkgHeader(std::vector<uint8_t>& pkgData)
                                               &pkgHeader, &pkgVersion);
     if (rc)
     {
-        std::cerr << "Decoding PLDM package header information failed, RC="
-                  << rc << "\n";
+        error("Decoding PLDM package header information failed, RC={RC}", "RC",
+              rc);
         return nullptr;
     }
 

--- a/fw-update/test/meson.build
+++ b/fw-update/test/meson.build
@@ -23,6 +23,7 @@ foreach t : tests
                          fw_update_test_src,
                          gmock,
                          gtest,
+			 phosphor_logging_dep,
                          libpldm_dep,
                          libpldmutils,
                          nlohmann_json,

--- a/fw-update/update_manager.cpp
+++ b/fw-update/update_manager.cpp
@@ -4,11 +4,14 @@
 #include "common/utils.hpp"
 #include "package_parser.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cassert>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <string>
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -35,9 +38,9 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
         if (activation->activation() ==
             software::Activation::Activations::Activating)
         {
-            std::cerr
-                << "Activation of PLDM FW update package already in progress"
-                << ", PACKAGE_VERSION=" << parser->pkgVersion << "\n";
+            error(
+                "Activation of PLDM FW update package already in progress, PACKAGE_VERSION={PKG_VERS}",
+                "PKG_VERS", parser->pkgVersion);
             std::filesystem::remove(packageFilePath);
             return -1;
         }
@@ -51,9 +54,9 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
                  std::ios::binary | std::ios::in | std::ios::ate);
     if (!package.good())
     {
-        std::cerr << "Opening the PLDM FW update package failed, ERR="
-                  << unsigned(errno) << ", PACKAGEFILE=" << packageFilePath
-                  << "\n";
+        error(
+            "Opening the PLDM FW update package failed, ERR={ERR}, PACKAGEFILE={PKG_PATH}",
+            "ERR", unsigned(errno), "PKG_PATH", packageFilePath.c_str());
         package.close();
         std::filesystem::remove(packageFilePath);
         return -1;
@@ -62,9 +65,9 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
     uintmax_t packageSize = package.tellg();
     if (packageSize < sizeof(pldm_package_header_information))
     {
-        std::cerr << "PLDM FW update package length less than the length of "
-                     "the package header information, PACKAGESIZE="
-                  << packageSize << "\n";
+        error(
+            "PLDM FW update package length less than the length of the package header information, PACKAGESIZE={PKG_SIZE}",
+            "PKG_SIZE", packageSize);
         package.close();
         std::filesystem::remove(packageFilePath);
         return -1;
@@ -89,8 +92,7 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
     parser = parsePkgHeader(packageHeader);
     if (parser == nullptr)
     {
-        std::cerr << "Invalid PLDM package header information"
-                  << "\n";
+        error("Invalid PLDM package header information");
         package.close();
         std::filesystem::remove(packageFilePath);
         return -1;
@@ -110,8 +112,7 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Invalid PLDM package header"
-                  << "\n";
+        error("Invalid PLDM package header");
         activation = std::make_unique<Activation>(
             pldm::utils::DBusHandler::getBus(), objPath,
             software::Activation::Activations::Invalid, this);
@@ -125,9 +126,8 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
                               totalNumComponentUpdates);
     if (!deviceUpdaterInfos.size())
     {
-        std::cerr
-            << "No matching devices found with the PLDM firmware update package"
-            << "\n";
+        error(
+            "No matching devices found with the PLDM firmware update package");
         activation = std::make_unique<Activation>(
             pldm::utils::DBusHandler::getBus(), objPath,
             software::Activation::Activations::Invalid, this);
@@ -203,11 +203,9 @@ void UpdateManager::updateDeviceCompletion(mctp_eid_t eid, bool status)
         }
 
         auto endTime = std::chrono::steady_clock::now();
-        std::cerr << "Firmware update time: "
-                  << std::chrono::duration<double, std::milli>(endTime -
-                                                               startTime)
-                         .count()
-                  << " ms\n";
+        error("Firmware update time: {DUR} ms", "DUR",
+              std::chrono::duration<double, std::milli>(endTime - startTime)
+                  .count());
         activation->activation(software::Activation::Activations::Active);
     }
     return;

--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -5,6 +5,10 @@
 #include "serialize.hpp"
 #include "type.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace dbus
@@ -612,8 +616,8 @@ void CustomDBus::removeDBus(const std::vector<uint16_t> types)
             continue;
         }
 
-        std::cerr << "Deleting the dbus objects of type : " << (unsigned)type
-                  << std::endl;
+        error("Deleting the dbus objects of type : {DBUS_OBJ_TYP}",
+              "DBUS_OBJ_TYP", (unsigned)type);
         for (const auto& [path, entites] : savedObjs.at(type))
         {
             deleteObject(path);

--- a/host-bmc/dbus/deserialize.cpp
+++ b/host-bmc/dbus/deserialize.cpp
@@ -6,6 +6,9 @@
 #include "serialize.hpp"
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -186,8 +189,8 @@ std::pair<std::set<uint16_t>, std::set<uint16_t>>
 
     if (!fs::exists(path) || fs::is_empty(path))
     {
-        std::cerr << "The file does not exist or is empty, FILE_PATH = " << path
-                  << std::endl;
+        error("The file does not exist or is empty, FILE_PATH = {FILE_PATH}",
+              "FILE_PATH", path.c_str());
         return std::make_pair(restoreTypes, storeTypes);
     }
 
@@ -214,8 +217,9 @@ std::pair<std::set<uint16_t>, std::set<uint16_t>>
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to parse config file, FILE_PATH = " << path
-                  << ", ERROR = " << e.what() << std::endl;
+        error(
+            "Failed to parse config file, FILE_PATH = {FILE_PATH}, ERROR = {ERR_EXCEP}",
+            "FILE_PATH", path.c_str(), "ERR_EXCEP", e.what());
     }
 
     return std::make_pair(restoreTypes, storeTypes);
@@ -246,7 +250,7 @@ void restoreDbusObj(HostPDRHandler* hostPDRHandler)
             continue;
         }
 
-        std::cout << "Restoring dbus of type : " << type << std::endl;
+        info("Restoring dbus of type : {DBUS_TYP}", "DBUS_TYP", type);
         // updateObjectPathMaps();
         for (auto& [path, entites] : objs)
         {
@@ -260,9 +264,8 @@ void restoreDbusObj(HostPDRHandler* hostPDRHandler)
             {
                 if (!ibmDbusHandler.contains(name))
                 {
-                    std::cerr
-                        << "name is not in ibmDbusHandler, name = " << name
-                        << std::endl;
+                    error("name is not in ibmDbusHandler, name = {NAME}",
+                          "NAME", name);
                     continue;
                 }
                 ibmDbusHandler.at(name)(path, propertyValue);

--- a/host-bmc/dbus/led_group.cpp
+++ b/host-bmc/dbus/led_group.cpp
@@ -2,6 +2,10 @@
 
 #include "libpldm/state_set.h"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace dbus
@@ -41,13 +45,14 @@ bool LEDGroup::asserted(bool value)
                 hostEffecterParser->getPldmPDR(), entity.entity_type,
                 entity.entity_instance_num, entity.entity_container_id,
                 PLDM_STATE_SET_IDENTIFY_STATE, false);
-            std::cerr << "Setting the led on : [ " << objectPath << "] ,[ "
-                      << entity.entity_type << " , "
-                      << entity.entity_instance_num << " , "
-                      << entity.entity_container_id << " ] , effecter ID : [ "
-                      << effecterId << " ] , current value : [ "
-                      << std::boolalpha << asserted() << " ] new value : [ "
-                      << value << " ] " << std::endl;
+            auto curVal = asserted() ? "true" : "false";
+            error(
+                "Setting the led on : [ {OBJ_PATH} ], [{ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID}] effecter ID : [ {EFFECTER_ID} ] , current value : [ {CUR_VAL} ], new value : [ {NEW_VAL} ]",
+                "OBJ_PATH", objectPath, "ENTITY_TYP",
+                static_cast<unsigned>(entity.entity_type), "ENTITY_NUM",
+                static_cast<unsigned>(entity.entity_instance_num), "ENTITY_ID",
+                static_cast<unsigned>(entity.entity_container_id),
+                "EFFECTER_ID", effecterId, "CUR_VAL", curVal, "NEW_VAL", value);
             hostEffecterParser->sendSetStateEffecterStates(
                 mctpEid, effecterId, 1, stateField,
                 std::bind(std::mem_fn(&pldm::dbus::LEDGroup::updateAsserted),

--- a/host-bmc/dbus/linkreset.cpp
+++ b/host-bmc/dbus/linkreset.cpp
@@ -4,11 +4,14 @@
 #include "libpldm/state_set.h"
 #include "libpldm/states.h"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace dbus
 {
-
 bool Link::linkReset(bool value)
 {
     std::vector<set_effecter_state_field> stateField;
@@ -27,7 +30,7 @@ bool Link::linkReset(bool value)
 
     if (value && hostEffecterParser)
     {
-        std::cerr << "Got a link reset request on : " << path << std::endl;
+        error("Got a link reset request on : {PATH}", "PATH", path.c_str());
         uint16_t effecterID = getEffecterID();
 
         if (effecterID == 0)
@@ -35,13 +38,15 @@ bool Link::linkReset(bool value)
             return false;
         }
 
-        std::cerr
-            << "[link reset] : Sending a effecter call to host with effecter id: "
-            << effecterID << std::endl;
+        error(
+            "[link reset] : Sending a effecter call to host with effecter id: {EFFECTER_ID}",
+            "EFFECTER_ID", effecterID);
         hostEffecterParser->sendSetStateEffecterStates(
             mctpEid, effecterID, 1, stateField, nullptr, value);
-        std::cerr << "Link reset on path : " << path
-                  << " is successful setting it back to false" << std::endl;
+        error(
+            "Link reset on path : {PATH} is successful setting it back to false",
+            "PATH", path.c_str());
+
         return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset(
             false);
     }
@@ -60,9 +65,9 @@ uint16_t Link::getEffecterID()
 
     if (stateEffecterPDRs.empty())
     {
-        std::cerr
-            << "PCIe LinkReset: The state set PDR can not be found, entityType = "
-            << entityType << std::endl;
+        error(
+            "PCIe LinkReset: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+            "ENTITY_TYP", entityType);
         return effecterID;
     }
 
@@ -71,8 +76,8 @@ uint16_t Link::getEffecterID()
     entityInstance = pldm::responder::utils::getLinkResetInstanceNumber(path);
 #endif
 
-    std::cerr << "CustomDBus: BusID of the link is: " << entityInstance
-              << std::endl;
+    error("CustomDBus: BusID of the link is: {ENTITY_INST}", "ENTITY_INST",
+          entityInstance);
     for (auto& rep : stateEffecterPDRs)
     {
         auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(rep.data());

--- a/host-bmc/dbus/pcie_topology.cpp
+++ b/host-bmc/dbus/pcie_topology.cpp
@@ -5,11 +5,14 @@
 
 #include "host-bmc/dbus/custom_dbus.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace dbus
 {
-
 bool PCIETopology::pcIeTopologyRefresh() const
 {
     return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
@@ -157,9 +160,9 @@ uint16_t PCIETopology::getEffecterID()
         hostEffecterParser->getPldmPDR());
     if (stateEffecterPDRs.empty())
     {
-        std::cerr
-            << "PCIe Topology: The state set PDR can not be found, entityType = "
-            << entityType << std::endl;
+        error(
+            "PCIe Topology: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+            "ENTITY_TYP", entityType);
         return effecterID;
     }
     for (auto& rep : stateEffecterPDRs)

--- a/host-bmc/dbus/serialize.cpp
+++ b/host-bmc/dbus/serialize.cpp
@@ -8,10 +8,13 @@
 #include <cereal/types/tuple.hpp>
 #include <cereal/types/variant.hpp>
 #include <cereal/types/vector.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 // Register class version with Cereal
 CEREAL_CLASS_VERSION(pldm::serialize::Serialize, 1)
@@ -91,8 +94,8 @@ bool Serialize::deserialize()
 {
     if (!fs::exists(filePath))
     {
-        std::cerr << "File does not exist, FILE_PATH = " << filePath
-                  << std::endl;
+        error("File does not exist, FILE_PATH = {FILE_PATH}", "FILE_PATH",
+              filePath.c_str());
         return false;
     }
 
@@ -107,8 +110,8 @@ bool Serialize::deserialize()
     }
     catch (const cereal::Exception& e)
     {
-        std::cerr << "Failed to restore groups, ERROR = " << e.what()
-                  << std::endl;
+        error("Failed to restore groups, ERROR = {ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
         fs::remove(filePath);
     }
 
@@ -140,8 +143,9 @@ void Serialize::reSerialize(const std::vector<uint16_t> types)
     {
         if (savedObjs.contains(type))
         {
-            std::cerr << "Removing objects of type : " << (unsigned)type
-                      << " from the persistent cache\n";
+            error(
+                "Removing objects of type : {OBJ_TYP} from the persistent cache",
+                "OBJ_TYP", (unsigned)type);
             savedObjs.erase(savedObjs.find(type));
         }
     }

--- a/host-bmc/dbus_to_event_handler.cpp
+++ b/host-bmc/dbus_to_event_handler.cpp
@@ -4,9 +4,12 @@
 
 #include "libpldmresponder/pdr.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 using namespace pldm::dbus_api;
 using namespace pldm::responder;
 using namespace pldm::responder::pdr;
@@ -41,8 +44,8 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_platform_event_message_req, rc = " << rc
-                  << std::endl;
+        error("Failed to encode_platform_event_message_req, rc = {RC}", "RC",
+              rc);
         return;
     }
 
@@ -51,8 +54,7 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
                                                   size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr
-                << "Failed to receive response for platform event message \n";
+            error("Failed to receive response for platform event message");
             return;
         }
         uint8_t completionCode{};
@@ -61,10 +63,9 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
 
@@ -73,7 +74,7 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send the platform event message \n";
+        error("Failed to send the platform event message");
     }
 }
 

--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -4,11 +4,14 @@
 #include "libpldm/platform.h"
 #include "libpldm/pldm.h"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/State/OperatingSystem/Status/server.hpp>
 
 #include <fstream>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::utils;
 
@@ -39,15 +42,16 @@ void HostEffecterParser::parseEffecterJson(const std::string& jsonPath)
     fs::path jsonDir(jsonPath);
     if (!fs::exists(jsonDir) || fs::is_empty(jsonDir))
     {
-        std::cerr << "Host Effecter json path does not exist, DIR=" << jsonPath
-                  << "\n";
+        error("Host Effecter json path does not exist, DIR = {JSON_PATH}",
+              "JSON_PATH", jsonPath.c_str());
         return;
     }
 
     fs::path jsonFilePath = jsonDir / hostEffecterJson;
     if (!fs::exists(jsonFilePath))
     {
-        std::cerr << "json does not exist, PATH=" << jsonFilePath << "\n";
+        error("json does not exist, PATH = {JSON_PATH}", "JSON_PATH",
+              jsonFilePath.c_str());
         throw InternalFailure();
     }
 
@@ -55,7 +59,8 @@ void HostEffecterParser::parseEffecterJson(const std::string& jsonPath)
     auto data = Json::parse(jsonFile, nullptr, false);
     if (data.is_discarded())
     {
-        std::cerr << "Parsing json file failed, FILE=" << jsonFilePath << "\n";
+        error("Parsing json file failed, FILE = {JSON_PATH}", "JSON_PATH",
+              jsonFilePath.c_str());
         throw InternalFailure();
     }
     const Json empty{};
@@ -97,11 +102,10 @@ void HostEffecterParser::parseEffecterJson(const std::string& jsonPath)
             auto states = state.value("state_values", emptyStates);
             if (dbusInfo.propertyValues.size() != states.size())
             {
-                std::cerr << "Number of states do not match with"
-                          << " number of D-Bus property values in the json. "
-                          << "Object path " << dbusInfo.dbusMap.objectPath
-                          << " and property " << dbusInfo.dbusMap.propertyName
-                          << " will not be monitored \n";
+                error(
+                    "Number of states do not match with number of D-Bus property values in the json. Object path {JSON_OBJ_PATH} and property {DBUS_PROP}  will not be monitored",
+                    "JSON_OBJ_PATH", dbusInfo.dbusMap.objectPath.c_str(),
+                    "DBUS_PROP", dbusInfo.dbusMap.propertyName);
                 continue;
             }
             for (const auto& s : states)
@@ -148,7 +152,7 @@ void HostEffecterParser::processHostEffecterChangeNotification(
             localOrRemote);
         if (effecterId == PLDM_INVALID_EFFECTER_ID)
         {
-            std::cerr << "Effecter id not found in pdr repo \n";
+            error("Effecter id not found in pdr repo");
             return;
         }
     }
@@ -170,15 +174,15 @@ void HostEffecterParser::processHostEffecterChangeNotification(
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
                               "ProgressStages.SystemSetup"))
         {
-            std::cout << "Host is not up. Current host state: "
-                      << currHostState.c_str() << "\n";
+            info("Host is not up. Current host state: {CURR_HOST_STATE}",
+                 "CURR_HOST_STATE", currHostState.c_str());
             return;
         }
     }
     catch (const sdbusplus::exception::exception& e)
     {
-        std::cerr << "Error in getting current host state. Will still "
-                     "continue to set the host effecter \n";
+        error(
+            "Error in getting current host state. Will still continue to set the host effecter");
     }
     uint8_t newState{};
     try
@@ -188,8 +192,7 @@ void HostEffecterParser::processHostEffecterChangeNotification(
     }
     catch (const std::out_of_range& e)
     {
-        std::cerr << "new state not found in json"
-                  << "\n";
+        error("new state not found in json");
         return;
     }
 
@@ -213,13 +216,12 @@ void HostEffecterParser::processHostEffecterChangeNotification(
     }
     catch (const std::runtime_error& e)
     {
-        std::cerr << "Could not set host state effecter \n";
+        error("Could not set host state effecter");
         return;
     }
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Could not set the host state effecter, rc= " << rc
-                  << " \n";
+        error("Could not set the host state effecter, rc= {RC}", "RC", rc);
     }
 }
 
@@ -264,9 +266,9 @@ int HostEffecterParser::sendSetStateEffecterStates(
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Message encode SetStateEffecterStates failure. PLDM error code = "
-            << std::hex << std::showbase << rc << "\n";
+        error(
+            "Message encode SetStateEffecterStates failure. PLDM error code = {RC}",
+            "RC", lg2::hex, rc);
         requester->markFree(mctpEid, instanceId);
         return rc;
     }
@@ -276,8 +278,8 @@ int HostEffecterParser::sendSetStateEffecterStates(
                                                  size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for "
-                      << "setStateEffecterStates command \n";
+            error(
+                "Failed to receive response for setStateEffecterStates command");
             return;
         }
         uint8_t completionCode{};
@@ -285,19 +287,19 @@ int HostEffecterParser::sendSetStateEffecterStates(
                                                         &completionCode);
         if (rc)
         {
-            std::cerr
-                << "Failed to decode setStateEffecterStates response, effecter Id : "
-                << effecterId << " , rc " << rc << "\n";
+            error(
+                "Failed to decode setStateEffecterStates response, effecter Id : {EFFECTER_ID}, rc = {RC}",
+                "EFFECTER_ID", effecterId, "RC", rc);
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
                 pldm::PelSeverity::ERROR);
         }
         if (completionCode)
         {
-            std::cerr << "Failed to set a Host effecter, effecter Id :  "
-                      << effecterId
-                      << " , cc=" << static_cast<unsigned>(completionCode)
-                      << "\n";
+            error(
+                "Failed to set a Host effecter, effecter Id : {EFFECTER_ID}, cc = {CC}",
+                "EFFECTER_ID", effecterId, "CC",
+                static_cast<unsigned>(completionCode));
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
                 pldm::PelSeverity::ERROR);
@@ -316,7 +318,7 @@ int HostEffecterParser::sendSetStateEffecterStates(
         std::move(requestMsg), std::move(setStateEffecterStatesRespHandler));
     if (rc)
     {
-        std::cerr << "Failed to send request to set an effecter on Host \n";
+        error("Failed to send request to set an effecter on Host");
     }
     return rc;
 }

--- a/host-bmc/dbus_to_host_effecters.hpp
+++ b/host-bmc/dbus_to_host_effecters.hpp
@@ -5,16 +5,18 @@
 #include "pldmd/dbus_impl_requester.hpp"
 #include "requester/handler.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <string>
 #include <utility>
 #include <vector>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace host_effecters
 {
-
 using DbusChgHostEffecterProps =
     std::map<dbus::Property, pldm::utils::PropertyValue>;
 
@@ -91,8 +93,9 @@ class HostEffecterParser
         }
         catch (const std::exception& e)
         {
-            std::cerr << "The json file does not exist or malformed, ERROR="
-                      << e.what() << "\n";
+            error(
+                "The json file does not exist or malformed, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
         }
     }
 

--- a/host-bmc/host_associations_parser.cpp
+++ b/host-bmc/host_associations_parser.cpp
@@ -1,9 +1,12 @@
 #include "host_associations_parser.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <fstream>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::utils;
 
@@ -21,8 +24,8 @@ void HostAssociationsParser::parseHostAssociations(const std::string& jsonPath)
     fs::path jsonDir(jsonPath);
     if (!fs::exists(jsonDir) || fs::is_empty(jsonDir))
     {
-        std::cerr << "Host Associations json path does not exist, DIR="
-                  << jsonPath << "\n";
+        error("Host Associations json path does not exist, DIR = {JSON_PATH}",
+              "JSON_PATH", jsonPath.c_str());
         return;
     }
 
@@ -30,7 +33,8 @@ void HostAssociationsParser::parseHostAssociations(const std::string& jsonPath)
 
     if (!fs::exists(jsonFilePath))
     {
-        std::cerr << "json does not exist, PATH=" << jsonFilePath << "\n";
+        error("json does not exist, PATH = {JSON_PATH}", "JSON_PATH",
+              jsonFilePath.c_str());
         throw InternalFailure();
     }
 
@@ -38,7 +42,8 @@ void HostAssociationsParser::parseHostAssociations(const std::string& jsonPath)
     auto data = Json::parse(jsonFile, nullptr, false);
     if (data.is_discarded())
     {
-        std::cerr << "Parsing json file failed, FILE=" << jsonFilePath << "\n";
+        error("Parsing json file failed, FILE = {JSON_PATH}", "JSON_PATH",
+              jsonFilePath.c_str());
         throw InternalFailure();
     }
     const Json empty{};

--- a/host-bmc/host_associations_parser.hpp
+++ b/host-bmc/host_associations_parser.hpp
@@ -3,16 +3,18 @@
 #include "common/types.hpp"
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <string>
 #include <utility>
 #include <vector>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace host_associations
 {
-
 /** @class HostAssociationsParser
  *
  *  @brief This class parses the Host Effecter json file and monitors for the
@@ -40,8 +42,9 @@ class HostAssociationsParser
         }
         catch (const std::exception& e)
         {
-            std::cerr << "The json file does not exist or malformed, ERROR="
-                      << e.what() << "\n";
+            error(
+                "The json file does not exist or malformed, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
         }
     }
 

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -5,6 +5,8 @@
 #include "libpldm/fru.h"
 #include "libpldm/pldm.h"
 #include "libpldm/state_set.h"
+
+#include <phosphor-logging/lg2.hpp>
 #ifdef OEM_IBM
 #include "libpldm/fru_oem_ibm.h"
 #include "libpldm/pdr_oem_ibm.h"
@@ -24,6 +26,8 @@
 
 #include <fstream>
 #include <type_traits>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -118,7 +122,7 @@ HostPDRHandler::HostPDRHandler(
             auto data = Json::parse(jsonFile, nullptr, false);
             if (data.is_discarded())
             {
-                std::cerr << "Parsing Host FRU json file failed" << std::endl;
+                error("Parsing Host FRU json file failed");
             }
             else
             {
@@ -136,8 +140,8 @@ HostPDRHandler::HostPDRHandler(
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Parsing Host FRU json file failed, exception = "
-                      << e.what() << std::endl;
+            error("Parsing Host FRU json file failed, exception = {ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
         }
     }
 
@@ -257,9 +261,9 @@ HostPDRHandler::HostPDRHandler(
                         }
                         catch (const std::exception& e)
                         {
-                            std::cerr
-                                << "Unable to set the slot power state to Off "
-                                << "ERROR=" << e.what() << "\n";
+                            error(
+                                "Unable to set the slot power state to Off, ERROR = {ERR_EXCEP}",
+                                "ERR_EXCEP", e.what());
                         }
                     }
                 }
@@ -357,7 +361,7 @@ void HostPDRHandler::getHostPDR(uint32_t nextRecordHandle)
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_get_pdr_req, rc = " << rc << std::endl;
+        error("Failed to encode_get_pdr_req, rc = {RC}", "RC", rc);
         return;
     }
 
@@ -367,7 +371,7 @@ void HostPDRHandler::getHostPDR(uint32_t nextRecordHandle)
         std::move(std::bind_front(&HostPDRHandler::processHostPDRs, this)));
     if (rc)
     {
-        std::cerr << "Failed to send the GetPDR request to Host \n";
+        error("Failed to send the GetPDR request to Host");
     }
 }
 std::string HostPDRHandler::updateLedGroupPath(const std::string& path)
@@ -405,16 +409,19 @@ int HostPDRHandler::handleStateSensorEvent(
                 auto ledGroupPath = updateLedGroupPath(entity.first);
                 if (!ledGroupPath.empty())
                 {
-                    std::cout
-                        << "led state event for [ " << ledGroupPath << " ] , [ "
-                        << node_entity.entity_type << " ,"
-                        << node_entity.entity_instance_num << " ,"
-                        << node_entity.entity_container_id
-                        << " ] , current value : [ " << std::boolalpha
-                        << CustomDBus::getCustomDBus().getAsserted(ledGroupPath)
-                        << " ] new value : [ "
-                        << bool(state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED)
-                        << " ]\n";
+                    auto currVal =
+                        CustomDBus::getCustomDBus().getAsserted(ledGroupPath)
+                            ? "true"
+                            : "false";
+                    auto newVal =
+                        bool(state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED);
+                    info(
+                        "led state event for [ {LED_GRP_PATH} ], [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID}] , current value : [ {CURR_VAL} ] new value : [ {NEW_VAL} ]",
+                        "LED_GRP_PATH", ledGroupPath, "ENTITY_TYP",
+                        (unsigned)node_entity.entity_type, "ENTITY_NUM",
+                        (unsigned)node_entity.entity_instance_num, "ENTITY_ID",
+                        (unsigned)node_entity.entity_container_id, "CURR_VAL",
+                        currVal, "NEW_VAL", (unsigned)newVal);
                     CustomDBus::getCustomDBus().setAsserted(
                         ledGroupPath, node_entity,
                         state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED,
@@ -430,8 +437,8 @@ int HostPDRHandler::handleStateSensorEvent(
                 stateSetId[0] == PLDM_STATE_SET_HEALTH_STATE &&
                 strstr(entity.first.c_str(), "core"))
             {
-                std::cerr << "Guard event on CORE : [" << entity.first
-                          << "] \n";
+                error("Guard event on CORE : [{ENTITY_FIRST}]", "ENTITY_FIRST",
+                      entity.first.c_str());
             }
             CustomDBus::getCustomDBus().setOperationalStatus(
                 entity.first, state == PLDM_OPERATIONAL_NORMAL,
@@ -442,8 +449,7 @@ int HostPDRHandler::handleStateSensorEvent(
         else if (stateSetId[0] == PLDM_STATE_SET_VERSION)
         {
             // There is a version changed on any of the dbus objects
-            std::cout
-                << "Got a signal from Host about a possible change in Version\n";
+            info("Got a signal from Host about a possible change in Version");
             createDbusObjects();
             return PLDM_SUCCESS;
         }
@@ -452,8 +458,7 @@ int HostPDRHandler::handleStateSensorEvent(
     auto rc = stateSensorHandler.eventAction(entry, state);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to fetch and update D-bus property, rc = " << rc
-                  << std::endl;
+        error("Failed to fetch and update D-bus property, rc = {RC}", "RC", rc);
         return rc;
     }
 
@@ -527,8 +532,7 @@ void HostPDRHandler::mergeEntityAssociations(
         pldm_find_entity_ref_in_tree(entityTree, entities[0], &node);
         if (node == nullptr)
         {
-            std::cerr
-                << "\ncould not find referrence of the entity in the tree \n";
+            error("could not find referrence of the entity in the tree");
         }
         else
         {
@@ -570,9 +574,9 @@ void HostPDRHandler::mergeEntityAssociations(
 void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
                                                uint8_t eventDataFormat)
 {
-    std::cerr
-        << "Sending the repo change event after merging the PDRs, MCTP_ID:"
-        << (unsigned)mctp_eid << std::endl;
+    error(
+        "Sending the repo change event after merging the PDRs, MCTP_ID: {MCTP_ID}",
+        "MCTP_ID", (unsigned)mctp_eid);
     assert(eventDataFormat == FORMAT_IS_PDR_HANDLES);
 
     // Extract from the PDR repo record handles of PDRs we want the host
@@ -636,9 +640,8 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
         &firstEntry, eventData, &actualSize, maxSize);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to encode_pldm_pdr_repository_chg_event_data, rc = "
-            << rc << std::endl;
+        error("Failed to encode_pldm_pdr_repository_chg_event_data, rc = {RC}",
+              "RC", rc);
         return;
     }
     auto instanceId = requester.getInstanceId(mctp_eid);
@@ -653,8 +656,8 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_platform_event_message_req, rc = " << rc
-                  << std::endl;
+        error("Failed to encode_platform_event_message_req, rc = {RC}", "RC",
+              rc);
         return;
     }
 
@@ -663,9 +666,8 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
                                                   size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the PDR repository "
-                         "changed event"
-                      << "\n";
+            error(
+                "Failed to receive response for the PDR repository changed event");
             return;
         }
 
@@ -676,10 +678,9 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: {RC}, cc = {CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
 
@@ -688,8 +689,7 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send the PDR repository changed event request"
-                  << "\n";
+        error("Failed to send the PDR repository changed event request");
     }
 }
 
@@ -736,8 +736,7 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
     uint8_t transferCRC{};
     if (response == nullptr || !respMsgLen)
     {
-        std::cerr << "Failed to receive response for the GetPDR"
-                     " command \n";
+        error("Failed to receive response for the GetPDR command");
         return;
     }
 
@@ -750,7 +749,7 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
     memcpy(responsePDRMsg.data(), response, respMsgLen + sizeof(pldm_msg_hdr));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to decode_get_pdr_resp, rc = " << rc << std::endl;
+        error("Failed to decode_get_pdr_resp, rc = {RC}", "RC", rc);
         return;
     }
     else
@@ -762,11 +761,10 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
                                  respCount, &transferCRC);
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Failed to decode_get_pdr_resp: "
-                      << "rc= "
-                      << ", NextRecordhandle :" << rc << nextRecordHandle
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_get_pdr_resp: rc = {RC}, NextRecordhandle : {NXT_RECORD_HNDL}, cc = {CC}",
+                "RC", rc, "NXT_RECORD_HNDL", nextRecordHandle, "CC",
+                static_cast<unsigned>(completionCode));
             return;
         }
         else
@@ -805,12 +803,10 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
 
                     terminusHandle = tlpdr->terminus_handle;
                     tid = tlpdr->tid;
-                    std::cerr
-                        << "Got a terminus Locator PDR with TID:"
-                        << (unsigned)tid
-                        << " and Terminus handle:" << terminusHandle
-                        << " with Valid bit as:" << (unsigned)tlpdr->validity
-                        << std::endl;
+                    error(
+                        "Got a terminus Locator PDR with TID: {TID} and Terminus handle: {TERMINUS_HNDL} with Valid bit as: {VALID_BIT}",
+                        "TID", (unsigned)tid, "TERMINUS_HNDL", terminusHandle,
+                        "VALID_BIT", (unsigned)tlpdr->validity);
                     auto terminus_locator_type = tlpdr->terminus_locator_type;
                     if (terminus_locator_type ==
                         PLDM_TERMINUS_LOCATOR_TYPE_MCTP_EID)
@@ -951,11 +947,11 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
     {
         pldm_pdr_record* firstRecord = repo->first;
         pldm_pdr_record* lastRecord = repo->last;
-        std::cerr << "First Record in the repo after PDR exchange is: "
-                  << firstRecord->record_handle << std::endl;
-        std::cerr << "Last Record in the repo after PDR exchange is:"
-                  << lastRecord->record_handle << std::endl;
-
+        error(
+            "First Record in the repo after PDR exchange is: {FIRST_REC_HNDL}",
+            "FIRST_REC_HNDL", firstRecord->record_handle);
+        error("Last Record in the repo after PDR exchange is: {LAST_REC_HNDL}",
+              "LAST_REC_HNDL", lastRecord->record_handle);
         pldm::hostbmc::utils::updateEntityAssociation(
             entityAssociations, entityTree, objPathMap, oemPlatformHandler);
 
@@ -972,7 +968,7 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
         this->createDbusObjects();
         if (isHostUp())
         {
-            std::cout << "Host is UP & Completed the PDR Exchange with host\n";
+            info("Host is UP & Completed the PDR Exchange with host");
             this->setHostSensorState();
         }
 
@@ -1049,8 +1045,8 @@ void HostPDRHandler::setHostFirmwareCondition()
                                      PLDM_BASE, request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "GetPLDMVersion encode failure. PLDM error code = "
-                  << std::hex << std::showbase << rc << "\n";
+        error("GetPLDMVersion encode failure. PLDM error code = {RC}", "RC",
+              lg2::hex, rc);
         requester.markFree(mctp_eid, instanceId);
         return;
     }
@@ -1060,13 +1056,12 @@ void HostPDRHandler::setHostFirmwareCondition()
                                         size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for "
-                      << "getPLDMVersion command, Host seems to be off \n";
+            error(
+                "Failed to receive response for getPLDMVersion command, Host seems to be off");
             return;
         }
-        std::cout << "Getting the response. PLDM RC = " << std::hex
-                  << std::showbase
-                  << static_cast<uint16_t>(response->payload[0]) << "\n";
+        error("Getting the response. PLDM RC = {RC}", "RC", lg2::hex,
+              (uint16_t)response->payload[0]);
         this->responseReceived = true;
     };
     rc = handler->registerRequest(mctp_eid, instanceId, PLDM_BASE,
@@ -1074,7 +1069,7 @@ void HostPDRHandler::setHostFirmwareCondition()
                                   std::move(getPLDMVersionHandler));
     if (rc)
     {
-        std::cerr << "Failed to discover Host state. Assuming Host as off \n";
+        error("Failed to discover Host state. Assuming Host as off");
     }
 }
 
@@ -1093,8 +1088,8 @@ void HostPDRHandler::_setHostSensorState()
 {
     if (isHostOff)
     {
-        std::cerr
-            << "set host state sensor begin : Host is off, stopped sending sensor state commands\n";
+        error(
+            "set host state sensor begin : Host is off, stopped sending sensor state commands");
         return;
     }
     if (sensorIndex != stateSensorPDRs.end())
@@ -1106,7 +1101,7 @@ void HostPDRHandler::_setHostSensorState()
 
         if (!pdr)
         {
-            std::cerr << "Failed to get State sensor PDR" << std::endl;
+            error("Failed to get State sensor PDR");
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostSensorState.GetStateSensorPDRFail",
                 pldm::PelSeverity::ERROR);
@@ -1139,9 +1134,9 @@ void HostPDRHandler::_setHostSensorState()
                 if (rc != PLDM_SUCCESS)
                 {
                     requester.markFree(mctpEid, instanceId);
-                    std::cerr << "Failed to "
-                                 "encode_get_state_sensor_readings_req, rc = "
-                              << rc << " SensorId=" << sensorId << std::endl;
+                    error(
+                        "Failed to encode_get_state_sensor_readings_req, rc = {RC}, SensorId = {SENSOR_ID}",
+                        "RC", rc, "SENSOR_ID", sensorId);
                     pldm::utils::reportError(
                         "xyz.openbmc_project.PLDM.Error.SetHostSensorState.EncodeStateSensorFail",
                         pldm::PelSeverity::ERROR);
@@ -1155,14 +1150,13 @@ void HostPDRHandler::_setHostSensorState()
                                                             size_t respMsgLen) {
                     if (response == nullptr || !respMsgLen)
                     {
-                        std::cerr
-                            << "Failed to receive response for "
-                               "getStateSensorReading command for sensor id="
-                            << sensorId << std::endl;
+                        error(
+                            "Failed to receive response for getStateSensorReading command for sensor id = {SENSOR_ID}",
+                            "SENSOR_ID", sensorId);
                         if (this->isHostOff)
                         {
-                            std::cerr
-                                << "set host state sensor : Host is off, stopped sending sensor state commands\n";
+                            error(
+                                "set host state sensor : Host is off, stopped sending sensor state commands");
                             return;
                         }
                         if (sensorIndex == stateSensorPDRs.end())
@@ -1183,12 +1177,10 @@ void HostPDRHandler::_setHostSensorState()
 
                     if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
                     {
-                        std::cerr
-                            << "Failed to "
-                               "decode_get_state_sensor_readings_resp, rc = "
-                            << rc
-                            << " cc=" << static_cast<unsigned>(completionCode)
-                            << " SensorId=" << sensorId << std::endl;
+                        error(
+                            "Failed to decode_get_state_sensor_readings_resp, rc = {RC} cc = {CC} SensorId = {SENSOR_ID}",
+                            "RC", rc, "CC", (unsigned)completionCode,
+                            "SENSOR_ID", sensorId);
                         if (sensorIndex == stateSensorPDRs.end())
                         {
                             return;
@@ -1235,17 +1227,16 @@ void HostPDRHandler::_setHostSensorState()
                             }
                             catch (const std::out_of_range& e)
                             {
-                                std::cerr << "No mapping for the events"
-                                          << std::endl;
+                                error("No mapping for the events");
                                 continue;
                             }
                         }
 
                         if (sensorOffset > compositeSensorStates.size())
                         {
-                            std::cerr
-                                << " Error Invalid data, Invalid sensor offset,"
-                                << " SensorId=" << sensorId << std::endl;
+                            error(
+                                "Error Invalid data, Invalid sensor offset, SensorId = {SENSOR_ID}",
+                                "SENSOR_ID", sensorId);
                             return;
                         }
 
@@ -1254,9 +1245,9 @@ void HostPDRHandler::_setHostSensorState()
                         if (possibleStates.find(eventState) ==
                             possibleStates.end())
                         {
-                            std::cerr
-                                << " Error invalid_data, Invalid event state,"
-                                << " SensorId=" << sensorId << std::endl;
+                            error(
+                                "Error invalid_data, Invalid event state, SensorId = {SENSOR_ID}",
+                                "SENSOR_ID", sensorId);
                             return;
                         }
                         const auto& [containerId, entityType, entityInstance] =
@@ -1284,9 +1275,9 @@ void HostPDRHandler::_setHostSensorState()
 
                 if (rc != PLDM_SUCCESS)
                 {
-                    std::cerr << " Failed to send request to get State sensor "
-                                 "reading on Host,"
-                              << " SensorId=" << sensorId << std::endl;
+                    error(
+                        " Failed to send request to get State sensor reading on Host, SensorId={SENSOR_ID}",
+                        "SENSOR_ID", sensorId);
                 }
             }
         }
@@ -1306,8 +1297,8 @@ void HostPDRHandler::getFRURecordTableMetadataByHost()
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_get_fru_record_table_metadata_req, rc = "
-                  << rc << std::endl;
+        error("Failed to encode_get_fru_record_table_metadata_req, rc = {RC}",
+              "RC", rc);
         return;
     }
 
@@ -1317,8 +1308,8 @@ void HostPDRHandler::getFRURecordTableMetadataByHost()
                                                            size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the Get FRU Record "
-                         "Table Metadata\n";
+            error(
+                "Failed to receive response for the Get FRU Record Table Metadata");
             return;
         }
 
@@ -1336,9 +1327,9 @@ void HostPDRHandler::getFRURecordTableMetadataByHost()
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Faile to decode get fru record table metadata resp, "
-                         "Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            error(
+                "Failed to decode get fru record table metadata resp, Message Error: rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", (int)cc);
             return;
         }
 
@@ -1352,8 +1343,7 @@ void HostPDRHandler::getFRURecordTableMetadataByHost()
         std::move(getFruRecordTableMetadataResponseHandler));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to send the the Set State Effecter States request\n";
+        error("Failed to send the the Set State Effecter States request");
     }
 
     return;
@@ -1380,8 +1370,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_get_fru_record_table_req, rc = " << rc
-                  << std::endl;
+        error("Failed to encode_get_fru_record_table_req, rc = {RC}", "RC", rc);
         return;
     }
 
@@ -1391,8 +1380,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
                                                    size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the Get FRU Record "
-                         "Table\n";
+            error("Failed to receive response for the Get FRU Record Table");
             return;
         }
 
@@ -1409,9 +1397,9 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr
-                << "Failed to decode get fru record table resp, Message Error: "
-                << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            error(
+                "Failed to decode get fru record table resp, Message Error: rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", (int)cc);
             return;
         }
 
@@ -1422,7 +1410,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
         {
             fruRecordData.clear();
 
-            std::cerr << "failed to parse fru recrod data format.\n";
+            error("failed to parse fru recrod data format.");
             return;
         }
 
@@ -1434,8 +1422,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
         std::move(requestMsg), std::move(getFruRecordTableResponseHandler));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to send the the Set State Effecter States request\n";
+        error("Failed to send the the Set State Effecter States request");
     }
 }
 
@@ -1469,8 +1456,8 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctpEid, instanceId);
-        std::cerr << "Failed to encode_get_state_sensor_readings_req, rc = "
-                  << rc << std::endl;
+        error("Failed to encode_get_state_sensor_readings_req, rc = {RC}", "RC",
+              rc);
         return;
     }
 
@@ -1482,16 +1469,15 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
                                                      size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr
-                << "Failed to receive response for get_state_sensor_readings command, sensor id : "
-                << sensorId << std::endl;
+            error(
+                "Failed to receive response for get_state_sensor_readings command, sensor id : {SENSOR_ID}",
+                "SENSOR_ID", sensorId);
             // even when for some reason , if we fail to get a response
             // to one sensor, try all the dbus objects
 
             if (this->isHostOff)
             {
-                std::cerr
-                    << "Host is off, stopped sending sensor states command\n";
+                error("Host is off, stopped sending sensor states command");
                 return;
             }
 
@@ -1516,9 +1502,9 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
             stateField.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Faile to decode get state sensor readings resp, "
-                         "Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            error(
+                "Failed to decode get state sensor readings resp, Message Error: rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", (int)cc);
             ++sensorMapIndex;
             if (sensorMapIndex == sensorMap.end())
             {
@@ -1579,7 +1565,7 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
         std::move(getStateSensorReadingsResponseHandler));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to get the State Sensor Readings request\n";
+        error("Failed to get the State Sensor Readings request");
     }
 
     return;
@@ -1645,11 +1631,12 @@ void HostPDRHandler::setLocationCode(
                     if (tlv.fruFieldType == PLDM_FRU_FIELD_TYPE_VERSION &&
                         node.entity_type == PLDM_ENTITY_SYSTEM_CHASSIS)
                     {
-                        std::cout << "Refreshing the mex firmware version : "
-                                  << std::string(reinterpret_cast<const char*>(
-                                                     tlv.fruFieldValue.data()),
-                                                 tlv.fruFieldLen)
-                                  << std::endl;
+                        auto mex_vers =
+                            std::string(reinterpret_cast<const char*>(
+                                            tlv.fruFieldValue.data()),
+                                        tlv.fruFieldLen);
+                        info("Refreshing the mex firmware version : {MEX_VERS}",
+                             "MEX_VERS", mex_vers);
                         CustomDBus::getCustomDBus().setSoftwareVersion(
                             entity.first,
                             std::string(reinterpret_cast<const char*>(
@@ -1773,7 +1760,7 @@ void HostPDRHandler::setAvailabilityState(const std::string& path)
 
 void HostPDRHandler::createDbusObjects()
 {
-    std::cerr << "Refreshing dbus hosted by pldm Started \n";
+    error("Refreshing dbus hosted by pldm Started");
 
     objMapIndex = objPathMap.begin();
 
@@ -1855,7 +1842,7 @@ void HostPDRHandler::createDbusObjects()
 
     // update xyz.openbmc_project.State.Decorator.OperationalStatus
     setOperationStatus();
-    std::cerr << "Refreshing dbus hosted by pldm Completed \n";
+    error("Refreshing dbus hosted by pldm Completed");
 }
 
 void HostPDRHandler::deleteDbusObjects(const std::vector<uint16_t> types)
@@ -1873,15 +1860,15 @@ void HostPDRHandler::deleteDbusObjects(const std::vector<uint16_t> types)
             continue;
         }
 
-        std::cerr << "Deleting the dbus objects of type : " << (unsigned)type
-                  << std::endl;
+        error("Deleting the dbus objects of type : {OBJ_TYP} ", "OBJ_TYP",
+              (unsigned)type);
         for (const auto& [path, entites] : savedObjs.at(type))
         {
             if (type !=
                 (PLDM_ENTITY_PROC | 0x8000)) // other than CPU core object
             {
-                std::cout << "Erasing Dbus Path from ObjectMap " << path
-                          << std::endl;
+                info("Erasing Dbus Path from ObjectMap {DBUS_PATH}",
+                     "DBUS_PATH", path.c_str());
                 objPathMap.erase(path);
                 // Delete the Mex Led Dbus Object paths
                 auto ledGroupPath = updateLedGroupPath(path);
@@ -1948,11 +1935,11 @@ void HostPDRHandler::setRecordPresent(uint32_t recordHandle)
                 recordEntity.entity_instance_num &&
             dbusEntity.entity_container_id == recordEntity.entity_container_id)
         {
-            std::cerr << "Removing Host FRU "
-                      << "[ " << path << " ]  with entityid [ "
-                      << recordEntity.entity_type << ","
-                      << recordEntity.entity_instance_num << ","
-                      << recordEntity.entity_container_id << "]" << std::endl;
+            error(
+                "Removing Host FRU [ {PATH} ] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ]",
+                "ENTITY_TYP", (unsigned)recordEntity.entity_type, "ENTITY_NUM",
+                (unsigned)recordEntity.entity_instance_num, "ENTITY_ID",
+                (unsigned)recordEntity.entity_container_id);
             // if the record has the same entity id, mark that dbus object as
             // not present
             CustomDBus::getCustomDBus().updateItemPresentStatus(path, false);
@@ -1967,7 +1954,8 @@ void HostPDRHandler::deletePDRFromRepo(PDRRecordHandles&& recordHandles)
 {
     for (auto& recordHandle : recordHandles)
     {
-        std::cerr << "Record handle deleted: " << recordHandle << std::endl;
+        error("Record handle deleted: {REC_HANDLE}", "REC_HANDLE",
+              recordHandle);
         this->setRecordPresent(recordHandle);
         pldm_delete_by_record_handle(repo, recordHandle, true);
     }

--- a/host-bmc/test/meson.build
+++ b/host-bmc/test/meson.build
@@ -48,6 +48,7 @@ foreach t : tests
                          gtest,
                          gmock,
                          host_bmc_test_src,
+			 phosphor_logging_dep,
                          libpldm_dep,
                          libpldmutils,
                          nlohmann_json,

--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -5,7 +5,11 @@
 #include "common/utils.hpp"
 #include "utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace fs = std::filesystem;
 namespace pldm
@@ -14,7 +18,6 @@ namespace hostbmc
 {
 namespace utils
 {
-
 Entities getParentEntites(const EntityAssociations& entityAssoc)
 {
     Entities parents{};
@@ -195,11 +198,11 @@ void updateEntityAssociation(
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "Parent entity not found in the entityMaps, type = "
-                    << parent.entity_type
-                    << ", num = " << parent.entity_instance_num
-                    << ", e = " << e.what() << std::endl;
+                error(
+                    "Parent entity not found in the entityMaps, type = {ENTITY_TYP}, num = {ENTITY_NUM}, e = {ERR_EXCEP}",
+                    "ENTITY_TYP", static_cast<int>(parent.entity_type),
+                    "ENTITY_NUM", static_cast<int>(parent.entity_instance_num),
+                    "ERR_EXCEP", e.what());
                 found = false;
                 break;
             }
@@ -272,8 +275,9 @@ void setCoreCount(const EntityAssociations& Associations)
                     }
                     catch (const std::exception& e)
                     {
-                        std::cerr << "failed to set the core count property "
-                                  << " ERROR=" << e.what() << "\n";
+                        error(
+                            "failed to set the core count property ERROR={ERR_EXCEP}",
+                            "ERR_EXCEP", e.what());
                     }
                 }
             }

--- a/libpldmresponder/base.cpp
+++ b/libpldmresponder/base.cpp
@@ -11,6 +11,8 @@
 #include "common/utils.hpp"
 #include "libpldmresponder/pdr.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <array>
 #include <cstring>
 #include <iostream>
@@ -23,14 +25,14 @@
 #include "libpldm/host.h"
 #endif
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 using Type = uint8_t;
 
 namespace responder
 {
-
 using Cmd = std::vector<uint8_t>;
 
 static const std::map<Type, Cmd> capabilities{
@@ -71,7 +73,6 @@ static const std::map<Type, ver32_t> versions{
 
 namespace base
 {
-
 Response Handler::getPLDMTypes(const pldm_msg* request,
                                size_t /*payloadLength*/)
 {
@@ -196,8 +197,8 @@ void Handler::processSetEventReceiver(
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(eid, instanceId);
-        std::cerr << "Failed to encode_set_event_receiver_req, rc = "
-                  << std::hex << std::showbase << rc << std::endl;
+        error("Failed to encode_set_event_receiver_req, rc = {RC}", "RC",
+              lg2::hex, rc);
         return;
     }
 
@@ -206,8 +207,7 @@ void Handler::processSetEventReceiver(
                                               size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for "
-                         "setEventReceiver command \n";
+            error("Failed to receive response for setEventReceiver command");
             return;
         }
 
@@ -216,9 +216,9 @@ void Handler::processSetEventReceiver(
                                                  &completionCode);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode setEventReceiver command response,"
-                      << " rc=" << rc << "cc=" << (unsigned)completionCode
-                      << "\n";
+            error(
+                "Failed to decode setEventReceiver command response, rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", (unsigned)completionCode);
             pldm::utils::reportError(
                 "xyz.openbmc_project.bmc.pldm.InternalFailure",
                 pldm::PelSeverity::ERROR);
@@ -230,8 +230,7 @@ void Handler::processSetEventReceiver(
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to send the setEventReceiver request"
-                  << "\n";
+        error("Failed to send the setEventReceiver request");
     }
 
     if (oemPlatformHandler)

--- a/libpldmresponder/bios.cpp
+++ b/libpldmresponder/bios.cpp
@@ -4,6 +4,8 @@
 
 #include <time.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <array>
 #include <chrono>
 #include <ctime>
@@ -12,6 +14,8 @@
 #include <string>
 #include <variant>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::utils;
 
@@ -123,9 +127,9 @@ Response Handler::getDateTime(const pldm_msg* request, size_t /*payloadLength*/)
     }
     catch (const sdbusplus::exception_t& e)
     {
-        std::cerr << "Error getting time, PATH=" << bmcTimePath
-                  << " TIME INTERACE=" << timeInterface << "\n";
-
+        error(
+            "Error getting time, PATH={BMC_TIME_PATH} TIME INTERACE={TIME_INTF}",
+            "BMC_TIME_PATH", bmcTimePath, "TIME_INTF", timeInterface);
         return CmdHandler::ccOnlyResponse(request, PLDM_ERROR);
     }
 
@@ -177,10 +181,10 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error getting the time sync property, PATH="
-                  << timeSyncPath << "INTERFACE=" << timeSyncInterface
-                  << "PROPERTY=" << timeSyncProperty << "ERROR=" << e.what()
-                  << "\n";
+        error(
+            "Error getting the time sync property, PATH={TIME_SYNC_PATH} INTERFACE={SYNC_INTERFACE} PROPERTY={SYNC_PROP} ERROR={ERR_EXCEP}",
+            "TIME_SYNC_PATH", timeSyncPath, "SYNC_INTERFACE", timeSyncInterface,
+            "SYNC_PROP", timeSyncProperty, "ERR_EXCEP", e.what());
     }
 
     constexpr auto setTimeInterface = "xyz.openbmc_project.Time.EpochTime";
@@ -207,10 +211,10 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error Setting time,PATH=" << setTimePath
-                  << "TIME INTERFACE=" << setTimeInterface
-                  << "ERROR=" << e.what() << "\n";
-
+        error(
+            "Error Setting time,PATH={SET_TIME_PATH} TIME INTERFACE={TIME_INTERFACE} ERROR={ERR_EXCEP}",
+            "SET_TIME_PATH", setTimePath, "TIME_INTERFACE", setTimeInterface,
+            "ERR_EXCEP", e.what());
         return ccOnlyResponse(request, PLDM_ERROR);
     }
 

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -6,6 +6,7 @@
 #include "bios_table.hpp"
 #include "common/bios_utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/BIOSConfig/Manager/server.hpp>
 
 #include <fstream>
@@ -17,6 +18,8 @@
 
 using namespace pldm::dbus_api;
 using namespace pldm::utils;
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -472,8 +475,8 @@ void BIOSConfig::updateBaseBIOSTableProperty()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to update BaseBIOSTable property, ERROR="
-                  << e.what() << "\n";
+        error("failed to update BaseBIOSTable property, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 }
 
@@ -521,8 +524,8 @@ void BIOSConfig::buildAndStoreAttrTables(const Table& stringTable)
     // bios-settings-manager in sync
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to read BaseBIOSTable property, ERROR=" << e.what()
-                  << "\n";
+        error("Failed to read BaseBIOSTable property, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 
     Table attrTable, attrValueTable;
@@ -547,8 +550,8 @@ void BIOSConfig::buildAndStoreAttrTables(const Table& stringTable)
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Construct Table Entry Error, AttributeName = "
-                      << attr->name << std::endl;
+            error("Construct Table Entry Error, AttributeName = {ATTR_NAME}",
+                  "ATTR_NAME", attr->name);
         }
     }
 
@@ -630,16 +633,16 @@ void BIOSConfig::load(const fs::path& filePath, ParseHandler handler)
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr
-                        << "Failed to parse JSON config file(entry handler) : "
-                        << filePath.c_str() << ", " << e.what() << std::endl;
+                    error(
+                        "Failed to parse JSON config file(entry handler) : {FILE_PATH}, {ERR_EXCEP}",
+                        "FILE_PATH", filePath.c_str(), "ERR_EXCEP", e.what());
                 }
             }
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to parse JSON config file : "
-                      << filePath.c_str() << std::endl;
+            error("Failed to parse JSON config file : {FILE_PATH}", "FILE_PATH",
+                  filePath.c_str());
         }
     }
 }
@@ -704,10 +707,13 @@ void BIOSConfig::traceBIOSUpdate(
 
             for (uint8_t handle : handles)
             {
-                std::cout << "BIOS:" << attrName << ", updated to value: "
-                          << displayStringHandle(attrHandle, handle, attrTable,
-                                                 stringTable)
-                          << ", by BMC: " << std::boolalpha << isBMC << "\n";
+                auto chkBMC = isBMC ? "true" : "false";
+                info(
+                    "BIOS:{ATTR_NAME}, updated to value: {VAL}, by BMC: {CHK_BMC}",
+                    "ATTR_NAME", attrName, "VAL",
+                    displayStringHandle(attrHandle, handle, attrTable,
+                                        stringTable),
+                    "CHK_BMC", chkBMC);
             }
             break;
         }
@@ -716,8 +722,10 @@ void BIOSConfig::traceBIOSUpdate(
         {
             auto value =
                 table::attribute_value::decodeIntegerEntry(attrValueEntry);
-            std::cout << "BIOS:" << attrName << ", updated to value: " << value
-                      << ", by BMC:" << std::boolalpha << isBMC << std::endl;
+            auto bmcChk = isBMC ? "true" : "false";
+            info(
+                "BIOS: {ATTR_NAME}, updated to value: {NEW_VAL}, by BMC: {BMC_CHK}",
+                "ATTR_NAME", attrName, "NEW_VAL", value, "BMC_CHK", bmcChk);
             break;
         }
         case PLDM_BIOS_STRING:
@@ -725,8 +733,10 @@ void BIOSConfig::traceBIOSUpdate(
         {
             auto value =
                 table::attribute_value::decodeStringEntry(attrValueEntry);
-            std::cout << "BIOS:" << attrName << " updated to value: " << value
-                      << ", by BMC:" << std::boolalpha << isBMC << std::endl;
+            auto bmcChk = isBMC ? "true" : "false";
+            info(
+                "BIOS:{ATTR_NAME} updated to value: {NEW_VAL}, by BMC:{BMC_CHK}",
+                "ATTR_NAME", attrName, "NEW_VAL", value, "BMC_CHK", bmcChk);
             break;
         }
         default:
@@ -757,8 +767,8 @@ int BIOSConfig::checkAttrValueToUpdate(
             }
             if (value[0] >= pvHdls.size())
             {
-                std::cerr << "Enum: Illgeal index, Index = " << (int)value[0]
-                          << std::endl;
+                error("Enum: Illgeal index, Index = {ATTR_VAL}", "ATTR_VAL",
+                      (int)value[0]);
                 return PLDM_ERROR_INVALID_DATA;
             }
             return PLDM_SUCCESS;
@@ -773,8 +783,8 @@ int BIOSConfig::checkAttrValueToUpdate(
 
             if (value < lower || value > upper)
             {
-                std::cerr << "Integer: out of bound, value = " << value
-                          << std::endl;
+                error("Integer: out of bound, value = {ATTR_VAL}", "ATTR_VAL",
+                      value);
                 return PLDM_ERROR_INVALID_DATA;
             }
             return PLDM_SUCCESS;
@@ -788,15 +798,16 @@ int BIOSConfig::checkAttrValueToUpdate(
             if (value.size() < stringConf.minLength ||
                 value.size() > stringConf.maxLength)
             {
-                std::cerr << "String: Length error, string = " << value
-                          << " length = " << value.size() << std::endl;
+                error(
+                    "String: Length error, string = {ATTR_VAL} length {ATTR_VAL_LEN}",
+                    "ATTR_VAL", value, "ATTR_VAL_LEN", value.size());
                 return PLDM_ERROR_INVALID_LENGTH;
             }
             return PLDM_SUCCESS;
         }
         default:
-            std::cerr << "ReadOnly or Unspported type, type = " << attrType
-                      << std::endl;
+            error("ReadOnly or Unspported type, type = {ATTR_TYP}", "ATTR_TYP",
+                  attrType);
             return PLDM_ERROR;
     };
 }
@@ -860,7 +871,7 @@ int BIOSConfig::setAttrValue(const void* entry, size_t size, bool isBMC,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Set attribute value error: " << e.what() << std::endl;
+        error("Set attribute value error: {ERR_EXCEP}", "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -881,7 +892,7 @@ void BIOSConfig::removeTables()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Remove the tables error: " << e.what() << std::endl;
+        error("Remove the tables error: {ERR_EXCEP}", "ERR_EXCEP", e.what());
     }
 }
 
@@ -902,7 +913,7 @@ void BIOSConfig::processBiosAttrChangeNotification(
     auto stringTable = getBIOSTable(PLDM_BIOS_STRING_TABLE);
     if (!stringTable.has_value())
     {
-        std::cerr << "BIOS string table unavailable\n";
+        error("BIOS string table unavailable");
         return;
     }
     BIOSStringTable biosStringTable(*stringTable);
@@ -913,23 +924,24 @@ void BIOSConfig::processBiosAttrChangeNotification(
     }
     catch (const std::invalid_argument& e)
     {
-        std::cerr << "Could not find handle for BIOS string, ATTRIBUTE="
-                  << attrName.c_str() << "\n";
+        error("Could not find handle for BIOS string, ATTRIBUTE={ATTR_NAME}",
+              "ATTR_NAME", attrName.c_str());
         return;
     }
 
     auto attrTable = getBIOSTable(PLDM_BIOS_ATTR_TABLE);
     if (!attrTable.has_value())
     {
-        std::cerr << "Attribute table not present\n";
+        error("Attribute table not present");
         return;
     }
     const struct pldm_bios_attr_table_entry* tableEntry =
         table::attribute::findByStringHandle(*attrTable, attrNameHdl);
     if (tableEntry == nullptr)
     {
-        std::cerr << "Attribute not found in attribute table, name= "
-                  << attrName.c_str() << "name handle=" << attrNameHdl << "\n";
+        error(
+            "Attribute not found in attribute table, name= {ATTR_NAME} name handle={ATTR_HNDL}",
+            "ATTR_NAME", attrName.c_str(), "ATTR_HNDL", attrNameHdl);
         return;
     }
 
@@ -940,7 +952,7 @@ void BIOSConfig::processBiosAttrChangeNotification(
 
     if (!attrValueSrcTable.has_value())
     {
-        std::cerr << "Attribute value table not present\n";
+        error("Attribute value table not present");
         return;
     }
 
@@ -949,9 +961,9 @@ void BIOSConfig::processBiosAttrChangeNotification(
         newValue, attrHdl, attrType, newPropVal);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Could not update the attribute value table for attribute "
-                     "handle="
-                  << attrHdl << " and type=" << (uint32_t)attrType << "\n";
+        error(
+            "Could not update the attribute value table for attribute handle={ATTR_HNDL} and type={ATTR_TYP}",
+            "ATTR_HNDL", attrHdl, "ATTR_TYP", (uint32_t)attrType);
         return;
     }
     auto destTable = table::attribute_value::updateTable(
@@ -964,8 +976,8 @@ void BIOSConfig::processBiosAttrChangeNotification(
     rc = setAttrValue(newValue.data(), newValue.size(), true, false);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "could not setAttrValue on base bios table and dbus, rc = "
-                  << rc << "\n";
+        error("could not setAttrValue on base bios table and dbus, rc = {RC}",
+              "RC", rc);
     }
 }
 
@@ -1009,8 +1021,8 @@ void BIOSConfig::constructPendingAttribute(
 
         if (iter == biosAttributes.end())
         {
-            std::cerr << "Wrong attribute name, attributeName = "
-                      << attributeName << std::endl;
+            error("Wrong attribute name, attributeName = {ATTR_NAME}",
+                  "ATTR_NAME", attributeName);
             continue;
         }
 
@@ -1026,8 +1038,8 @@ void BIOSConfig::constructPendingAttribute(
             type != BIOSConfigManager::AttributeType::String &&
             type != BIOSConfigManager::AttributeType::Integer)
         {
-            std::cerr << "Attribute type not supported, attributeType = "
-                      << attributeType << std::endl;
+            error("Attribute type not supported, attributeType = {ATTR_TYP}",
+                  "ATTR_TYP", attributeType);
             continue;
         }
 

--- a/libpldmresponder/bios_config.hpp
+++ b/libpldmresponder/bios_config.hpp
@@ -8,6 +8,7 @@
 #include "requester/handler.hpp"
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <functional>
 #include <iostream>
@@ -16,6 +17,8 @@
 #include <set>
 #include <string>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -203,8 +206,8 @@ class BIOSConfig
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Constructs Attribute Error, " << e.what()
-                      << std::endl;
+            error("Constructs Attribute Error, {ERR_EXCEP}", "ERR_EXCEP",
+                  e.what());
         }
     }
 

--- a/libpldmresponder/bios_enum_attribute.cpp
+++ b/libpldmresponder/bios_enum_attribute.cpp
@@ -4,9 +4,13 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
 
 using namespace pldm::utils;
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -14,7 +18,6 @@ namespace responder
 {
 namespace bios
 {
-
 BIOSEnumAttribute::BIOSEnumAttribute(const Json& entry,
                                      DBusHandler* const dbusHandler) :
     BIOSAttribute(entry, dbusHandler)
@@ -114,8 +117,8 @@ void BIOSEnumAttribute::buildValMap(const Json& dbusVals)
         }
         else
         {
-            std::cerr << "Unknown D-Bus property type, TYPE="
-                      << dBusMap->propertyType << "\n";
+            error("Unknown D-Bus property type, TYPE={DBUS_PROP_TYP}",
+                  "DBUS_PROP_TYP", dBusMap->propertyType);
             throw std::invalid_argument("Unknown D-BUS property type");
         }
         valMap.emplace(value, possibleValues[pos]);
@@ -222,9 +225,10 @@ void BIOSEnumAttribute::constructEntry(
             }
             catch (std::invalid_argument const& ex)
             {
-                std::cerr << "Enum Value " << currValue
-                          << " is not one of the possible values. Error: "
-                          << ex.what() << " for Attribute " << name << '\n';
+                error(
+                    "Enum Value {ENUM_VAL} is not one of the possible values. Error:{ERR_EXCEP} for Attribute {ATTR_NAME}",
+                    "ENUM_VAL", currValue, "ERR_EXCEP", ex.what(), "ATTR_NAME",
+                    name);
                 currValueIndices[0] =
                     getValueIndex(defaultValue, possibleValues);
             }
@@ -250,8 +254,8 @@ int BIOSEnumAttribute::updateAttrVal(Table& newValue, uint16_t attrHdl,
     auto iter = valMap.find(newPropVal);
     if (iter == valMap.end())
     {
-        std::cerr << "Could not find index for new BIOS enum, value="
-                  << std::get<std::string>(newPropVal) << "\n";
+        error("Could not find index for new BIOS enum, value={ENUM_VAL}",
+              "ENUM_VAL", std::get<std::string>(newPropVal));
         return PLDM_ERROR;
     }
     auto currentValue = iter->second;

--- a/libpldmresponder/bios_integer_attribute.cpp
+++ b/libpldmresponder/bios_integer_attribute.cpp
@@ -2,6 +2,10 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 using namespace pldm::utils;
 
 namespace pldm
@@ -10,7 +14,6 @@ namespace responder
 {
 namespace bios
 {
-
 BIOSIntegerAttribute::BIOSIntegerAttribute(const Json& entry,
                                            DBusHandler* const dbusHandler) :
     BIOSAttribute(entry, dbusHandler)
@@ -33,13 +36,12 @@ BIOSIntegerAttribute::BIOSIntegerAttribute(const Json& entry,
     auto rc = pldm_bios_table_attr_entry_integer_info_check(&info, &errmsg);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Wrong filed for integer attribute, ATTRIBUTE_NAME="
-                  << attr.c_str() << " ERRMSG=" << errmsg
-                  << " LOWER_BOUND=" << integerInfo.lowerBound
-                  << " UPPER_BOUND=" << integerInfo.upperBound
-                  << " DEFAULT_VALUE=" << integerInfo.defaultValue
-                  << " SCALAR_INCREMENT=" << integerInfo.scalarIncrement
-                  << "\n";
+        error(
+            "Wrong filed for integer attribute, ATTRIBUTE_NAME={ATTR_NAME} ERRMSG= {ERR_MSG} LOWER_BOUND={LOW_BOUND} UPPER_BOUND={UPPER_BOUND} DEFAULT_VALUE={DEF_VAL} SCALAR_INCREMENT={SCALAR_INCREMENT}",
+            "ATTR_NAME", attr.c_str(), "ERR_MSG", errmsg, "LOW_BOUND",
+            integerInfo.lowerBound, "UPPER_BOUND", integerInfo.upperBound,
+            "DEF_VAL", integerInfo.defaultValue, "SCALAR_INCREMENT",
+            integerInfo.scalarIncrement);
         throw std::invalid_argument("Wrong field for integer attribute");
     }
 }
@@ -95,8 +97,8 @@ void BIOSIntegerAttribute::setAttrValueOnDbus(
                                             static_cast<double>(currentValue));
     }
 
-    std::cerr << "Unsupported property type on dbus: " << dBusMap->propertyType
-              << std::endl;
+    error("Unsupported property type on dbus: {DBUS_PROP_TYP}", "DBUS_PROP_TYP",
+          dBusMap->propertyType);
     throw std::invalid_argument("dbus type error");
 }
 
@@ -137,9 +139,10 @@ void BIOSIntegerAttribute::constructEntry(
     if (currentValue < (int64_t)integerInfo.lowerBound ||
         currentValue > (int64_t)integerInfo.upperBound)
     {
-        std::cerr << "Setting to default value " << integerInfo.defaultValue
-                  << " For Attribute " << name
-                  << " Received value: " << currentValue << std::endl;
+        error(
+            "Setting to default value {DEF_VAL} For Attribute {ATTR_NAME} Received value: {CURR_VAL}",
+            "DEF_VAL", integerInfo.defaultValue, "ATTR_NAME", name, "CURR_VAL",
+            currentValue);
         currentValue = integerInfo.defaultValue;
     }
 
@@ -184,8 +187,8 @@ uint64_t BIOSIntegerAttribute::getAttrValue(const PropertyValue& propertyValue)
     }
     else
     {
-        std::cerr << "Unsupported property type for getAttrValue: "
-                  << dBusMap->propertyType << std::endl;
+        error("Unsupported property type for getAttrValue: {DBUS_PROP_TYP}",
+              "DBUS_PROP_TYP", dBusMap->propertyType);
         throw std::invalid_argument("dbus type error");
     }
     return value;
@@ -208,8 +211,8 @@ uint64_t BIOSIntegerAttribute::getAttrValue()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Get Integer Attribute Value Error: AttributeName = "
-                  << name << std::endl;
+        error("Get Integer Attribute Value Error: AttributeName = {ATTR_NAME}",
+              "ATTR_NAME", name);
         return integerInfo.defaultValue;
     }
 }

--- a/libpldmresponder/bios_string_attribute.cpp
+++ b/libpldmresponder/bios_string_attribute.cpp
@@ -2,11 +2,15 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
 #include <tuple>
 #include <variant>
 
 using namespace pldm::utils;
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -14,7 +18,6 @@ namespace responder
 {
 namespace bios
 {
-
 BIOSStringAttribute::BIOSStringAttribute(const Json& entry,
                                          DBusHandler* const dbusHandler) :
     BIOSAttribute(entry, dbusHandler)
@@ -23,8 +26,9 @@ BIOSStringAttribute::BIOSStringAttribute(const Json& entry,
     auto iter = strTypeMap.find(strTypeTmp);
     if (iter == strTypeMap.end())
     {
-        std::cerr << "Wrong string type, STRING_TYPE=" << strTypeTmp
-                  << " ATTRIBUTE_NAME=" << name << "\n";
+        error(
+            "Wrong string type, STRING_TYPE={STRING_TYPE} ATTRIBUTE_NAME={ATTR_NAME}",
+            "STRING_TYPE", strTypeTmp, "ATTR_NAME", name);
         throw std::invalid_argument("Wrong string type");
     }
     stringInfo.stringType = static_cast<uint8_t>(iter->second);
@@ -48,12 +52,11 @@ BIOSStringAttribute::BIOSStringAttribute(const Json& entry,
     auto rc = pldm_bios_table_attr_entry_string_info_check(&info, &errmsg);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Wrong field for string attribute, ATTRIBUTE_NAME=" << name
-                  << " ERRMSG=" << errmsg
-                  << " MINIMUM_STRING_LENGTH=" << stringInfo.minLength
-                  << " MAXIMUM_STRING_LENGTH=" << stringInfo.maxLength
-                  << " DEFAULT_STRING_LENGTH=" << stringInfo.defLength
-                  << " DEFAULT_STRING=" << stringInfo.defString << "\n";
+        error(
+            "Wrong field for string attribute, ATTRIBUTE_NAME={ATTR_NAME} ERRMSG={ERR_MSG} MINIMUM_STRING_LENGTH={MIN_LEN} MAXIMUM_STRING_LENGTH={MAX_LEN} DEFAULT_STRING_LENGTH={DEF_LEN} DEFAULT_STRING={DEF_STR}",
+            "ATTR_NAME", name, "ERR_MSG", errmsg, "MIN_LEN",
+            stringInfo.minLength, "MAX_LEN", stringInfo.maxLength, "DEF_LEN",
+            stringInfo.defLength, "DEF_STR", stringInfo.defString);
         throw std::invalid_argument("Wrong field for string attribute");
     }
 }
@@ -86,8 +89,8 @@ std::string BIOSStringAttribute::getAttrValue()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Get String Attribute Value Error: AttributeName = "
-                  << name << std::endl;
+        error("Get String Attribute Value Error: AttributeName = {ATTR_NAME}",
+              "ATTR_NAME", name);
         return stringInfo.defString;
     }
 }
@@ -129,8 +132,9 @@ void BIOSStringAttribute::constructEntry(
     if (currStr.size() < stringInfo.minLength ||
         currStr.size() > stringInfo.maxLength)
     {
-        std::cerr << "Setting to default. Received string size "
-                  << currStr.size() << " For Attribute " << name << std::endl;
+        error(
+            "Setting to default. Received string size {STR_SIZE} For Attribute {ATTR_NAME}",
+            "STR_SIZE", currStr.size(), "ATTR_NAME", name);
         currStr = stringInfo.defString;
     }
 
@@ -150,8 +154,8 @@ int BIOSStringAttribute::updateAttrVal(Table& newValue, uint16_t attrHdl,
     }
     catch (const std::bad_variant_access& e)
     {
-        std::cerr << "invalid value passed for the property, error: "
-                  << e.what() << "\n";
+        error("invalid value passed for the property, error: {ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -14,10 +14,13 @@
 #include <config.h>
 #include <systemd/sd-journal.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
 
 #include <iostream>
 #include <set>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -163,8 +166,8 @@ void FruImpl::buildFRUTable()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Look up of inventory objects failed and PLDM FRU table "
-                     "creation failed\n";
+        info(
+            "Look up of inventory objects failed and PLDM FRU table creation failed");
         return;
     }
 
@@ -210,9 +213,9 @@ void FruImpl::buildFRUTable()
                 }
                 catch (const std::exception& e)
                 {
-                    std::cout << "Config JSONs missing for the item "
-                                 "interface type, interface = "
-                              << interface.first << "\n";
+                    info(
+                        "Config JSONs missing for the item interface type, interface = {INTF}",
+                        "INTF", interface.first);
                     break;
                 }
             }
@@ -249,9 +252,8 @@ std::string FruImpl::populatefwVersion()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call "
-                     "Asociation, ERROR= "
-                  << e.what() << "\n";
+        error("failed to make a d-bus call Asociation, ERROR= {ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return {};
     }
     return currentBmcVersion;
@@ -401,11 +403,12 @@ void FruImpl::removeIndividualFRU(const std::string& fruObjPath)
 
     objectPathToRSIMap.erase(fruObjPath);
     objToEntityNode.erase(fruObjPath); // sm00
-    std::cerr << "Removing Individual FRU "
-              << "[ " << fruObjPath << " ] "
-              << "with entityid [ " << removeEntity.entity_type << ","
-              << removeEntity.entity_instance_num << ","
-              << removeEntity.entity_container_id << " ]\n";
+    error(
+        "Removing Individual FRU [ {FRU_OBJ_PATH} ] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ]",
+        "FRU_OBJ_PATH", fruObjPath, "ENTITY_TYP",
+        static_cast<unsigned>(removeEntity.entity_type), "ENTITY_NUM",
+        static_cast<unsigned>(removeEntity.entity_instance_num), "ENTITY_ID",
+        static_cast<unsigned>(removeEntity.entity_container_id));
     associatedEntityMap.erase(fruObjPath); // sm00
 
     deleteFruRecord(rsi);
@@ -556,14 +559,15 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
             PLDM_ENTITY_ASSOCIAION_PHYSICAL, false, true, last_container_id);
         pldm_entity node_entity = pldm_entity_extract(node);
         objToEntityNode[fruObjectPath] = node_entity;
-        std::cerr << " Building Individual FRU "
-                  << "[ " << fruObjectPath << " ] "
-                  << "with entityid [ " << node_entity.entity_type << ","
-                  << node_entity.entity_instance_num << ","
-                  << node_entity.entity_container_id << " ] "
-                  << "Parent :[ " << parent.entity_type << ","
-                  << parent.entity_instance_num << ","
-                  << parent.entity_container_id << " ]\n";
+        error(
+            "Building Individual FRU [FRU_OBJ_PATH] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ] Parent :[ {P_ENTITY_TYP}, {P_ENTITY_NUM}, {P_ENTITY_ID} ]",
+            "FRU_OBJ_PATH", fruObjectPath, "ENTITY_TYP",
+            static_cast<unsigned>(node_entity.entity_type), "ENTITY_NUM",
+            static_cast<unsigned>(node_entity.entity_instance_num), "ENTITY_ID",
+            static_cast<unsigned>(node_entity.entity_container_id),
+            "P_ENTITY_TYP", static_cast<unsigned>(parent.entity_type),
+            "P_ENTITY_NUM", static_cast<unsigned>(parent.entity_instance_num),
+            "P_ENTITY_ID", static_cast<unsigned>(parent.entity_container_id));
         auto recordInfos = parser.getRecordInfo(fruInterface);
 
         // sm00
@@ -597,9 +601,9 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
     }
     catch (const std::exception& e)
     {
-        std::cout << "Config JSONs missing for the item "
-                  << " in concurrent add path "
-                  << "interface type, interface = " << fruInterface << "\n";
+        info(
+            "Config JSONs missing for the item in concurrent add path interface type, interface = {FRU_INTF}",
+            "FRU_INTF", fruInterface);
     }
 #ifdef OEM_IBM
     auto lastLocalRecord = pldm_pdr_find_last_local_record(pdrRepo);
@@ -712,22 +716,24 @@ void FruImpl::reGenerateStatePDR(const std::string& fruObjectPath,
             }
             catch (const InternalFailure& e)
             {
-                std::cerr
-                    << "PDR config directory does not exist or empty, TYPE= "
-                    << (unsigned)pdrType << "PATH= " << dirEntry
-                    << " ERROR=" << e.what() << "\n";
+                error(
+                    "PDR config directory does not exist or empty, TYPE= {PDR_TYP} PATH= {DIR_PATH} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", (unsigned)pdrType, "DIR_PATH",
+                    dirEntry.path().string(), "ERR_EXCEP", e.what());
                 // log an error here
             }
             catch (const Json::exception& e)
             {
-                std::cerr << "Failed parsing PDR JSON file, TYPE= "
-                          << (unsigned)pdrType << " ERROR=" << e.what() << "\n";
+                error(
+                    "Failed parsing PDR JSON file, TYPE= {PDR_TYP} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", (unsigned)pdrType, "ERR_EXCEP", e.what());
                 // log error
             }
             catch (const std::exception& e)
             {
-                std::cerr << "Failed parsing PDR JSON file, TYPE= "
-                          << (unsigned)pdrType << " ERROR=" << e.what() << "\n";
+                error(
+                    "Failed parsing PDR JSON file, TYPE= {PDR_TYP} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", (unsigned)pdrType, "ERR_EXCEP", e.what());
                 // log appropriate error
             }
         }
@@ -865,8 +871,9 @@ void FruImpl::subscribeFruPresence(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "could not subscribe for concurrent maintenance of fru: "
-                  << fruInterface << " error " << e.what() << "\n";
+        error(
+            "could not subscribe for concurrent maintenance of fru: {FRU_INTF} error {ERR_EXCEP}",
+            "FRU_INTF", fruInterface, "ERR_EXCEP", e.what());
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.CMsubscribeFailure",
             pldm::PelSeverity::ERROR);
@@ -966,9 +973,8 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to encode_pldm_pdr_repository_chg_event_data, rc = "
-            << rc << std::endl;
+        error("Failed to encode_pldm_pdr_repository_chg_event_data, rc = {RC}",
+              "RC", static_cast<int>(rc));
         return;
     }
     auto instanceId = requester.getInstanceId(mctp_eid);
@@ -983,8 +989,8 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_platform_event_message_req, rc = " << rc
-                  << std::endl;
+        error("Failed to encode_platform_event_message_req, rc = {RC}", "RC",
+              static_cast<unsigned>(rc));
         return;
     }
     auto platformEventMessageResponseHandler = [](mctp_eid_t /*eid*/,
@@ -992,9 +998,8 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
                                                   size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the PDR repository "
-                         "changed event"
-                      << "\n";
+            error(
+                "Failed to receive response for the PDR repository changed event");
             return;
         }
         uint8_t completionCode{};
@@ -1004,10 +1009,10 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: rc={RC}, cc={CC}",
+                "RC", static_cast<int>(rc), "CC",
+                static_cast<unsigned>(completionCode));
         }
     };
     rc = handler->registerRequest(
@@ -1015,9 +1020,8 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send the PDR repository changed event request "
-                     "after CM"
-                  << "\n";
+        error(
+            "Failed to send the PDR repository changed event request after CM");
     }
 }
 
@@ -1056,10 +1060,10 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 auto statesSize = set.value("size", 0);
                 if (!statesSize)
                 {
-                    std::cerr << "Malformed PDR JSON return "
-                                 "pdrEntry;- no state set "
-                                 "info, TYPE="
-                              << PLDM_STATE_EFFECTER_PDR << "\n";
+                    error(
+                        "Malformed PDR JSON return pdrEntry;- no state set info, TYPE={INFO_TYP}",
+                        "INFO_TYP",
+                        static_cast<unsigned>(PLDM_STATE_EFFECTER_PDR));
                     throw InternalFailure();
                 }
                 pdrSize += sizeof(state_effecter_possible_states) -
@@ -1075,7 +1079,7 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
             if (!pdr)
             {
-                std::cerr << "Failed to get state effecter PDR.\n";
+                error("Failed to get state effecter PDR.");
                 continue;
             }
             pdr->hdr.record_handle = 0;
@@ -1183,9 +1187,9 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr
-                        << "D-Bus object path does not exist, effecter ID: "
-                        << pdr->effecter_id << "\n";
+                    error(
+                        "D-Bus object path does not exist, effecter ID: {EFFECTER_ID}",
+                        "EFFECTER_ID", static_cast<uint16_t>(pdr->effecter_id));
                 }
                 dbusMappings.emplace_back(std::move(dbusMapping));
                 dbusValMaps.emplace_back(std::move(dbusIdToValMap));
@@ -1223,10 +1227,10 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 auto statesSize = set.value("size", 0);
                 if (!statesSize)
                 {
-                    std::cerr << "Malformed PDR JSON return "
-                                 "pdrEntry;- no state set "
-                                 "info, TYPE="
-                              << PLDM_STATE_SENSOR_PDR << "\n";
+                    error(
+                        "Malformed PDR JSON return pdrEntry;- no state set info, TYPE={INFO_TYP}",
+                        "INFO_TYP",
+                        static_cast<unsigned>(PLDM_STATE_SENSOR_PDR));
                     throw InternalFailure();
                 }
                 pdrSize += sizeof(state_sensor_possible_states) -
@@ -1242,7 +1246,7 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
             if (!pdr)
             {
-                std::cerr << "Failed to get state sensor PDR.\n";
+                error("Failed to get state sensor PDR.");
                 continue;
             }
             pdr->hdr.record_handle = 0;
@@ -1362,8 +1366,9 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr << "D-Bus object path does not exist, sensor ID: "
-                              << pdr->sensor_id << "\n";
+                    error(
+                        "D-Bus object path does not exist, sensor ID: {SENSOR_ID}",
+                        "SENSOR_ID", static_cast<uint16_t>(pdr->sensor_id));
                 }
                 dbusMappings.emplace_back(std::move(dbusMapping));
                 dbusValMaps.emplace_back(std::move(dbusIdToValMap));

--- a/libpldmresponder/fru_parser.cpp
+++ b/libpldmresponder/fru_parser.cpp
@@ -1,23 +1,23 @@
 #include "fru_parser.hpp"
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 
+PHOSPHOR_LOG2_USING;
+
 using namespace pldm::responder::dbus;
 
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace fru_parser
 {
-
 using Json = nlohmann::json;
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
@@ -50,8 +50,9 @@ void FruParser::setupDefaultDBusLookup(const fs::path& masterJsonPath)
     auto data = Json::parse(jsonFile, nullptr, false);
     if (data.is_discarded())
     {
-        std::cerr << "Parsing FRU Dbus Lookup Map config file failed, FILE="
-                  << masterJsonPath;
+        error(
+            "Parsing FRU Dbus Lookup Map config file failed, FILE={JSON_PATH}",
+            "JSON_PATH", masterJsonPath.c_str());
         std::abort();
     }
     std::map<Interface, EntityType> defIntfToEntityType;
@@ -66,7 +67,7 @@ void FruParser::setupDefaultDBusLookup(const fs::path& masterJsonPath)
         }
         catch (const std::exception& e)
         {
-            std::cerr << "FRU DBus lookup map format error\n";
+            error("FRU DBus lookup map format error");
             throw InternalFailure();
         }
     }
@@ -118,7 +119,8 @@ void FruParser::setupFruRecordMap(const std::string& dirPath)
         auto data = Json::parse(jsonFile, nullptr, false);
         if (data.is_discarded())
         {
-            std::cerr << "Parsing FRU config file failed, FILE=" << file.path();
+            error("Parsing FRU config file failed, FILE={FILE}", "FILE",
+                  file.path().c_str());
             throw InternalFailure();
         }
 

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -1,5 +1,6 @@
 libpldmresponder_deps = [
   phosphor_dbus_interfaces,
+  phosphor_logging_dep,
   nlohmann_json,
   sdbusplus,
   sdeventplus,

--- a/libpldmresponder/pdr_numeric_effecter.hpp
+++ b/libpldmresponder/pdr_numeric_effecter.hpp
@@ -4,15 +4,16 @@
 
 #include "libpldmresponder/pdr_utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace pdr_numeric_effecter
 {
-
 using Json = nlohmann::json;
 
 static const Json empty{};
@@ -41,7 +42,7 @@ void generateNumericEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
             reinterpret_cast<pldm_numeric_effecter_value_pdr*>(entry.data());
         if (!pdr)
         {
-            std::cerr << "Failed to get numeric effecter PDR.\n";
+            error("Failed to get numeric effecter PDR.");
             continue;
         }
         pdr->hdr.record_handle = 0;
@@ -218,9 +219,10 @@ void generateNumericEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "D-Bus object path " << objectPath
-                      << " does not exist, numeric effecter ID: "
-                      << pdr->effecter_id << " error : " << e.what() << "\n";
+            error(
+                "D-Bus object path {OBJ_PATH} does not exist, numeric effecter ID: {EFFECTER_ID} error : {ERR_EXCEP}",
+                "OBJ_PATH", objectPath.c_str(), "EFFECTER_ID",
+                static_cast<unsigned>(pdr->effecter_id), "ERR_EXCEP", e.what());
         }
         dbusMappings.emplace_back(std::move(dbusMapping));
 

--- a/libpldmresponder/pdr_state_effecter.hpp
+++ b/libpldmresponder/pdr_state_effecter.hpp
@@ -7,15 +7,16 @@
 
 #include <config.h>
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace pdr_state_effecter
 {
-
 using Json = nlohmann::json;
 
 static const Json empty{};
@@ -44,10 +45,9 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
             auto statesSize = set.value("size", 0);
             if (!statesSize)
             {
-                std::cerr << "Malformed PDR JSON return "
-                             "pdrEntry;- no state set "
-                             "info, TYPE="
-                          << PLDM_STATE_EFFECTER_PDR << "\n";
+                error(
+                    "Malformed PDR JSON return pdrEntry;- no state set info, TYPE={PDR_TYP}",
+                    "PDR_TYP", static_cast<unsigned>(PLDM_STATE_EFFECTER_PDR));
                 throw InternalFailure();
             }
             pdrSize += sizeof(state_effecter_possible_states) -
@@ -62,7 +62,7 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
             reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
         if (!pdr)
         {
-            std::cerr << "Failed to get state effecter PDR.\n";
+            error("Failed to get state effecter PDR.");
             continue;
         }
         pdr->hdr.record_handle = 0;
@@ -161,10 +161,11 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
             }
             catch (const std::exception& e)
             {
-                std::cerr << "D-Bus object " << objectPath
-                          << " does not exist, state effecter ID: "
-                          << pdr->effecter_id << " error : " << e.what()
-                          << "\n";
+                error(
+                    "D-Bus object path {OBJ_PATH} does not exist, numeric effecter ID: {EFFECTER_ID} error : {ERR_EXCEP}",
+                    "OBJ_PATH", objectPath.c_str(), "EFFECTER_ID",
+                    static_cast<unsigned>(pdr->effecter_id), "ERR_EXCEP",
+                    e.what());
             }
 
             dbusMappings.emplace_back(std::move(dbusMapping));

--- a/libpldmresponder/pdr_utils.cpp
+++ b/libpldmresponder/pdr_utils.cpp
@@ -5,20 +5,21 @@
 
 #include <config.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <bitset>
 #include <climits>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::pdr;
 
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace pdr_utils
 {
-
 pldm_pdr* Repo::getPdr() const
 {
     return repo;
@@ -83,10 +84,9 @@ StatestoDbusVal populateMapping(const std::string& type, const Json& dBusValues,
     StatestoDbusVal valueMap;
     if (dBusValues.size() != pv.size())
     {
-        std::cerr
-            << "dBusValues size is not equal to pv size, dBusValues Size: "
-            << dBusValues.size() << ", pv Size: " << pv.size() << "\n";
-
+        error(
+            "dBusValues size is not equal to pv size, dBusValues Size: {DBUS_VAL_SIZE}, pv Size: {PV_SIZE}",
+            "DBUS_VAL_SIZE", dBusValues.size(), "PV_SIZE", pv.size());
         return {};
     }
 
@@ -134,8 +134,8 @@ StatestoDbusVal populateMapping(const std::string& type, const Json& dBusValues,
         }
         else
         {
-            std::cerr << "Unknown D-Bus property type, TYPE=" << type.c_str()
-                      << "\n";
+            error("Unknown D-Bus property type, TYPE={TYP}", "TYP",
+                  type.c_str());
             return {};
         }
 
@@ -277,8 +277,8 @@ std::vector<uint8_t> fetchBitMap(const std::vector<std::vector<uint8_t>>& pdrs)
                 tempStream << std::setfill('0') << std::setw(2) << std::hex
                            << byte << " ";
             }
-            std::cout << "Panel:BitMap received: " << tempStream.str()
-                      << std::endl;
+            error("Panel:BitMap received: {RECV_STREAM}", "RECV_STREAM",
+                  tempStream.str());
             if (compEffCount)
             {
                 statesPtr += sizeof(state_effecter_possible_states) +

--- a/libpldmresponder/pdr_utils.hpp
+++ b/libpldmresponder/pdr_utils.hpp
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <filesystem>
@@ -15,6 +16,8 @@
 #include <functional>
 #include <iostream>
 #include <string>
+
+PHOSPHOR_LOG2_USING;
 
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
@@ -98,7 +101,7 @@ inline Json readJson(const std::string& path)
     std::ifstream jsonFile(path);
     if (!jsonFile.is_open())
     {
-        std::cerr << "Error opening PDR JSON file, PATH=" << path << "\n";
+        error("Error opening PDR JSON file, PATH={PDR_JSON}", "PDR_JSON", path);
         return {};
     }
 

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -19,9 +19,13 @@
 
 #include <config.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 using namespace pldm::utils;
 using namespace pldm::responder::pdr;
 using namespace pldm::responder::pdr_utils;
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -68,7 +72,7 @@ void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
 {
     for (const auto& directory : dir)
     {
-        std::cerr << "checking if : " << directory << "exists" << std::endl;
+        error("checking if : {DIR} exists", "DIR", directory.c_str());
         if (!fs::exists(directory))
         {
             return;
@@ -138,23 +142,25 @@ void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
             }
             catch (const InternalFailure& e)
             {
-                std::cerr
-                    << "PDR config directory does not exist or empty, TYPE= "
-                    << pdrType << "PATH= " << dirEntry << " ERROR=" << e.what()
-                    << "\n";
+                error(
+                    "PDR config directory does not exist or empty, TYPE= {PDR_TYP} PATH= {DIR_PATH} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", pdrType, "DIR_PATH", dirEntry.path().string(),
+                    "ERR_EXCEP", e.what());
             }
             catch (const Json::exception& e)
             {
-                std::cerr << "Failed parsing PDR JSON file, TYPE= " << pdrType
-                          << " ERROR=" << e.what() << "\n";
+                error(
+                    "Failed parsing PDR JSON file, TYPE= {PDR_TYP} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", pdrType, "ERR_EXCEP", e.what());
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.Generate.PDRJsonFileParseFail",
                     pldm::PelSeverity::ERROR);
             }
             catch (const std::exception& e)
             {
-                std::cerr << "Failed parsing PDR JSON file, TYPE= " << pdrType
-                          << " ERROR=" << e.what() << "\n";
+                error(
+                    "Failed parsing PDR JSON file, TYPE= {PDR_TYP} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", pdrType, "ERR_EXCEP", e.what());
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.Generate.PDRJsonFileParseFail",
                     pldm::PelSeverity::ERROR);
@@ -311,8 +317,8 @@ Response Handler::getPDR(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error accessing PDR, HANDLE=" << recordHandle
-                  << " ERROR=" << e.what() << "\n";
+        error("Error accessing PDR, HANDLE={REC_HNDL} ERROR={ERR_EXCEP}",
+              "REC_HNDL", recordHandle, "ERR_EXCEP", e.what());
         return CmdHandler::ccOnlyResponse(request, PLDM_ERROR);
     }
     return response;
@@ -554,8 +560,7 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                                        uint8_t /*formatVersion*/, uint8_t tid,
                                        size_t eventDataOffset)
 {
-    std::cerr << "Got a repo change event from TID: " << (unsigned)tid
-              << std::endl;
+    error("Got a repo change event from TID: {TID}", "TID", (unsigned)tid);
     uint8_t eventDataFormat{};
     uint8_t eventDataOperation{};
     uint8_t numberOfChangeRecords{};
@@ -598,8 +603,8 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                 return rc;
             }
 
-            std::cout << "pldmPDRRepositoryChgEvent eventDataOperation : "
-                      << (unsigned)eventDataOperation << std::endl;
+            error("pldmPDRRepositoryChgEvent eventDataOperation : {EVENT_OP}",
+                  "EVENT_OP", (unsigned)eventDataOperation);
 
             if (eventDataOperation == PLDM_RECORDS_ADDED ||
                 eventDataOperation == PLDM_RECORDS_DELETED)
@@ -686,7 +691,8 @@ int Handler::getPDRRecordHandles(const ChangeEntry* changeEntryData,
     }
     for (const auto& i : pdrRecordHandles)
     {
-        std::cerr << "Record handles sent down to BMC: " << i << std::endl;
+        error("Record handles sent down to BMC: {PDR_REC_HNDL}", "PDR_REC_HNDL",
+              static_cast<unsigned>(i));
     }
     return PLDM_SUCCESS;
 }
@@ -865,7 +871,7 @@ bool isOemNumericEffecter(Handler& handler, uint16_t effecterId,
 
     if (numericEffecterPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return false;
     }
 
@@ -923,7 +929,7 @@ bool isOemStateSensor(Handler& handler, uint16_t sensorId,
     getRepoByType(handler.getRepo(), stateSensorPDRs, PLDM_STATE_SENSOR_PDR);
     if (stateSensorPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return false;
     }
 
@@ -950,10 +956,10 @@ bool isOemStateSensor(Handler& handler, uint16_t sensorId,
 
         if (sensorRearmCount > tmpCompSensorCnt)
         {
-            std::cerr << "The requester sent wrong sensorRearm"
-                      << " count for the sensor, SENSOR_ID=" << sensorId
-                      << "SENSOR_REARM_COUNT=" << (uint16_t)sensorRearmCount
-                      << "\n";
+            error(
+                "The requester sent wrong sensorRearm count for the sensor, SENSOR_ID={SENSOR_ID} SENSOR_REARM_COUNT={SENSOR_REARM_COUNT}",
+                "SENSOR_ID", sensorId, "SENSOR_REARM_COUNT",
+                (uint16_t)sensorRearmCount);
             break;
         }
 
@@ -990,7 +996,7 @@ bool isOemStateEffecter(Handler& handler, uint16_t effecterId,
                   PLDM_STATE_EFFECTER_PDR);
     if (stateEffecterPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return false;
     }
 
@@ -1016,9 +1022,10 @@ bool isOemStateEffecter(Handler& handler, uint16_t effecterId,
 
         if (compEffecterCnt > pdr->composite_effecter_count)
         {
-            std::cerr << "The requester sent wrong composite effecter"
-                      << " count for the effecter, EFFECTER_ID=" << effecterId
-                      << "COMP_EFF_CNT=" << (uint16_t)compEffecterCnt << "\n";
+            error(
+                "The requester sent wrong composite effecter count for the effecter, EFFECTER_ID={EFFECTER_ID} COMP_EFF_CNT={COMP_EFF_CNT}",
+                "EFFECTER_ID", effecterId, "COMP_EFF_CNT",
+                (uint16_t)compEffecterCnt);
             return false;
         }
 

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -18,7 +18,11 @@
 
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <map>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -26,7 +30,6 @@ namespace responder
 {
 namespace platform
 {
-
 using generatePDR = std::function<void(
     const pldm::utils::DBusHandler& dBusIntf, const pldm::utils::Json& json,
     pdr_utils::RepoInterface& repo,
@@ -340,7 +343,7 @@ class Handler : public CmdHandler
         getRepoByType(pdrRepo, stateEffecterPDRs, PLDM_STATE_EFFECTER_PDR);
         if (stateEffecterPDRs.empty())
         {
-            std::cerr << "Failed to get record by PDR type\n";
+            error("Failed to get record by PDR type");
             return PLDM_PLATFORM_INVALID_EFFECTER_ID;
         }
 
@@ -361,11 +364,10 @@ class Handler : public CmdHandler
                 pdr->possible_states);
             if (compEffecterCnt > pdr->composite_effecter_count)
             {
-                std::cerr << "The requester sent wrong composite effecter"
-                          << " count for the effecter, EFFECTER_ID="
-                          << (unsigned)effecterId
-                          << "COMP_EFF_CNT=" << (unsigned)compEffecterCnt
-                          << "\n";
+                error(
+                    "The requester sent wrong composite effecter count for the effecter, EFFECTER_ID={EFFECTER_ID} COMP_EFF_CNT={COMP_EFF_CNT}",
+                    "EFFECTER_ID", (unsigned)effecterId, "COMP_EFF_CNT",
+                    (unsigned)compEffecterCnt);
                 return PLDM_ERROR_INVALID_DATA;
             }
             break;
@@ -393,13 +395,12 @@ class Handler : public CmdHandler
                 if (states->possible_states_size < bitfieldIndex ||
                     !(states->states[bitfieldIndex].byte & (1 << bit)))
                 {
-                    std::cerr
-                        << "Invalid state set value, EFFECTER_ID="
-                        << (unsigned)effecterId << " VALUE="
-                        << (unsigned)stateField[currState].effecter_state
-                        << " COMPOSITE_EFFECTER_ID=" << (unsigned)currState
-                        << " DBUS_PATH=" << dbusMappings[currState].objectPath
-                        << "\n";
+                    error(
+                        "Invalid state set value, EFFECTER_ID={EFFECTER_ID} VALUE={VAL} COMPOSITE_EFFECTER_ID={COMP_EFF_ID} DBUS_PATH={DBUS_OBJ_PATH}",
+                        "EFFECTER_ID", (unsigned)effecterId, "VAL",
+                        (unsigned)stateField[currState].effecter_state,
+                        "COMP_EFF_ID", (unsigned)currState, "DBUS_OBJ_PATH",
+                        dbusMappings[currState].objectPath.c_str());
                     rc = PLDM_PLATFORM_SET_EFFECTER_UNSUPPORTED_SENSORSTATE;
                     break;
                 }
@@ -418,12 +419,12 @@ class Handler : public CmdHandler
                     }
                     catch (const std::exception& e)
                     {
-                        std::cerr
-                            << "Error setting property, ERROR=" << e.what()
-                            << " PROPERTY=" << dbusMapping.propertyName
-                            << " INTERFACE="
-                            << dbusMapping.interface << " PATH="
-                            << dbusMapping.objectPath << "\n";
+                        error(
+                            "Error setting property, ERROR={ERR_EXCEP} PROPERTY={DBUS_PROP_NAME} INTERFACE={INTF} PATH={DBUS_OBJ_PATH}",
+                            "ERR_EXCEP", e.what(), "DBUS_PROP_NAME",
+                            dbusMapping.propertyName, "INTF",
+                            dbusMapping.interface, "DBUS_OBJ_PATH",
+                            dbusMapping.objectPath.c_str());
                         return PLDM_ERROR;
                     }
                 }
@@ -438,8 +439,9 @@ class Handler : public CmdHandler
         }
         catch (const std::out_of_range& e)
         {
-            std::cerr << "the effecterId does not exist. effecter id: "
-                      << (unsigned)effecterId << e.what() << '\n';
+            error(
+                "the effecterId does not exist. effecter id: {EFFECTER_ID}, {ERR_EXCEP}",
+                "EFFECTER_ID", (unsigned)effecterId, "ERR_EXCEP", e.what());
         }
 
         return rc;

--- a/libpldmresponder/platform_numeric_effecter.hpp
+++ b/libpldmresponder/platform_numeric_effecter.hpp
@@ -13,8 +13,12 @@
 #include <math.h>
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <map>
 #include <optional>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -22,7 +26,6 @@ namespace responder
 {
 namespace platform_numeric_effecter
 {
-
 /** @brief Function to get the effecter value by PDR factor coefficient, etc.
  *  @param[in] pdr - The structure of pldm_numeric_effecter_value_pdr.
  *  @param[in] effecterValue - effecter value.
@@ -223,7 +226,7 @@ std::pair<int, std::optional<pldm::utils::PropertyValue>>
     }
     else
     {
-        std::cerr << "Wrong field effecterDataSize...\n";
+        error("Wrong field effecterDataSize...");
         return {PLDM_ERROR, {}};
     }
 }
@@ -262,7 +265,7 @@ int setNumericEffecterValueHandler(const DBusInterface& dBusIntf,
                                         PLDM_NUMERIC_EFFECTER_PDR);
     if (numericEffecterPDRs.empty())
     {
-        std::cerr << "The Numeric Effecter PDR repo is empty." << std::endl;
+        error("The Numeric Effecter PDR repo is empty.");
         return PLDM_ERROR;
     }
 
@@ -290,7 +293,7 @@ int setNumericEffecterValueHandler(const DBusInterface& dBusIntf,
 
     if (effecterValueLength != effecterValueArrayLength)
     {
-        std::cerr << "effecter data size is incorrect.\n";
+        error("effecter data size is incorrect.");
         return PLDM_ERROR_INVALID_DATA;
     }
 
@@ -315,16 +318,18 @@ int setNumericEffecterValueHandler(const DBusInterface& dBusIntf,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Error setting property, ERROR=" << e.what()
-                      << " PROPERTY=" << dbusMapping.propertyName
-                      << " INTERFACE=" << dbusMapping.interface << " PATH="
-                      << dbusMapping.objectPath << "\n";
+            error(
+                "Error setting property, ERROR={ERR_EXCEP} PROPERTY={DBUS_PROP} INTERFACE={DBUS_INTF}, PATH={DBUS_OBJ_PATH}",
+                "ERR_EXCEP", e.what(), "DBUS_PROP", dbusMapping.propertyName,
+                "DBUS_INTF", dbusMapping.interface, "DBUS_OBJ_PATH",
+                dbusMapping.objectPath);
             return PLDM_ERROR;
         }
     }
     catch (const std::out_of_range& e)
     {
-        std::cerr << "Unknown effecter ID : " << effecterId << e.what() << '\n';
+        error("Unknown effecter ID : {EFFECTER_ID} , {ERR_EXCEP}",
+              "EFFECTER_ID", effecterId, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 

--- a/libpldmresponder/platform_state_effecter.hpp
+++ b/libpldmresponder/platform_state_effecter.hpp
@@ -10,8 +10,12 @@
 #include "pdr_utils.hpp"
 #include "pldmd/handler.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cstdint>
 #include <map>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -53,7 +57,7 @@ int setStateEffecterStatesHandler(
                   PLDM_STATE_EFFECTER_PDR);
     if (stateEffecterPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return PLDM_PLATFORM_INVALID_EFFECTER_ID;
     }
 
@@ -73,9 +77,9 @@ int setStateEffecterStatesHandler(
             pdr->possible_states);
         if (compEffecterCnt > pdr->composite_effecter_count)
         {
-            std::cerr << "The requester sent wrong composite effecter"
-                      << " count for the effecter, EFFECTER_ID=" << effecterId
-                      << "COMP_EFF_CNT=" << compEffecterCnt << "\n";
+            error(
+                "The requester sent wrong composite effecter count for the effecter, EFFECTER_ID={EFFECTER_ID} COMP_EFF_CNT={COMP_EFF_CNT}",
+                "EFFECTER_ID", effecterId, "COMP_EFF_CNT", compEffecterCnt);
             return PLDM_ERROR_INVALID_DATA;
         }
         break;
@@ -101,12 +105,11 @@ int setStateEffecterStatesHandler(
             if (states->possible_states_size < bitfieldIndex ||
                 !(states->states[bitfieldIndex].byte & (1 << bit)))
             {
-                std::cerr << "Invalid state set value, EFFECTER_ID="
-                          << effecterId
-                          << " VALUE=" << stateField[currState].effecter_state
-                          << " COMPOSITE_EFFECTER_ID=" << currState
-                          << " DBUS_PATH=" << dbusMappings[currState].objectPath
-                          << "\n";
+                error(
+                    "Invalid state set value, EFFECTER_ID={EFFECTER_ID} VALUE={VALUE} COMPOSITE_EFFECTER_ID={COMP_EFFECTER_ID} DBUS_PATH={DBUS_PATH}",
+                    "EFFECTER_ID", effecterId, "VALUE",
+                    stateField[currState].effecter_state, "COMP_EFFECTER_ID",
+                    currState, "DBUS_PATH", dbusMappings[currState].objectPath);
                 rc = PLDM_PLATFORM_SET_EFFECTER_UNSUPPORTED_SENSORSTATE;
                 break;
             }
@@ -124,11 +127,12 @@ int setStateEffecterStatesHandler(
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr
-                        << "Error setting property, ERROR=" << e.what()
-                        << " PROPERTY=" << dbusMapping.propertyName
-                        << " INTERFACE=" << dbusMapping.interface << " PATH="
-                        << dbusMapping.objectPath << "\n";
+                    error(
+                        "Error setting property, ERROR={ERR_EXCEP} PROPERTY={DBUS_PROP} INTERFACE={INTF} PATH={DBUS_OBJ_PATH}",
+                        "ERR_EXCEP", e.what(), "DBUS_PROP",
+                        dbusMapping.propertyName, "DBUS_INTF",
+                        dbusMapping.interface, "DBUS_OBJ_PATH",
+                        dbusMapping.objectPath);
                     return PLDM_ERROR;
                 }
             }
@@ -143,7 +147,8 @@ int setStateEffecterStatesHandler(
     }
     catch (const std::out_of_range& e)
     {
-        std::cerr << "Unknown effecter ID : " << effecterId << e.what() << '\n';
+        error("Unknown effecter ID : {EFFECTER_ID}, {ERR_EXCEP}", "EFFECTER_ID",
+              effecterId, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 

--- a/libpldmresponder/platform_state_sensor.hpp
+++ b/libpldmresponder/platform_state_sensor.hpp
@@ -10,8 +10,12 @@
 #include "pdr_utils.hpp"
 #include "pldmd/handler.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cstdint>
 #include <map>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -66,9 +70,9 @@ uint8_t getStateSensorEventState(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Get StateSensor EventState from dbus Error, interface : "
-                  << dbusMapping.objectPath.c_str()
-                  << " ,exception : " << e.what() << '\n';
+        error(
+            "Get StateSensor EventState from dbus Error, interface : {INTF} ,exception : {ERR_EXCEP}",
+            "INTF", dbusMapping.objectPath.c_str(), "ERR_EXCEP", e.what());
     }
 
     return PLDM_SENSOR_UNKNOWN;
@@ -108,7 +112,7 @@ int getStateSensorReadingsHandler(
     getRepoByType(handler.getRepo(), stateSensorPDRs, PLDM_STATE_SENSOR_PDR);
     if (stateSensorPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return PLDM_PLATFORM_INVALID_SENSOR_ID;
     }
 
@@ -128,9 +132,9 @@ int getStateSensorReadingsHandler(
         compSensorCnt = pdr->composite_sensor_count;
         if (sensorRearmCnt > compSensorCnt)
         {
-            std::cerr << "The requester sent wrong sensorRearm"
-                      << " count for the sensor, SENSOR_ID=" << sensorId
-                      << "SENSOR_REARM_COUNT=" << sensorRearmCnt << "\n";
+            error(
+                "The requester sent wrong sensorRearm count for the sensor, SENSOR_ID={SENSOR_ID} SENSOR_REARM_COUNT={SENSOR_REARM_CNT}",
+                "SENSOR_ID", sensorId, "SENSOR_REARM_CNT", sensorRearmCnt);
             return PLDM_PLATFORM_REARM_UNAVAILABLE_IN_PRESENT_STATE;
         }
 
@@ -198,8 +202,9 @@ int getStateSensorReadingsHandler(
     }
     catch (const std::out_of_range& e)
     {
-        std::cerr << "the sensorId does not exist. sensor id: " << sensorId
-                  << e.what() << '\n';
+        error(
+            "the sensorId does not exist. sensor id: {SENSOR_ID}, {ERR_EXCEP}",
+            "SENSOR_ID", sensorId, "ERR_EXCEP", e.what());
         rc = PLDM_ERROR;
     }
 

--- a/libpldmresponder/test/meson.build
+++ b/libpldmresponder/test/meson.build
@@ -37,6 +37,7 @@ foreach t : tests
                          libpldm_dep,
                          libpldmresponder_dep,
                          libpldmutils,
+			 phosphor_logging_dep,
                          gtest,
                          gmock,
                          nlohmann_json,

--- a/meson.build
+++ b/meson.build
@@ -70,6 +70,7 @@ phosphor_dbus_interfaces = dependency('phosphor-dbus-interfaces')
 sdbusplus = dependency('sdbusplus')
 sdeventplus = dependency('sdeventplus')
 stdplus = dependency('stdplus')
+phosphor_logging_dep = dependency('phosphor-logging')
 
 if cpp.has_header('nlohmann/json.hpp')
   nlohmann_json = declare_dependency()
@@ -142,6 +143,7 @@ libpldmutils = library(
   dependencies: [
       libpldm_dep,
       phosphor_dbus_interfaces,
+      phosphor_logging_dep,
       nlohmann_json,
       sdbusplus,
   ],
@@ -176,6 +178,7 @@ deps = [
   libpldmutils,
   nlohmann_json,
   phosphor_dbus_interfaces,
+  phosphor_logging_dep,
   sdbusplus,
   sdeventplus,
   stdplus,

--- a/oem/ibm/host-bmc/host_lamp_test.cpp
+++ b/oem/ibm/host-bmc/host_lamp_test.cpp
@@ -9,13 +9,16 @@
 #include "common/types.hpp"
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
 namespace led
 {
-
 bool HostLampTest::asserted() const
 {
     return sdbusplus::xyz::openbmc_project::Led::server::Group::asserted();
@@ -91,9 +94,9 @@ uint16_t HostLampTest::getEffecterID()
 
     if (stateEffecterPDRs.empty())
     {
-        std::cerr
-            << "Lamp Test: The state set PDR can not be found, entityType = "
-            << entityType << std::endl;
+        error(
+            "Lamp Test: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+            "ENTITY_TYP", entityType);
         return effecterID;
     }
 
@@ -123,8 +126,8 @@ void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_set_state_effecter_states_req, rc = "
-                  << rc << std::endl;
+        error("Failed to encode_set_state_effecter_states_req, rc = {RC}", "RC",
+              static_cast<int>(rc));
         return;
     }
 
@@ -133,8 +136,8 @@ void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
                                                        size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the Set State "
-                         "Effecter States\n";
+            error(
+                "Failed to receive response for the Set State Effecter States");
             return;
         }
 
@@ -145,10 +148,9 @@ void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Failed to decode_set_state_effecter_states_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_set_state_effecter_states_resp: rc={RC}, cc={CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
 
@@ -158,8 +160,7 @@ void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
         std::move(setStateEffecterStatesResponseHandler));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to send the the Set State Effecter States request\n";
+        error("Failed to send the the Set State Effecter States request");
     }
 
     return;

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -15,11 +15,15 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <thread>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -32,7 +36,6 @@ extern SocketWriteStatus socketWriteStatus;
 namespace fs = std::filesystem;
 namespace dma
 {
-
 /** @struct AspeedXdmaOp
  *
  * Structure representing XDMA operation
@@ -66,9 +69,9 @@ int DMA::transferHostDataToSocket(int fd, uint32_t length, uint64_t address)
     if (dmaFd < 0)
     {
         rc = -errno;
-        std::cerr
-            << "transferHostDataToSocket : Failed to open the XDMA device, RC="
-            << rc << "\n";
+        error(
+            "transferHostDataToSocket : Failed to open the XDMA device, RC={RC}",
+            "RC", rc);
         return rc;
     }
 
@@ -79,9 +82,9 @@ int DMA::transferHostDataToSocket(int fd, uint32_t length, uint64_t address)
     if (MAP_FAILED == vgaMemDump)
     {
         rc = -errno;
-        std::cerr
-            << "transferHostDataToSocket : Failed to mmap the XDMA device, RC="
-            << rc << "\n";
+        error(
+            "transferHostDataToSocket : Failed to mmap the XDMA device, RC={RC}",
+            "RC", rc);
         return rc;
     }
 
@@ -94,18 +97,17 @@ int DMA::transferHostDataToSocket(int fd, uint32_t length, uint64_t address)
     if (rc < 0)
     {
         rc = -errno;
-        std::cerr
-            << "transferHostDataToSocket : Failed to execute the DMA operation, RC="
-            << rc << " ADDRESS=" << address << " LENGTH=" << length << "\n";
+        error(
+            "transferHostDataToSocket : Failed to execute the DMA operation, RC={RC} ADDRESS={ADDR} LENGTH={LEN}",
+            "RC", rc, "ADDR", address, "LEN", length);
         if (rc != -EINTR)
         {
             munmap(vgaMemDump, pageAlignedLength);
         }
         else
         {
-            std::cerr
-                << "transferHostDataToSocket : Received interrupt during dump DMA transfer. Skipping Unmap"
-                << std::endl;
+            error(
+                "transferHostDataToSocket : Received interrupt during dump DMA transfer. Skipping Unmap");
         }
         return rc;
     }
@@ -136,9 +138,7 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
         }
         else
         {
-            std::cerr
-                << "Received interrupt during DMA transfer. Skipping Unmap"
-                << std::endl;
+            error("Received interrupt during DMA transfer. Skipping Unmap");
         }
     };
 
@@ -147,8 +147,8 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
     if (dmaFd < 0)
     {
         rc = -errno;
-        std::cerr << "transferDataHost : Failed to open the XDMA device, RC="
-                  << rc << "\n";
+        error("transferDataHost : Failed to open the XDMA device, RC={RC}",
+              "RC", rc);
         return rc;
     }
 
@@ -160,8 +160,8 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
     if (MAP_FAILED == vgaMem)
     {
         rc = -errno;
-        std::cerr << "transferDataHost : Failed to mmap the XDMA device, RC="
-                  << rc << "\n";
+        error("transferDataHost : Failed to mmap the XDMA device, RC={RC}",
+              "RC", rc);
         return rc;
     }
 
@@ -172,9 +172,9 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
         rc = lseek(fd, offset, SEEK_SET);
         if (rc == -1)
         {
-            std::cerr << "transferDataHost upstream : lseek failed, ERROR="
-                      << errno << ", UPSTREAM=" << upstream
-                      << ", OFFSET=" << offset << "\n";
+            error(
+                "transferDataHost upstream : lseek failed, ERROR={ERR}, UPSTREAM={UP_STRM}, OFFSET={KEY2}",
+                "ERR", errno, "UP_STRM", upstream, "OFFSET", offset);
             return rc;
         }
 
@@ -186,17 +186,17 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
         rc = read(fd, buffer.data(), length);
         if (rc == -1)
         {
-            std::cerr << "transferDataHost upstream : file read failed, ERROR="
-                      << errno << ", UPSTREAM=" << upstream
-                      << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
+            error(
+                "transferDataHost upstream : file read failed, ERROR={ERR}, UPSTREAM={UP_STRM}, LENGTH={LEN}, OFFSET={OFFSET}",
+                "ERR", errno, "UP_STRM", upstream, "LEN", length, "OFFSET",
+                offset);
             return rc;
         }
         if (rc != static_cast<int>(length))
         {
-            std::cerr
-                << "transferDataHost upstream : mismatch between number of characters to read and "
-                << "the length read, LENGTH=" << length << " COUNT=" << rc
-                << "\n";
+            error(
+                "transferDataHost upstream : mismatch between number of characters to read and the length read, LENGTH={LEN} COUNT={RC}",
+                "LEN", length, "RC", rc);
             return -1;
         }
         memcpy(static_cast<char*>(vgaMemPtr.get()), buffer.data(),
@@ -212,10 +212,9 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
     if (rc < 0)
     {
         rc = -errno;
-        std::cerr
-            << "transferDataHost : Failed to execute the DMA operation, RC="
-            << rc << " UPSTREAM=" << upstream << " ADDRESS=" << address
-            << " LENGTH=" << length << "\n";
+        error(
+            "transferDataHost : Failed to execute the DMA operation, RC={RC} UPSTREAM={UP_STRM} ADDRESS={ADDR} LENGTH={LEN}",
+            "RC", rc, "UP_STRM", upstream, "ADDR", address, "LEN", length);
         return rc;
     }
 
@@ -224,18 +223,18 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
         rc = lseek(fd, offset, SEEK_SET);
         if (rc == -1)
         {
-            std::cerr << "transferDataHost downstream : lseek failed, ERROR="
-                      << errno << ", UPSTREAM=" << upstream
-                      << ", OFFSET=" << offset << "\n";
+            error(
+                "transferDataHost downstream : lseek failed, ERROR={ERR}, UPSTREAM={UP_STRM}, OFFSET={OFFSET}",
+                "ERR", errno, "UP_STRM", upstream, "OFFSET", offset);
             return rc;
         }
         rc = write(fd, static_cast<const char*>(vgaMemPtr.get()), length);
         if (rc == -1)
         {
-            std::cerr
-                << "transferDataHost downstream : file write failed, ERROR="
-                << errno << ", UPSTREAM=" << upstream << ", LENGTH=" << length
-                << ", OFFSET=" << offset << "\n";
+            error(
+                "transferDataHost downstream : file write failed, ERROR={ERR}, UPSTREAM={UP_STRM}, LENGTH={LEN}, OFFSET={OFFSET}",
+                "ERR", errno, "UP_STRM", upstream, "LEN", length, "OFFSET",
+                offset);
             return rc;
         }
     }
@@ -247,7 +246,6 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
 
 namespace oem_ibm
 {
-
 Response Handler::readFileIntoMemory(const pldm_msg* request,
                                      size_t payloadLength)
 {
@@ -280,8 +278,9 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "File handle does not exist in the file table, HANDLE="
-                  << fileHandle << "\n";
+        error(
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
+            "FILE_HNDL", fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -290,7 +289,8 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
 
     if (!fs::exists(value.fsPath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle << "\n";
+        error("File does not exist, HANDLE={FILE_HNDL}", "FILE_HNDL",
+              fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -300,8 +300,8 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
     auto fileSize = fs::file_size(value.fsPath);
     if (offset >= fileSize)
     {
-        std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                  << " FILE_SIZE=" << fileSize << "\n";
+        error("Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+              "OFFSET", offset, "FILE_SIZE", fileSize);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_DATA_OUT_OF_RANGE, 0, responsePtr);
@@ -315,8 +315,8 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
 
     if ((length == 0) && (length % dma::minSize))
     {
-        std::cerr << "Read length is not a multiple of DMA minSize, LENGTH="
-                  << length << "\n";
+        error("Read length is not a multiple of DMA minSize, LENGTH={LEN}",
+              "LEN", length);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_ERROR_INVALID_LENGTH, 0, responsePtr);
@@ -354,8 +354,8 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
 
     if ((length == 0) || (length % dma::minSize))
     {
-        std::cerr << "Write length is not a multiple of DMA minSize, LENGTH="
-                  << length << "\n";
+        error("Write length is not a multiple of DMA minSize, LENGTH={LEN}",
+              "LEN", length);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_ERROR_INVALID_LENGTH, 0, responsePtr);
@@ -372,8 +372,9 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "File handle does not exist in the file table, HANDLE="
-                  << fileHandle << "\n";
+        error(
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
+            "FILE_HNDL", fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -382,7 +383,8 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
 
     if (!fs::exists(value.fsPath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle << "\n";
+        error("File does not exist, HANDLE={FILE_HNDL}", "FILE_HNDL",
+              fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -392,8 +394,8 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
     auto fileSize = fs::file_size(value.fsPath);
     if (offset >= fileSize)
     {
-        std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                  << " FILE_SIZE=" << fileSize << "\n";
+        error("Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+              "OFFSET", offset, "FILE_SIZE", fileSize);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_DATA_OUT_OF_RANGE, 0, responsePtr);
@@ -497,8 +499,10 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "File handle does not exist in the file table, HANDLE="
-                  << fileHandle << "\n";
+        error(
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
+            "FILE_HNDL", fileHandle);
+
         encode_read_file_resp(request->hdr.instance_id,
                               PLDM_INVALID_FILE_HANDLE, length, responsePtr);
         return response;
@@ -506,7 +510,8 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
 
     if (!fs::exists(value.fsPath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle << "\n";
+        error("File does not exist, HANDLE={FILE_HNDL}", "FILE_HNDL",
+              fileHandle);
         encode_read_file_resp(request->hdr.instance_id,
                               PLDM_INVALID_FILE_HANDLE, length, responsePtr);
         return response;
@@ -515,8 +520,8 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
     auto fileSize = fs::file_size(value.fsPath);
     if (offset >= fileSize)
     {
-        std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                  << " FILE_SIZE=" << fileSize << "\n";
+        error("Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+              "OFFSET", offset, "FILE_SIZE", fileSize);
         encode_read_file_resp(request->hdr.instance_id, PLDM_DATA_OUT_OF_RANGE,
                               length, responsePtr);
         return response;
@@ -578,8 +583,9 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "File handle does not exist in the file table, HANDLE="
-                  << fileHandle << "\n";
+        error(
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
+            "FILE_HNDL", fileHandle);
         encode_write_file_resp(request->hdr.instance_id,
                                PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
         return response;
@@ -587,7 +593,8 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
 
     if (!fs::exists(value.fsPath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle << "\n";
+        error("File does not exist, HANDLE={FILE_HNDL}", "FILE_HNDL",
+              fileHandle);
         encode_write_file_resp(request->hdr.instance_id,
                                PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
         return response;
@@ -596,8 +603,8 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
     auto fileSize = fs::file_size(value.fsPath);
     if (offset >= fileSize)
     {
-        std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                  << " FILE_SIZE=" << fileSize << "\n";
+        error("Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+              "OFFSET", offset, "FILE_SIZE", fileSize);
         encode_write_file_resp(request->hdr.instance_id, PLDM_DATA_OUT_OF_RANGE,
                                0, responsePtr);
         return response;
@@ -649,8 +656,8 @@ Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
     }
     if ((length == 0) || (length % dma::minSize))
     {
-        std::cerr << "Length is not a multiple of DMA minSize, LENGTH="
-                  << length << "\n";
+        error("Length is not a multiple of DMA minSize, LENGTH={LEN}", "LEN",
+              length);
         encode_rw_file_by_type_memory_resp(request->hdr.instance_id, cmd,
                                            PLDM_ERROR_INVALID_LENGTH, 0,
                                            responsePtr);
@@ -664,7 +671,7 @@ Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={LEN}", "LEN", fileType);
         encode_rw_file_by_type_memory_resp(request->hdr.instance_id, cmd,
                                            PLDM_INVALID_FILE_TYPE, 0,
                                            responsePtr);
@@ -729,7 +736,7 @@ Response Handler::writeFileByType(const pldm_msg* request, size_t payloadLength)
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         encode_rw_file_by_type_resp(request->hdr.instance_id,
                                     PLDM_WRITE_FILE_BY_TYPE,
                                     PLDM_INVALID_FILE_TYPE, 0, responsePtr);
@@ -778,7 +785,7 @@ Response Handler::readFileByType(const pldm_msg* request, size_t payloadLength)
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         encode_rw_file_by_type_resp(request->hdr.instance_id,
                                     PLDM_READ_FILE_BY_TYPE,
                                     PLDM_INVALID_FILE_TYPE, 0, responsePtr);
@@ -898,7 +905,7 @@ Response Handler::newFileAvailable(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 
@@ -942,7 +949,7 @@ Response Handler::fileAckWithMetaData(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 
@@ -988,7 +995,7 @@ Response Handler::newFileAvailableWithMetaData(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -18,9 +18,13 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <filesystem>
 #include <iostream>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -28,7 +32,6 @@ namespace responder
 {
 namespace dma
 {
-
 // The minimum data size of dma transfer in bytes
 constexpr uint32_t minSize = 16;
 
@@ -117,7 +120,8 @@ Response transferAll(DMAInterface* intf, uint8_t command, fs::path& path,
     int file = open(path.string().c_str(), flags);
     if (file == -1)
     {
-        std::cerr << "File does not exist, path = " << path.string() << "\n";
+        error("File does not exist, path = {FILE_PATH}", "FILE_PATH",
+              path.string());
         encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
                                    responsePtr);
         return response;

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
 
 #include <exception>
@@ -26,6 +27,8 @@
 #include <fstream>
 #include <iostream>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -83,15 +86,16 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
         fileExists = fs::exists(path);
         if (!fileExists)
         {
-            std::cerr << "File does not exist. PATH=" << path.c_str() << "\n";
+            error("File does not exist. PATH={PATH}", "PATH", path.c_str());
             return PLDM_INVALID_FILE_HANDLE;
         }
 
         size_t fileSize = fs::file_size(path);
         if (offset >= fileSize)
         {
-            std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                      << " FILE_SIZE=" << fileSize << "\n";
+            error(
+                "Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+                "OFFSET", offset, "FILE_SIZE", fileSize);
             return PLDM_DATA_OUT_OF_RANGE;
         }
         if (offset + length > fileSize)
@@ -116,8 +120,7 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
     int file = open(path.string().c_str(), flags);
     if (file == -1)
     {
-        std::cerr << "File does not exist, PATH = " << path.string() << "\n";
-        ;
+        error("File does not exist, PATH = {PATH}", "PATH", path.string());
         return PLDM_ERROR;
     }
     pldm::utils::CustomFD fd(file);
@@ -200,16 +203,16 @@ int FileHandler::readFile(const std::string& filePath, uint32_t offset,
 {
     if (!fs::exists(filePath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle
-                  << " PATH=" << filePath.c_str() << "\n";
+        error("File does not exist, HANDLE={FILE_HNDLE} PATH={PATH}",
+              "FILE_HNDLE", fileHandle, "PATH", filePath.c_str());
         return PLDM_INVALID_FILE_HANDLE;
     }
 
     size_t fileSize = fs::file_size(filePath);
     if (offset >= fileSize)
     {
-        std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                  << " FILE_SIZE=" << fileSize << "\n";
+        error("Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+              "OFFSET", offset, "FILE_SIZE", fileSize);
         return PLDM_DATA_OUT_OF_RANGE;
     }
 
@@ -229,7 +232,8 @@ int FileHandler::readFile(const std::string& filePath, uint32_t offset,
         stream.read(filePos, length);
         return PLDM_SUCCESS;
     }
-    std::cerr << "Unable to read file, FILE=" << filePath.c_str() << "\n";
+    error("Unable to read file, FILE={FILE_PATH}", "FILE_PATH",
+          filePath.c_str());
     return PLDM_ERROR;
 }
 

--- a/oem/ibm/libpldmresponder/file_io_type_cert.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.cpp
@@ -7,7 +7,11 @@
 
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -15,7 +19,6 @@ using namespace utils;
 
 namespace responder
 {
-
 constexpr auto certObjPath = "/xyz/openbmc_project/certs/ca/entry/";
 constexpr auto certEntryIntf = "xyz.openbmc_project.Certs.Entry";
 static constexpr auto certFilePath = "/var/lib/ibm/bmcweb/";
@@ -29,8 +32,9 @@ int CertHandler::writeFromMemory(uint32_t offset, uint32_t length,
     auto it = certMap.find(certType);
     if (it == certMap.end())
     {
-        std::cerr << "CertHandler::writeFromMemory:file for type " << certType
-                  << " doesn't exist\n";
+        error(
+            "CertHandler::writeFromMemory:file for type {CERT_TYP} doesn't exist",
+            "CERT_TYP", certType);
         return PLDM_ERROR;
     }
 
@@ -71,9 +75,9 @@ int CertHandler::readIntoMemory(uint32_t offset, uint32_t& length,
 int CertHandler::read(uint32_t offset, uint32_t& length, Response& response,
                       oem_platform::Handler* /*oemPlatformHandler*/)
 {
-    std::cout
-        << "CertHandler::read:Read file response for Sign CSR, file handle: "
-        << fileHandle << std::endl;
+    info(
+        "CertHandler::read:Read file response for Sign CSR, file handle: {FILE_HNDL}",
+        "FILE_HNDL", fileHandle);
     std::string filePath = certFilePath;
     filePath += "CSR_" + std::to_string(fileHandle);
     if (certType != PLDM_FILE_TYPE_CERT_SIGNING_REQUEST)
@@ -95,8 +99,8 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
     auto it = certMap.find(certType);
     if (it == certMap.end())
     {
-        std::cerr << "CertHandler::write:file for type " << certType
-                  << " doesn't exist\n";
+        error("CertHandler::write:file for type {CERT_TYP} doesn't exist",
+              "CERT_TYP", certType);
         return PLDM_ERROR;
     }
 
@@ -104,15 +108,17 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
     int rc = lseek(fd, offset, SEEK_SET);
     if (rc == -1)
     {
-        std::cerr << "CertHandler::write:lseek failed, ERROR=" << errno
-                  << ", OFFSET=" << offset << "\n";
+        error(
+            "CertHandler::write:lseek failed, ERROR={ERR_EXCEP}, OFFSET={OFFSET}",
+            "ERR_EXCEP", errno, "OFFSET", offset);
         return PLDM_ERROR;
     }
     rc = ::write(fd, buffer, length);
     if (rc == -1)
     {
-        std::cerr << "CertHandler::write:file write failed, ERROR=" << errno
-                  << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
+        error(
+            "CertHandler::write:file write failed, ERROR={ERR_EXCEP}, LENGTH={LEN}, OFFSET={OFFSET}",
+            "ERR_EXCEP", errno, "LEN", length, "OFFSET", offset);
         return PLDM_ERROR;
     }
     length = rc;
@@ -152,10 +158,9 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "CertHandler::write:failed to set Client certificate, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "CertHandler::write:failed to set Client certificate, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
             PropertyValue valueStatus{
@@ -165,18 +170,17 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
                                           certEntryIntf, "Status", "string"};
             try
             {
-                std::cout
-                    << "CertHandler::write:Client cert write, status: complete. File handle: "
-                    << fileHandle << std::endl;
+                info(
+                    "CertHandler::write:Client cert write, status: complete. File handle: {FILE_HNDL}",
+                    "FILE_HNDL", fileHandle);
                 pldm::utils::DBusHandler().setDbusProperty(dbusMappingStatus,
                                                            valueStatus);
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "CertHandler::write:failed to set status property of certicate entry, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "CertHandler::write:failed to set status property of certicate entry, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
             fs::remove(filePath);
@@ -188,17 +192,16 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
                                     certEntryIntf, "Status", "string"};
             try
             {
-                std::cout
-                    << "CertHandler::write:Client cert write, status: Bad CSR. File handle: "
-                    << fileHandle << std::endl;
+                info(
+                    "CertHandler::write:Client cert write, status: Bad CSR. File handle: {FILE_HNDLE}",
+                    "FILE_HNDLE", fileHandle);
                 pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "CertHandler::write:failed to set status property of certicate entry, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "CertHandler::write:failed to set status property of certicate entry, {ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
         }
@@ -221,9 +224,9 @@ int CertHandler::newFileAvailable(uint64_t length)
     }
     if (certType == PLDM_FILE_TYPE_SIGNED_CERT)
     {
-        std::cout
-            << "CertHandler::newFileAvailable:new file available client cert file, file handle: "
-            << fileHandle << std::endl;
+        info(
+            "CertHandler::newFileAvailable:new file available client cert file, file handle: {FILE_HNDLE}",
+            "FILE_HNDLE", fileHandle);
         fileFd = open(
             (filePath + "ClientCert_" + std::to_string(fileHandle)).c_str(),
             flags, S_IRUSR | S_IWUSR);
@@ -235,9 +238,9 @@ int CertHandler::newFileAvailable(uint64_t length)
     }
     if (fileFd == -1)
     {
-        std::cerr
-            << "CertHandler::newFileAvailable:failed to open file for type "
-            << certType << " ERROR=" << errno << "\n";
+        error(
+            "CertHandler::newFileAvailable:failed to open file for type {CERT_TYP} ERROR={ERR_EXCEP}",
+            "CERT_TYP", certType, "ERR_EXCEP", errno);
         return PLDM_ERROR;
     }
     certMap.emplace(certType, std::tuple(fileFd, length));
@@ -266,18 +269,18 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
     {
         if (certSigningStatus == PLDM_SUCCESS)
         {
-            std::cerr
-                << "CertHandler::newFileAvailableWithMetaData:new file available client cert file, file handle: "
-                << fileHandle << std::endl;
+            error(
+                "CertHandler::newFileAvailableWithMetaData:new file available client cert file, file handle: {FILE_HNDL}",
+                "FILE_HNDL", fileHandle);
             fileFd = open(
                 (filePath + "ClientCert_" + std::to_string(fileHandle)).c_str(),
                 flags, S_IRUSR | S_IWUSR);
         }
         else if (certSigningStatus == PLDM_INVALID_CERT_DATA)
         {
-            std::cerr
-                << "newFileAvailableWithMetaData:client cert file Invalid data, file handle: "
-                << fileHandle << std::endl;
+            error(
+                "newFileAvailableWithMetaData:client cert file Invalid data, file handle: {FILE_HNDL}",
+                "FILE_HNDL", fileHandle);
             DBusMapping dbusMapping{certObjPath + std::to_string(fileHandle),
                                     certEntryIntf, "Status", "string"};
             std::string status = "xyz.openbmc_project.Certs.Entry.State.BadCSR";
@@ -288,10 +291,9 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "newFileAvailableWithMetaData:Failed to set status property of certicate entry, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "newFileAvailableWithMetaData:Failed to set status property of certicate entry, ERROR= {ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
         }
@@ -303,9 +305,9 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
     }
     if (fileFd == -1)
     {
-        std::cerr
-            << "newFileAvailableWithMetaData:failed to open file for type "
-            << certType << " ERROR=" << errno << "\n";
+        error(
+            "newFileAvailableWithMetaData:failed to open file for type {CERT_TYP} ERROR={ERR_EXCEP}",
+            "CERT_TYP", certType, "ERR_EXCEP", errno);
         return PLDM_ERROR;
     }
     certMap.emplace(certType, std::tuple(fileFd, length));
@@ -340,10 +342,9 @@ int CertHandler::fileAckWithMetaData(uint8_t fileStatus,
         }
         catch (const std::exception& e)
         {
-            std::cerr
-                << "CertHandler::fileAckWithMetaData:Failed to set status property of certicate entry, "
-                   "ERROR="
-                << e.what() << "\n";
+            error(
+                "CertHandler::fileAckWithMetaData:Failed to set status property of certicate entry, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -11,6 +11,7 @@
 #include <systemd/sd-bus.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Dump/NewDump/server.hpp>
 
@@ -19,6 +20,7 @@
 #include <iostream>
 #include <type_traits>
 
+PHOSPHOR_LOG2_USING;
 using namespace pldm::responder::utils;
 using namespace pldm::utils;
 
@@ -111,9 +113,9 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
 
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Failure with GetManagedObjects in findDumpObjPath call, ERROR="
-            << e.what() << "\n";
+        error(
+            "Failure with GetManagedObjects in findDumpObjPath call, ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.findDumpObjPath.GetManagedObjectsFail",
             pldm::PelSeverity::WARNING);
@@ -140,18 +142,16 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
                         if (fileHandle == dumpId)
                         {
                             curResDumpEntryPath = object.first.str;
-                            std::cout << "Hit the object path match for"
-                                      << curResDumpEntryPath << std::endl;
+                            info("Hit the object path match for {CUR_RES_DUMP}",
+                                 "CUR_RES_DUMP", curResDumpEntryPath);
                             return curResDumpEntryPath;
                         }
                     }
                     else
                     {
-                        std::cerr
-                            << "Invalid SourceDumpId in curResDumpEntryPath "
-                            << curResDumpEntryPath
-                            << " but continuing with next entry for a match..."
-                            << std::endl;
+                        error(
+                            "Invalid SourceDumpId in curResDumpEntryPath {CUR_RES_DUMP} but continuing with next entry for a match...",
+                            "CUR_RES_DUMP", curResDumpEntryPath);
                     }
                 }
             }
@@ -165,7 +165,7 @@ int DumpHandler::newFileAvailable(uint64_t length)
     static constexpr auto dumpInterface = "xyz.openbmc_project.Dump.NewDump";
     auto& bus = pldm::utils::DBusHandler::getBus();
 
-    std::cout << "newFileAvailable for NewDump" << std::endl;
+    info("newFileAvailable for NewDump");
     auto notifyObjPath = dumpObjPath;
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
     {
@@ -185,9 +185,9 @@ int DumpHandler::newFileAvailable(uint64_t length)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to notify"
-                     " a new dump request using newFileAvailable, ERROR="
-                  << e.what() << "\n";
+        error(
+            "failed to make a d-bus call to notify a new dump request using newFileAvailable, ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.newFileAvailable.NewDumpNotifyFail",
             pldm::PelSeverity::ERROR);
@@ -205,8 +205,9 @@ void DumpHandler::resetOffloadUri()
         return;
     }
 
-    std::cout << "DumpHandler::resetOffloadUri path = " << path.c_str()
-              << " fileHandle = " << fileHandle << std::endl;
+    info("DumpHandler::resetOffloadUri path = {PATH} fileHandle = {FILE_HNDLE}",
+         "PATH", path.c_str(), "FILE_HNDL", fileHandle);
+
     PropertyValue offloadUriValue{""};
     DBusMapping dbusMapping{path, dumpEntry, "OffloadUri", "string"};
     try
@@ -216,8 +217,8 @@ void DumpHandler::resetOffloadUri()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to set the OffloadUri dbus property, ERROR="
-                  << e.what() << "\n";
+        error("Failed to set the OffloadUri dbus property, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.fileAck.DumpEntryOffloadUriSetFail",
             pldm::PelSeverity::ERROR);
@@ -228,8 +229,8 @@ void DumpHandler::resetOffloadUri()
 std::string DumpHandler::getOffloadUri(uint32_t fileHandle)
 {
     auto path = findDumpObjPath(fileHandle);
-    std::cout << "DumpHandler::getOffloadUri path = " << path.c_str()
-              << " fileHandle = " << fileHandle << std::endl;
+    info("DumpHandler::getOffloadUri path = {PATH} fileHandle = {FILE_HNDL}",
+         "PATH", path.c_str(), "FILE_HNDL", fileHandle);
     if (path.empty())
     {
         return {};
@@ -242,12 +243,12 @@ std::string DumpHandler::getOffloadUri(uint32_t fileHandle)
         socketInterface =
             pldm::utils::DBusHandler().getDbusProperty<std::string>(
                 path.c_str(), "OffloadUri", dumpEntry);
-        std::cout << "socketInterface=" << socketInterface << std::endl;
+        info("socketInterface={SOCKET_INTF}", "SOCKET_INTF", socketInterface);
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to get the OffloadUri d-bus property, ERROR="
-                  << e.what() << "\n";
+        error("Failed to get the OffloadUri d-bus property, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.DumpHandler.getOffloadUriFail",
             pldm::PelSeverity::ERROR);
@@ -267,9 +268,7 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
         {
             sock = -errno;
             close(DumpHandler::fd);
-            std::cerr
-                << "DumpHandler::writeFromMemory: setupUnixSocket() failed"
-                << std::endl;
+            error("DumpHandler::writeFromMemory: setupUnixSocket() failed");
             std::remove(socketInterface.c_str());
             resetOffloadUri();
             return PLDM_ERROR;
@@ -279,9 +278,8 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
         auto rc = transferFileDataToSocket(DumpHandler::fd, length, address);
         if (rc < 0)
         {
-            std::cerr
-                << "DumpHandler::writeFromMemory: transferFileDataToSocket failed"
-                << std::endl;
+            error(
+                "DumpHandler::writeFromMemory: transferFileDataToSocket failed");
             if (DumpHandler::fd >= 0)
             {
                 close(DumpHandler::fd);
@@ -296,9 +294,8 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
 
     if (socketWriteStatus == Error)
     {
-        std::cerr
-            << "DumpHandler::writeFromMemory: Error while writing to Unix socket"
-            << std::endl;
+        error(
+            "DumpHandler::writeFromMemory: Error while writing to Unix socket");
         if (DumpHandler::fd >= 0)
         {
             close(DumpHandler::fd);
@@ -317,9 +314,7 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
     auto rc = transferFileDataToSocket(DumpHandler::fd, length, address);
     if (rc < 0)
     {
-        std::cerr
-            << "DumpHandler::writeFromMemory: transferFileDataToSocket failed"
-            << std::endl;
+        error("DumpHandler::writeFromMemory: transferFileDataToSocket failed");
         if (DumpHandler::fd >= 0)
         {
             close(DumpHandler::fd);
@@ -336,13 +331,13 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
 int DumpHandler::write(const char* buffer, uint32_t, uint32_t& length,
                        oem_platform::Handler* /*oemPlatformHandler*/)
 {
-    std::cout << "Enter DumpHandler::write length = " << length
-              << " DumpHandler::fd = " << DumpHandler::fd << std::endl;
+    info(
+        "Enter DumpHandler::write length = {LEN} DumpHandler::fd ={FILE_DESCRIPTION}",
+        "LEN", length, "FILE_DESCRIPTION", DumpHandler::fd);
 
     if (socketWriteStatus == Error)
     {
-        std::cerr << "DumpHandler::write: Error while writing to Unix socket"
-                  << std::endl;
+        error("DumpHandler::write: Error while writing to Unix socket");
         close(fd);
         auto socketInterface = getOffloadUri(fileHandle);
         std::remove(socketInterface.c_str());
@@ -357,8 +352,7 @@ int DumpHandler::write(const char* buffer, uint32_t, uint32_t& length,
     writeToUnixSocket(DumpHandler::fd, buffer, length);
     if (socketWriteStatus == Error)
     {
-        std::cerr << "DumpHandler::write: Error while writing to Unix socket"
-                  << std::endl;
+        error("DumpHandler::write: Error while writing to Unix socket");
         close(fd);
         auto socketInterface = getOffloadUri(fileHandle);
         std::remove(socketInterface.c_str());
@@ -376,7 +370,7 @@ int DumpHandler::fileAck(uint8_t fileStatus)
     {
         if (fileStatus != PLDM_SUCCESS)
         {
-            std::cerr << "Failue in resource dump file ack" << std::endl;
+            error("Failue in resource dump file ack");
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.fileAck.ResourceDumpFileAckFail",
                 PelSeverity::INFORMATIONAL);
@@ -391,10 +385,9 @@ int DumpHandler::fileAck(uint8_t fileStatus)
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "Failure in setting Progress as OperationStatus.Failed"
-                       "in fileAck, ERROR="
-                    << e.what() << "\n";
+                error(
+                    "Failure in setting Progress as OperationStatus.Failed in fileAck, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
             }
         }
 
@@ -430,10 +423,9 @@ int DumpHandler::fileAck(uint8_t fileStatus)
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr << "Failed to make a d-bus call to DUMP "
-                                 "manager to reset source dump id of "
-                              << path.c_str() << ", with ERROR=" << e.what()
-                              << "\n";
+                    error(
+                        "Failed to make a d-bus call to DUMP manager to reset source dump id of {PATH}, with ERROR={ERR_EXCEP}",
+                        "PATH", path.c_str(), "ERR_EXCEP", e.what());
                     pldm::utils::reportError(
                         "xyz.openbmc_project.PLDM.Error.fileAck.SourceDumpIdResetFail",
                         pldm::PelSeverity::ERROR);
@@ -451,9 +443,9 @@ int DumpHandler::fileAck(uint8_t fileStatus)
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "Failed to make a d-bus method to delete the dump entry "
-                    << path.c_str() << ", with ERROR=" << e.what() << "\n";
+                error(
+                    "Failed to make a d-bus method to delete the dump entry {PATH}, with ERROR={ERR_EXCEP}",
+                    "PATH", path.c_str(), "ERR_EXCEP", e.what());
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.fileAck.DumpEntryDeleteFail",
                     pldm::PelSeverity::ERROR);
@@ -478,9 +470,9 @@ int DumpHandler::fileAck(uint8_t fileStatus)
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "Failed to set the Offloaded dbus property to true, ERROR="
-                    << e.what() << "\n";
+                error(
+                    "Failed to set the Offloaded dbus property to true, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.fileAck.DumpEntryOffloadedSetFail",
                     pldm::PelSeverity::ERROR);
@@ -528,9 +520,9 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t& length,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to fetch the filepath of the dump entry"
-                      << std::hex << fileHandle << ", error = " << e.what()
-                      << "\n";
+            error(
+                "Failed to fetch the filepath of the dump entry {FILE_HNDLE}, ERROR={ERR_EXCEP}",
+                "FILE_HNDLE", lg2::hex, fileHandle, "ERR_EXCEP", e.what());
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.readIntoMemory.GetFilepathFail",
                 pldm::PelSeverity::ERROR);
@@ -564,9 +556,9 @@ int DumpHandler::read(uint32_t offset, uint32_t& length, Response& response,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to fetch the filepath of the dump entry"
-                      << std::hex << fileHandle << ", error = " << e.what()
-                      << "\n";
+            error(
+                "Failed to fetch the filepath of the dump entry {FILE_HNDLE}, ERROR={ERR_EXCEP}",
+                "FILE_HNDL", lg2::hex, fileHandle, "ERR_EXCEP", e.what());
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.read.GetFilepathFail",
                 pldm::PelSeverity::ERROR);
@@ -596,8 +588,9 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         pldm::utils::PropertyValue value =
             "com.ibm.Dump.Entry.Resource.HostResponse.Success";
 
-        std::cout << "fileAckWithMetaData with token: " << metaDataValue1
-                  << " and status: " << metaDataValue2 << std::endl;
+        info(
+            "fileAckWithMetaData with token: {META_DATA_VAL1} and status: {META_DATA_VAL2}",
+            "META_DATA_VAL1", metaDataValue1, "META_DATA_VAL2", metaDataValue2);
         if (statusCode == DumpRequestStatus::ResourceSelectorInvalid)
         {
             value =
@@ -647,17 +640,15 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr
-                << "failed to set DumpRequestStatus property for resource dump entry, "
-                   "ERROR="
-                << e.what() << "\n";
+            error(
+                "failed to set DumpRequestStatus property for resource dump entry, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
 
         if (statusCode != DumpRequestStatus::Success)
         {
-            std::cerr << "Failue in resource dump file ack with metadata"
-                      << std::endl;
+            error("Failue in resource dump file ack with metadata");
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.fileAck.ResourceDumpFileAckWithMetaDataFail",
                 pldm::PelSeverity::INFORMATIONAL);
@@ -673,10 +664,9 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "Failure in setting Progress as OperationStatus.Failed"
-                       "in fileAckWithMetaData, ERROR="
-                    << e.what() << "\n";
+                error(
+                    "Failure in setting Progress as OperationStatus.Failed in fileAckWithMetaData, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
             }
         }
 
@@ -700,9 +690,9 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "Failed to set the Offloaded dbus property to true, ERROR="
-                    << e.what() << "\n";
+                error(
+                    "Failed to set the Offloaded dbus property to true, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.fileAckWithMetaData.DumpEntryOffloadedSetFail",
                     pldm::PelSeverity::ERROR);
@@ -730,8 +720,8 @@ int DumpHandler::newFileAvailableWithMetaData(uint64_t length,
     static constexpr auto dumpInterface = "xyz.openbmc_project.Dump.NewDump";
     auto& bus = pldm::utils::DBusHandler::getBus();
 
-    std::cout << "newFileAvailableWithMetaData for NewDump with token :"
-              << metaDataValue1 << std::endl;
+    info("newFileAvailableWithMetaData for NewDump with token :{META_DATA_VAL}",
+         "META_DATA_VAL", metaDataValue1);
     auto notifyObjPath = dumpObjPath;
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
     {
@@ -754,10 +744,9 @@ int DumpHandler::newFileAvailableWithMetaData(uint64_t length,
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "failed to make a d-bus call to notify"
-               " a new dump request using newFileAvailableWithMetaData, ERROR="
-            << e.what() << "\n";
+        error(
+            "failed to make a d-bus call to notify a new dump request using newFileAvailableWithMetaData, ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.newFileAvailableWithMetaData.NewDumpNotifyFail",
             pldm::PelSeverity::ERROR);

--- a/oem/ibm/libpldmresponder/file_io_type_lic.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.cpp
@@ -7,7 +7,11 @@
 
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -19,7 +23,6 @@ const std::vector<Json> emptyJsonList{};
 
 namespace responder
 {
-
 static constexpr auto codFilePath = "/var/lib/ibm/cod/";
 static constexpr auto licFilePath = "/var/lib/pldm/license/";
 constexpr auto newLicenseFile = "new_license.bin";
@@ -34,8 +37,8 @@ int LicenseHandler::updateBinFileAndLicObjs(const fs::path& newLicJsonFilePath)
     auto dataNew = Json::parse(jsonFileNew, nullptr, false);
     if (dataNew.is_discarded())
     {
-        std::cerr << "Parsing the new license json file failed, FILE="
-                  << newLicJsonFilePath << "\n";
+        error("Parsing the new license json file failed, FILE={NEW_LIC_JSON}",
+              "NEW_LIC_JSON", newLicJsonFilePath.c_str());
         throw InternalFailure();
     }
 
@@ -46,8 +49,7 @@ int LicenseHandler::updateBinFileAndLicObjs(const fs::path& newLicJsonFilePath)
     rc = createOrUpdateLicenseObjs();
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "createOrUpdateLicenseObjs failed with rc= " << rc
-                  << " \n";
+        error("createOrUpdateLicenseObjs failed with rc= {RC}", "RC", rc);
         return rc;
     }
     return PLDM_SUCCESS;
@@ -69,8 +71,8 @@ int LicenseHandler::writeFromMemory(
                               std::ios::out | std::ios::binary);
     if (!licJsonFile)
     {
-        std::cerr << "license json file create error: " << newLicJsonFilePath
-                  << std::endl;
+        error("license json file create error: {NEW_LIC_JSON}", "NEW_LIC_JSON",
+              newLicJsonFilePath.c_str());
         return -1;
     }
 
@@ -78,7 +80,7 @@ int LicenseHandler::writeFromMemory(
         transferFileData(newLicJsonFilePath, false, offset, length, address);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "transferFileData failed with rc= " << rc << " \n";
+        error("transferFileData failed with rc= {RC}", "RC", rc);
         return rc;
     }
 
@@ -87,8 +89,7 @@ int LicenseHandler::writeFromMemory(
         rc = updateBinFileAndLicObjs(newLicJsonFilePath);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "updateBinFileAndLicObjs failed with rc= " << rc
-                      << " \n";
+            error("updateBinFileAndLicObjs failed with rc= {RC}", "RC", rc);
             return rc;
         }
     }
@@ -107,8 +108,8 @@ int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,
                               std::ios::out | std::ios::binary | std::ios::app);
     if (!licJsonFile)
     {
-        std::cerr << "license json file create error: " << newLicJsonFilePath
-                  << std::endl;
+        error("license json file create error: {NEW_LIC_JSON}", "NEW_LIC_JSON",
+              newLicJsonFilePath.c_str());
         return -1;
     }
 
@@ -121,7 +122,7 @@ int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,
     updateBinFileAndLicObjs(newLicJsonFilePath);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "updateBinFileAndLicObjs failed with rc= " << rc << " \n";
+        error("updateBinFileAndLicObjs failed with rc= {RC}", "RC", rc);
         return rc;
     }
 
@@ -178,9 +179,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -195,9 +196,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -212,9 +213,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -229,9 +230,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -246,9 +247,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -263,9 +264,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -280,9 +281,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -4,15 +4,18 @@
 
 #include "file_io_by_type.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <filesystem>
 #include <sstream>
 #include <string>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
 namespace responder
 {
-
 namespace fs = std::filesystem;
 
 using MarkerLIDremainingSize = uint64_t;
@@ -148,8 +151,8 @@ class LidHandler : public FileHandler
         auto fd = open(lidPath.c_str(), flags, S_IRUSR);
         if (fd == -1)
         {
-            std::cerr << "Could not open file for writing  " << lidPath.c_str()
-                      << "\n";
+            error("Could not open file for writing {LID_PATH}", "LID_PATH",
+                  lidPath.c_str());
             return PLDM_ERROR;
         }
         close(fd);
@@ -157,7 +160,7 @@ class LidHandler : public FileHandler
         rc = transferFileData(lidPath, false, offset, length, address);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "writeFileFromMemory failed with rc= " << rc << " \n";
+            error("writeFileFromMemory failed with rc= {RC}", "RC", rc);
             return rc;
         }
         if (lidType == PLDM_FILE_TYPE_LID_MARKER)
@@ -225,8 +228,9 @@ class LidHandler : public FileHandler
             size_t fileSize = fs::file_size(lidPath);
             if (offset > fileSize)
             {
-                std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                          << " FILE_SIZE=" << fileSize << "\n";
+                error(
+                    "Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+                    "OFFSET", offset, "FILE_SIZE", fileSize);
                 return PLDM_DATA_OUT_OF_RANGE;
             }
         }
@@ -235,28 +239,30 @@ class LidHandler : public FileHandler
             flags = O_WRONLY | O_CREAT | O_TRUNC | O_SYNC;
             if (offset > 0)
             {
-                std::cerr << "Offset is non zero in a new file \n";
+                error("Offset is non zero in a new file");
                 return PLDM_DATA_OUT_OF_RANGE;
             }
         }
         auto fd = open(lidPath.c_str(), flags, S_IRUSR);
         if (fd == -1)
         {
-            std::cerr << "could not open file " << lidPath.c_str() << "\n";
+            error("could not open file {LID_PATH}", "LID_PATH",
+                  lidPath.c_str());
             return PLDM_ERROR;
         }
         rc = lseek(fd, offset, SEEK_SET);
         if (rc == -1)
         {
-            std::cerr << "lseek failed, ERROR=" << errno
-                      << ", OFFSET=" << offset << "\n";
+            error("lseek failed, ERROR={ERR}, OFFSET={OFFSET}", "ERR", errno,
+                  "OFFSET", offset);
             return PLDM_ERROR;
         }
         rc = ::write(fd, buffer, length);
         if (rc == -1)
         {
-            std::cerr << "file write failed, ERROR=" << errno
-                      << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
+            error(
+                "file write failed, ERROR={ERR}, LENGTH={LEN}, OFFSET={OFFSET}",
+                "ERR", errno, "LEN", length, "OFFSET", offset);
             return PLDM_ERROR;
         }
         else if (rc == static_cast<int>(length))

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -12,6 +12,7 @@
 #include <systemd/sd-bus.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
 
@@ -21,16 +22,16 @@
 #include <iostream>
 #include <vector>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace responder
 {
-
 using namespace sdbusplus::xyz::openbmc_project::Logging::server;
 
 namespace detail
 {
-
 /**
  * @brief Finds the Entry::Level value for the severity of the PEL
  *        passed in.
@@ -83,7 +84,8 @@ Entry::Level getEntryLevelFromPEL(const std::string& pelFileName)
         }
         else
         {
-            std::cerr << "Unable to open PEL file " << pelFileName << "\n";
+            error("Unable to open PEL file {PEL_FILE_NAME}", "PEL_FILE_NAME",
+                  pelFileName);
         }
     }
 
@@ -115,8 +117,9 @@ int PelHandler::readIntoMemory(uint32_t offset, uint32_t& length,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "GetPEL D-Bus call failed, PEL id = 0x" << std::hex
-                  << fileHandle << ", error = " << e.what() << "\n";
+        error(
+            "GetPEL D-Bus call failed, PEL id = 0x{FILE_HNDL}, error ={ERR_EXCEP}",
+            "FILE_HNDL", lg2::hex, fileHandle, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -144,13 +147,14 @@ int PelHandler::read(uint32_t offset, uint32_t& length, Response& response,
         off_t fileSize = lseek(fd, 0, SEEK_END);
         if (fileSize == -1)
         {
-            std::cerr << "file seek failed";
+            error("file seek failed");
             return PLDM_ERROR;
         }
         if (offset >= fileSize)
         {
-            std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                      << " FILE_SIZE=" << fileSize << std::endl;
+            error(
+                "Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+                "OFFSET", offset, "FILE_SIZE", fileSize);
             return PLDM_DATA_OUT_OF_RANGE;
         }
         if (offset + length > fileSize)
@@ -160,7 +164,7 @@ int PelHandler::read(uint32_t offset, uint32_t& length, Response& response,
         auto rc = lseek(fd, offset, SEEK_SET);
         if (rc == -1)
         {
-            std::cerr << "file seek failed";
+            error("file seek failed");
             return PLDM_ERROR;
         }
         size_t currSize = response.size();
@@ -170,21 +174,22 @@ int PelHandler::read(uint32_t offset, uint32_t& length, Response& response,
         rc = ::read(fd, filePos, length);
         if (rc == -1)
         {
-            std::cerr << "file read failed";
+            error("file read failed");
             return PLDM_ERROR;
         }
         if (rc != length)
         {
-            std::cerr << "mismatch between number of characters to read and "
-                      << "the length read, LENGTH=" << length << " COUNT=" << rc
-                      << std::endl;
+            error(
+                "mismatch between number of characters to read and the length read, LENGTH={LEN} COUNT={COUNT}",
+                "LEN", length, "COUNT", rc);
             return PLDM_ERROR;
         }
     }
     catch (const std::exception& e)
     {
-        std::cerr << "GetPEL D-Bus call failed on PEL ID 0x" << std::hex
-                  << fileHandle << ", error = " << e.what() << "\n";
+        error(
+            "GetPEL D-Bus call failed on PEL ID 0x{FILE_HNDL}, error ={ERR_EXCEP}",
+            "FILE_HNDL", lg2::hex, fileHandle, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;
@@ -198,8 +203,8 @@ int PelHandler::writeFromMemory(uint32_t offset, uint32_t length,
     int fd = mkstemp(tmpFile);
     if (fd == -1)
     {
-        std::cerr << "failed to create a temporary pel, ERROR=" << errno
-                  << "\n";
+        error("failed to create a temporary pel, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", errno);
         return PLDM_ERROR;
     }
     close(fd);
@@ -230,8 +235,9 @@ int PelHandler::fileAck(uint8_t /*fileStatus*/)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "HostAck D-Bus call failed on PEL ID 0x" << std::hex
-                  << fileHandle << ", error = " << e.what() << "\n";
+        error(
+            "HostAck D-Bus call failed on PEL ID 0x{FILE_HNDL}, error ={ERR_EXCEP}",
+            "FILE_HNDL", lg2::hex, fileHandle, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -264,8 +270,8 @@ int PelHandler::storePel(std::string&& pelFileName)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to PEL daemon, ERROR="
-                  << e.what() << "\n";
+        error("failed to make a d-bus call to PEL daemon, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -279,7 +285,7 @@ int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
 
     if (offset > 0)
     {
-        std::cerr << "Offset is non zero \n";
+        error("Offset is non zero");
         return PLDM_ERROR;
     }
 
@@ -287,8 +293,8 @@ int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
     auto fd = mkstemp(tmpFile);
     if (fd == -1)
     {
-        std::cerr << "failed to create a temporary pel, ERROR=" << errno
-                  << "\n";
+        error("failed to create a temporary pel, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", errno);
         return PLDM_ERROR;
     }
 
@@ -306,8 +312,9 @@ int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
 
     if (rc == -1)
     {
-        std::cerr << "file write failed, ERROR=" << errno
-                  << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
+        error(
+            "file write failed, ERROR={ERR_EXCEP}, LENGTH={LEN}, OFFSET={OFFSET}",
+            "ERR_EXCEP", errno, "LEN", length, "ERR_EXCEP", offset);
         fs::remove(tmpFile);
         return PLDM_ERROR;
     }
@@ -318,8 +325,8 @@ int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
         rc = storePel(path.string());
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "save PEL failed, ERROR = " << rc
-                      << "tmpFile = " << tmpFile << "\n";
+            error("save PEL failed, ERROR = {RC} tmpFile = {TMP_FILE}", "KEY0",
+                  rc, "TMP_FILE", tmpFile);
         }
     }
 

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
@@ -2,12 +2,14 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace responder
 {
-
 int ProgressCodeHandler::setRawBootProperty(
     const std::tuple<uint64_t, std::vector<uint8_t>>& progressCodeBuffer)
 {
@@ -35,8 +37,9 @@ int ProgressCodeHandler::setRawBootProperty(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to host-postd daemon, ERROR="
-                  << e.what() << "\n";
+        error(
+            "failed to make a d-bus call to host-postd daemon, ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
@@ -7,7 +7,11 @@
 
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 typedef uint8_t byte;
 
@@ -39,8 +43,9 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Get keyword error from dbus interface : "
-                  << keywrdInterface << " ERROR= " << e.what() << std::endl;
+        error(
+            "Get keyword error from dbus interface : {INTF} ERROR= {ERR_EXCEP}",
+            "INTF", keywrdInterface, "ERR_EXCEP", e.what());
     }
 
     auto keywrdSize = std::get<std::vector<byte>>(keywrd).size();
@@ -65,8 +70,8 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
     keywrdFile.open(keywrdFilePath, std::ios::out | std::ofstream::binary);
     if (!keywrdFile)
     {
-        std::cerr << "VPD keyword file open error: " << keywrdFilePath
-                  << " errno: " << errno << std::endl;
+        error("VPD keyword file open error: {KEYWRD_PATH} errno: {ERR}",
+              "KEYWRD_PATH", keywrdFilePath, "ERR", errno);
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.readKeywordHandler.keywordFileOpenError",
             pldm::PelSeverity::ERROR);
@@ -76,8 +81,8 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
                      keywrdSize);
     if (keywrdFile.bad())
     {
-        std::cerr << "Error while writing to file: " << keywrdFilePath
-                  << std::endl;
+        error("Error while writing to file: {KEYWRD_PATH}", "KEYWRD_PATH",
+              keywrdFilePath);
     }
     keywrdFile.close();
 
@@ -85,8 +90,8 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
     fs::remove(keywrdFilePath);
     if (rc)
     {
-        std::cerr << "Read error for keyword file with size: " << keywrdSize
-                  << std::endl;
+        error("Read error for keyword file with size: {KEYWRD_SIZE}",
+              "KEYWRD_SIZE", keywrdSize);
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.readKeywordHandler.keywordFileReadError",
             pldm::PelSeverity::ERROR);

--- a/oem/ibm/libpldmresponder/file_table.cpp
+++ b/oem/ibm/libpldmresponder/file_table.cpp
@@ -2,30 +2,31 @@
 
 #include "libpldm/utils.h"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <fstream>
 #include <iostream>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace filetable
 {
-
 FileTable::FileTable(const std::string& fileTableConfigPath)
 {
     std::ifstream jsonFile(fileTableConfigPath);
     if (!jsonFile.is_open())
     {
-        std::cerr << "File table config file does not exist, FILE="
-                  << fileTableConfigPath.c_str() << "\n";
+        error("File table config file does not exist, FILE={FILE_TABLE_CONF}",
+              "FILE_TABLE_CONF", fileTableConfigPath.c_str());
         return;
     }
 
     auto data = Json::parse(jsonFile, nullptr, false);
     if (data.is_discarded())
     {
-        std::cerr << "Parsing config file failed"
-                  << "\n";
+        error("Parsing config file failed");
         return;
     }
 

--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -1,12 +1,15 @@
 #include "fru_oem_ibm.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace responder
 {
 namespace oem_ibm_fru
 {
-
 void pldm::responder::oem_ibm_fru::Handler::setFruHandler(
     pldm::responder::fru::Handler* handler)
 {
@@ -151,8 +154,8 @@ void Handler::dbus_map_update(const std::string& adapterObjPath,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To set " << propertyName << "property"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed To set {PROP_NAME} property ERROR={ERR_EXCEP}",
+              "PROP_NAME", propertyName, "ERR_EXCEP", e.what());
     }
 }
 
@@ -170,15 +173,14 @@ void Handler::setFruPresence(const std::string& adapterObjPath)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to set the present property"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed to set the present property ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 }
 
 void Handler::setFirmwareUAK(std::vector<uint8_t> data)
 {
-    std::cout << "Got a SetFRURecordTable cmd from host to set the firmware UAK"
-              << std::endl;
+    info("Got a SetFRURecordTable cmd from host to set the firmware UAK");
     static constexpr auto uakObjPath = "/com/ibm/VPD/Manager";
     static constexpr auto uakInterface = "com.ibm.VPD.Manager";
 
@@ -200,8 +202,8 @@ void Handler::setFirmwareUAK(std::vector<uint8_t> data)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a DBus call to VPD manager, ERROR="
-                  << e.what() << "\n";
+        error("failed to make a DBus call to VPD manager, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return;
     }
 }

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -8,11 +8,15 @@
 
 #include <arpa/inet.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Dump/NewDump/server.hpp>
 
 #include <exception>
 #include <fstream>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 using namespace utils;
@@ -73,7 +77,7 @@ int CodeUpdate::setCurrentBootSide(const std::string& currSide)
 
 int CodeUpdate::setNextBootSide(const std::string& nextSide)
 {
-    std::cout << "setNextBootSide, nextSide=" << nextSide << std::endl;
+    info("setNextBootSide, nextSide={NXT_SIDE}", "NXT_SIDE", nextSide);
     pldm_boot_side_data pldmBootSideData = readBootSideFile();
     currBootSide =
         (pldmBootSideData.current_boot_side == "Perm" ? Pside : Tside);
@@ -82,19 +86,19 @@ int CodeUpdate::setNextBootSide(const std::string& nextSide)
     std::string objPath{};
     if (nextBootSide == currBootSide)
     {
-        std::cout << "Current bootside is same as next boot side,\n"
-                  << "setting priority of running version 0" << std::endl;
+        info("Current bootside is same as next boot side");
+        info("setting priority of running version 0");
         objPath = runningVersion;
     }
     else
     {
-        std::cout << "Current bootside is not same as next boot side,\n"
-                  << "setting priority of non running version 0" << std::endl;
+        info("Current bootside is not same as next boot side");
+        info("setting priority of non running version 0");
         objPath = nonRunningVersion;
     }
     if (objPath.empty())
     {
-        std::cerr << "no nonRunningVersion present \n";
+        error("no nonRunningVersion present");
         return PLDM_PLATFORM_INVALID_STATE_VALUE;
     }
 
@@ -125,8 +129,9 @@ int CodeUpdate::setNextBootSide(const std::string& nextSide)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to set the next boot side to " << objPath.c_str()
-                  << " ERROR=" << e.what() << "\n";
+        error(
+            "failed to set the next boot side to {OBJ_PATH} ERROR={ERR_EXCEP}",
+            "OBJ_PATH", objPath.c_str(), "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
     writeBootSideFile(pldmBootSideData);
@@ -149,8 +154,8 @@ int CodeUpdate::setRequestedApplyTime()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To set RequestedApplyTime property "
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed To set RequestedApplyTime property ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         rc = PLDM_ERROR;
     }
     return rc;
@@ -172,8 +177,8 @@ int CodeUpdate::setRequestedActivation()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To set RequestedActivation property"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed To set RequestedActivation property ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         rc = PLDM_ERROR;
     }
     return rc;
@@ -240,13 +245,15 @@ void CodeUpdate::setVersions()
         else
         {
             pldm_boot_side_data pldmBootSideData = readBootSideFile();
+            std::string runningVers;
+            runningVers = pldmBootSideData.running_version_object;
             if (pldmBootSideData.running_version_object != runningPath)
             {
-                std::cout << "BMC have booted with the new image runningPath="
-                          << runningPath << std::endl;
-                std::cout << "Previous Image was: "
-                          << pldmBootSideData.running_version_object
-                          << std::endl;
+                info(
+                    "BMC have booted with the new image runningPath={RUNN_PATH}",
+                    "RUNN_PATH", runningPath.c_str());
+                info("Previous Image was: {RUNN_VERS}", "RUNN_VERS",
+                     runningVers);
                 auto current_boot_side =
                     (pldmBootSideData.current_boot_side == "Temp" ? "Perm"
                                                                   : "Temp");
@@ -262,9 +269,9 @@ void CodeUpdate::setVersions()
             }
             else
             {
-                std::cout
-                    << "BMC have booted with the previous image runningPath="
-                    << pldmBootSideData.running_version_object << std::endl;
+                info(
+                    "BMC have booted with the previous image runningPath={RUNN_PATH}",
+                    "RUNN_PATH", runningVers);
                 pldm_boot_side_data pldmBootSideData = readBootSideFile();
                 pldmBootSideData.next_boot_side =
                     pldmBootSideData.current_boot_side;
@@ -283,9 +290,9 @@ void CodeUpdate::setVersions()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to Object Mapper "
-                     "Association, ERROR="
-                  << e.what() << "\n";
+        error(
+            "failed to make a d-bus call to Object Mapper Association, ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         if (retrySetVersion < maxVersionRetry)
         {
             retrySetVersion++;
@@ -310,142 +317,175 @@ void CodeUpdate::setVersions()
                 msg.read(iface, props);
                 processPriorityChangeNotification(props);
             }));
-    fwUpdateMatcher.push_back(std::make_unique<sdbusplus::bus::match::match>(
-        pldm::utils::DBusHandler::getBus(),
-        "interface='org.freedesktop.DBus.ObjectManager',type='signal',"
-        "member='InterfacesAdded',path='/xyz/openbmc_project/software'",
-        [this](sdbusplus::message::message& msg) {
-            DBusInterfaceAdded interfaces;
-            sdbusplus::message::object_path path;
-            msg.read(path, interfaces);
+    fwUpdateMatcher.push_back(
+        std::make_unique<sdbusplus::bus::match::match>(
+            pldm::utils::DBusHandler::getBus(),
+            "interface='org.freedesktop.DBus.ObjectManager',type='signal',"
+            "member='InterfacesAdded',path='/xyz/openbmc_project/software'",
+            [this](sdbusplus::message::message& msg) {
+                DBusInterfaceAdded interfaces;
+                sdbusplus::message::object_path path;
+                msg.read(path, interfaces);
 
-            for (auto& interface : interfaces)
-            {
-                if (interface.first ==
-                    "xyz.openbmc_project.Software.Activation")
+                for (auto& interface : interfaces)
                 {
-                    auto imageInterface =
-                        "xyz.openbmc_project.Software.Activation";
-                    auto imageObjPath = path.str.c_str();
-
-                    try
+                    if (interface.first ==
+                        "xyz.openbmc_project.Software.Activation")
                     {
-                        nonRunningVersion = path.str;
+                        auto imageInterface =
+                            "xyz.openbmc_project.Software.Activation";
+                        auto imageObjPath = path.str.c_str();
 
-                        if (isCodeUpdateInProgress())
+                        try
                         {
-                            std::cout << "Inband Code update is InProgress\n";
-                            // Inband update
-                            newImageId = path.str;
-                            if (!imageActivationMatch)
+                            nonRunningVersion = path.str;
+
+                            if (isCodeUpdateInProgress())
                             {
-                                imageActivationMatch = std::make_unique<
-                                    sdbusplus::bus::match::match>(
-                                    pldm::utils::DBusHandler::getBus(),
-                                    propertiesChanged(newImageId,
-                                                      "xyz.openbmc_project."
-                                                      "Software.Activation"),
-                                    [this](sdbusplus::message::message& msg) {
-                                        DbusChangedProps props;
-                                        std::string iface;
-                                        msg.read(iface, props);
-                                        const auto itr =
-                                            props.find("Activation");
-                                        if (itr != props.end())
-                                        {
-                                            PropertyValue value = itr->second;
-                                            auto propVal =
-                                                std::get<std::string>(value);
-                                            if (propVal ==
-                                                "xyz.openbmc_project.Software."
-                                                "Activation.Activations.Active")
-                                            {
-                                                std::cout
-                                                    << "Received Active signal, Sending "
-                                                    << "success on End update sensor event "
-                                                    << "to PHYP\n";
-                                                CodeUpdateState state =
-                                                    CodeUpdateState::END;
-                                                setCodeUpdateProgress(false);
-                                                auto sensorId =
-                                                    getFirmwareUpdateSensor();
-                                                sendStateSensorEvent(
-                                                    sensorId,
-                                                    PLDM_STATE_SENSOR_STATE, 0,
-                                                    uint8_t(state),
-                                                    uint8_t(CodeUpdateState::
-                                                                START));
-                                                newImageId.clear();
-                                                imageActivationMatch.reset();
-                                            }
-                                            else if (propVal ==
-                                                         "xyz.openbmc_project."
-                                                         "Software.Activation."
-                                                         "Activations.Failed" ||
-                                                     propVal ==
-                                                         "xyz.openbmc_"
-                                                         "project.Software."
-                                                         "Activation."
-                                                         "Activations."
-                                                         "Invalid")
-                                            {
-                                                std::cout
-                                                    << "Image activation Failed or image "
-                                                    << "Invalid, sending Failure on End "
-                                                    << "update to PHYP\n";
-                                                CodeUpdateState state =
-                                                    CodeUpdateState::FAIL;
-                                                setCodeUpdateProgress(false);
-                                                auto sensorId =
-                                                    getFirmwareUpdateSensor();
-                                                sendStateSensorEvent(
-                                                    sensorId,
-                                                    PLDM_STATE_SENSOR_STATE, 0,
-                                                    uint8_t(state),
-                                                    uint8_t(CodeUpdateState::
-                                                                START));
-                                                newImageId.clear();
-                                                imageActivationMatch.reset();
-                                            }
-                                        }
-                                    });
+                                info("Inband Code update is InProgress");
+                                // Inband update
+                                newImageId = path.str;
+                                if (!imageActivationMatch)
+                                {
+                                    imageActivationMatch =
+                                        std::make_unique<sdbusplus::
+                                                             bus::
+                                                                 match::
+                                                                     match>(pldm::utils::
+                                                                                DBusHandler::
+                                                                                    getBus(),
+                                                                            propertiesChanged(
+                                                                                newImageId,
+                                                                                "xyz.openbmc_project."
+                                                                                "Software.Activation"),
+                                                                            [this](
+                                                                                sdbusplus::message::
+                                                                                    message&
+                                                                                        msg) {
+                                                                                DbusChangedProps
+                                                                                    props;
+                                                                                std::string
+                                                                                    iface;
+                                                                                msg.read(
+                                                                                    iface,
+                                                                                    props);
+                                                                                const auto itr =
+                                                                                    props
+                                                                                        .find(
+                                                                                            "Activation");
+                                                                                if (itr !=
+                                                                                    props
+                                                                                        .end())
+                                                                                {
+                                                                                    PropertyValue
+                                                                                        value =
+                                                                                            itr->second;
+                                                                                    auto propVal =
+                                                                                        std::get<
+                                                                                            std::
+                                                                                                string>(
+                                                                                            value);
+                                                                                    if (propVal ==
+                                                                                        "xyz.openbmc_project.Software."
+                                                                                        "Activation.Activations.Active")
+                                                                                    {
+                                                                                        info(
+                                                                                            "Received Active signal, Sending success on End update sensor event to PHYP");
+                                                                                        CodeUpdateState
+                                                                                            state = CodeUpdateState::
+                                                                                                END;
+                                                                                        setCodeUpdateProgress(
+                                                                                            false);
+                                                                                        auto sensorId =
+                                                                                            getFirmwareUpdateSensor();
+                                                                                        sendStateSensorEvent(
+                                                                                            sensorId,
+                                                                                            PLDM_STATE_SENSOR_STATE,
+                                                                                            0,
+                                                                                            uint8_t(
+                                                                                                state),
+                                                                                            uint8_t(
+                                                                                                CodeUpdateState::
+                                                                                                    START));
+                                                                                        newImageId
+                                                                                            .clear();
+                                                                                        imageActivationMatch
+                                                                                            .reset();
+                                                                                    }
+                                                                                    else if (
+                                                                                        propVal ==
+                                                                                            "xyz.openbmc_project."
+                                                                                            "Software.Activation."
+                                                                                            "Activations.Failed" ||
+                                                                                        propVal ==
+                                                                                            "xyz.openbmc_"
+                                                                                            "project.Software."
+                                                                                            "Activation."
+                                                                                            "Activations."
+                                                                                            "Invalid")
+                                                                                    {
+                                                                                        info(
+                                                                                            "Image activation Failed or image Invalid, sending Failure on End update to PHYP");
+                                                                                        CodeUpdateState
+                                                                                            state = CodeUpdateState::
+                                                                                                FAIL;
+                                                                                        setCodeUpdateProgress(
+                                                                                            false);
+                                                                                        auto sensorId =
+                                                                                            getFirmwareUpdateSensor();
+                                                                                        sendStateSensorEvent(
+                                                                                            sensorId,
+                                                                                            PLDM_STATE_SENSOR_STATE,
+                                                                                            0,
+                                                                                            uint8_t(
+                                                                                                state),
+                                                                                            uint8_t(
+                                                                                                CodeUpdateState::
+                                                                                                    START));
+                                                                                        newImageId
+                                                                                            .clear();
+                                                                                        imageActivationMatch
+                                                                                            .reset();
+                                                                                    }
+                                                                                }
+                                                                            });
+                                }
+                                auto rc = setRequestedActivation();
+                                if (rc != PLDM_SUCCESS)
+                                {
+                                    CodeUpdateState state =
+                                        CodeUpdateState::FAIL;
+                                    setCodeUpdateProgress(false);
+                                    auto sensorId = getFirmwareUpdateSensor();
+                                    sendStateSensorEvent(
+                                        sensorId, PLDM_STATE_SENSOR_STATE, 0,
+                                        uint8_t(state),
+                                        uint8_t(CodeUpdateState::START));
+                                    error("could not set RequestedActivation");
+                                }
+                                break;
                             }
-                            auto rc = setRequestedActivation();
-                            if (rc != PLDM_SUCCESS)
+                            else
                             {
-                                CodeUpdateState state = CodeUpdateState::FAIL;
-                                setCodeUpdateProgress(false);
-                                auto sensorId = getFirmwareUpdateSensor();
-                                sendStateSensorEvent(
-                                    sensorId, PLDM_STATE_SENSOR_STATE, 0,
-                                    uint8_t(state),
-                                    uint8_t(CodeUpdateState::START));
-                                std::cerr
-                                    << "could not set RequestedActivation \n";
+                                // Out of band update
+                                processRenameEvent();
                             }
-                            break;
                         }
-                        else
+                        catch (const sdbusplus::exception::exception& e)
                         {
-                            // Out of band update
-                            processRenameEvent();
+                            error(
+                                "Error in getting Activation status,ERROR= {ERR_EXCEP}, INTERFACE={INTF}, OBJECT PATH={OBJ_PATH}",
+                                "ERR_EXCEP", e.what(), "INTF", imageInterface,
+                                "OBJ_PATH", imageObjPath);
                         }
-                    }
-                    catch (const sdbusplus::exception::exception& e)
-                    {
-                        std::cerr << "Error in getting Activation status,"
-                                  << "ERROR=" << e.what()
-                                  << ", INTERFACE=" << imageInterface
-                                  << ", OBJECT PATH=" << imageObjPath << "\n";
                     }
                 }
-            }
-        }));
+            }));
 }
 
 void CodeUpdate::processRenameEvent()
 {
-    std::cout << "Processing Rename Event" << std::endl;
+    info("Processing Rename Event");
 
     BiosAttributeList biosAttrList;
     pldm_boot_side_data pldmBootSideData = readBootSideFile();
@@ -576,7 +616,8 @@ void CodeUpdate::deleteImage()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to delete image, ERROR=" << e.what() << "\n";
+        error("Failed to delete image, ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
         return;
     }
 }
@@ -671,7 +712,8 @@ int processCodeUpdateLid(const std::string& filePath)
     std::ifstream ifs(filePath, std::ios::in | std::ios::binary);
     if (!ifs)
     {
-        std::cerr << "ifstream open error: " << filePath << "\n";
+        error("ifstream open error: {FILE_PATH}", "FILE_PATH",
+              filePath.c_str());
         return PLDM_ERROR;
     }
     ifs.seekg(0);
@@ -690,7 +732,8 @@ int processCodeUpdateLid(const std::string& filePath)
     constexpr auto magicNumber = 0x0222;
     if (htons(header.magicNumber) != magicNumber)
     {
-        std::cerr << "Invalid magic number: " << filePath << "\n";
+        error("Invalid magic number: {FILE_PATH}", "FILE_PATH",
+              filePath.c_str());
         ifs.close();
         return PLDM_ERROR;
     }
@@ -709,8 +752,8 @@ int processCodeUpdateLid(const std::string& filePath)
                         ec);
         if (ec)
         {
-            std::cerr << "Failed to set the lid directory permissions: "
-                      << ec.message() << std::endl;
+            error("Failed to set the lid directory permissions:{ERR}", "ERR",
+                  ec.message());
             return PLDM_ERROR;
         }
     }
@@ -745,8 +788,8 @@ int processCodeUpdateLid(const std::string& filePath)
                         fs::perm_options::replace, ec);
         if (ec)
         {
-            std::cerr << "Failed to set the lid file permissions: "
-                      << ec.message() << std::endl;
+            error("Failed to set the lid file permissions: {ERR}", "ERR",
+                  ec.message());
             return PLDM_ERROR;
         }
     }
@@ -776,8 +819,7 @@ int CodeUpdate::assembleCodeUpdateImage()
                                 "-mkfs-time", "0", "-all-time", "0");
                 if (rc < 0)
                 {
-                    std::cerr << "Error occurred during the mksqusquashfs call"
-                              << std::endl;
+                    error("Error occurred during the mksqusquashfs call");
                     setCodeUpdateProgress(false);
                     auto sensorId = getFirmwareUpdateSensor();
                     sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
@@ -788,9 +830,8 @@ int CodeUpdate::assembleCodeUpdateImage()
             }
             catch (const std::exception& e)
             {
-                std::cerr << "Failed during the mksqusquashfs call, "
-                             "ERROR="
-                          << e.what() << "\n";
+                error("Failed during the mksqusquashfs call, ERROR={ERR_EXCEP}",
+                      "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
 
@@ -813,9 +854,9 @@ int CodeUpdate::assembleCodeUpdateImage()
             }
             catch (const std::exception& e)
             {
-                std::cerr << "Failed to Extract the BMC tarball content, "
-                             "ERROR="
-                          << e.what() << "\n";
+                error(
+                    "Failed to Extract the BMC tarball content, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
 
@@ -834,9 +875,8 @@ int CodeUpdate::assembleCodeUpdateImage()
                                 updateDirPath);
                 if (rc < 0)
                 {
-                    std::cerr
-                        << "Error occurred during the generation of the tarball"
-                        << std::endl;
+                    error(
+                        "Error occurred during the generation of the tarball");
                     setCodeUpdateProgress(false);
                     auto sensorId = getFirmwareUpdateSensor();
                     sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
@@ -847,10 +887,9 @@ int CodeUpdate::assembleCodeUpdateImage()
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "Failed to Remove the tarball file, then re-generate it, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "Failed to Remove the tarball file, then re-generate it, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
 
@@ -868,8 +907,7 @@ int CodeUpdate::assembleCodeUpdateImage()
         }
         else if (nextPid < 0)
         {
-            std::cerr << "Error occurred during fork. ERROR=" << errno
-                      << std::endl;
+            error("Error occurred during fork. ERROR={ERR}", "ERR", errno);
             exit(EXIT_FAILURE);
         }
 
@@ -882,21 +920,21 @@ int CodeUpdate::assembleCodeUpdateImage()
         int status;
         if (waitpid(pid, &status, 0) < 0)
         {
-            std::cerr << "Error occurred during waitpid. ERROR=" << errno
-                      << std::endl;
+            error("Error occurred during waitpid. ERROR={ERR}", "ERR", errno);
+
             return PLDM_ERROR;
         }
         else if (WEXITSTATUS(status) != 0)
         {
-            std::cerr
-                << "Failed to execute the assembling of the image. STATUS="
-                << status << std::endl;
+            error(
+                "Failed to execute the assembling of the image. STATUS={STATUS}",
+                "STATUS", status);
             return PLDM_ERROR;
         }
     }
     else
     {
-        std::cerr << "Error occurred during fork. ERROR=" << errno << std::endl;
+        error("Error occurred during fork. ERROR={ERR}", "ERR", errno);
         return PLDM_ERROR;
     }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -8,7 +8,11 @@
 #include "libpldmresponder/file_io.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <regex>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::pdr;
 using namespace pldm::utils;
@@ -139,7 +143,7 @@ int pldm::responder::oem_ibm_platform::Handler::
                 if (stateField[currState].effecter_state ==
                     uint8_t(CodeUpdateState::START))
                 {
-                    std::cout << "Received Start Update Request From PHYP\n";
+                    info("Received Start Update Request From PHYP");
                     codeUpdate->setCodeUpdateProgress(true);
                     startUpdateEvent =
                         std::make_unique<sdeventplus::source::Defer>(
@@ -151,7 +155,7 @@ int pldm::responder::oem_ibm_platform::Handler::
                 else if (stateField[currState].effecter_state ==
                          uint8_t(CodeUpdateState::END))
                 {
-                    std::cout << "Received End Update Request From PHYP\n";
+                    info("Received End Update Request From PHYP");
                     rc = PLDM_SUCCESS;
                     assembleImageEvent = std::make_unique<
                         sdeventplus::source::Defer>(
@@ -166,7 +170,7 @@ int pldm::responder::oem_ibm_platform::Handler::
                 else if (stateField[currState].effecter_state ==
                          uint8_t(CodeUpdateState::ABORT))
                 {
-                    std::cout << "Received Abort Update Request From PHYP\n";
+                    info("Received Abort Update Request From PHYP");
                     codeUpdate->setCodeUpdateProgress(false);
                     codeUpdate->clearDirPath(LID_STAGING_DIR);
                     auto sensorId = codeUpdate->getFirmwareUpdateSensor();
@@ -201,7 +205,7 @@ int pldm::responder::oem_ibm_platform::Handler::
             {
                 if (stateField[currState].effecter_state == POWER_CYCLE_HARD)
                 {
-                    std::cout << "Got a Deep IPL request" << std::endl;
+                    info("Got a Deep IPL request");
                     systemRebootEvent =
                         std::make_unique<sdeventplus::source::Defer>(
                             event,
@@ -274,8 +278,8 @@ void buildAllCodeUpdateEffecterPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
     pdr->hdr.record_handle = 0;
@@ -325,8 +329,8 @@ void buildAllSlotEnabeEffecterPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
 
@@ -391,8 +395,8 @@ void buildAllCodeUpdateSensorPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_SENSOR_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_SENSOR_ID));
         return;
     }
     pdr->hdr.record_handle = 0;
@@ -440,8 +444,8 @@ void buildAllSlotEnableSensorPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_SENSOR_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_SENSOR_ID));
         return;
     }
     auto& associatedEntityMap = platformHandler->getAssociateEntityMap();
@@ -502,8 +506,8 @@ void buildAllNumericEffecterPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_numeric_effecter_value_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
 
@@ -582,8 +586,8 @@ void buildAllSystemPowerStateEffecterPDR(
         reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
     pdr->hdr.record_handle = 0;
@@ -647,8 +651,9 @@ void attachOemEntityToEntityAssociationPDR(
         {
             // parent node not found in the entity association tree,
             // this should not be possible
-            std::cerr << "Parent Entity of type " << parent_entity.entity_type
-                      << " not found in the BMC Entity Association tree\n";
+            error(
+                "Parent Entity of type {ENTITY_TYP} not found in the BMC Entity Association tree ",
+                "ENTITY_TYP", static_cast<unsigned>(parent_entity.entity_type));
             return;
         }
         uint32_t bmc_record_handle = 0;
@@ -704,8 +709,10 @@ std::filesystem::path pldm::responder::oem_ibm_platform::Handler::getConfigDir()
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Error getting Names property , PATH=" << objectPath
-                      << " Compatible interface =" << ibmCompatible[0] << "\n";
+            error(
+                "Error getting Names property , PATH={OBJ_PATH} Compatible interface = {INTF}",
+                "OBJ_PATH", objectPath.c_str(), "INTF",
+                ibmCompatible[0].c_str());
         }
     }
     return fs::path();
@@ -725,8 +732,8 @@ void buildAllRealSAIEffecterPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
     pdr->hdr.record_handle = 0;
@@ -836,27 +843,27 @@ int pldm::responder::oem_ibm_platform::Handler::sendEventToHost(
         }
         std::cout << tempStream.str() << std::endl;
     }
-    auto oemPlatformEventMessageResponseHandler =
-        [](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
-            uint8_t completionCode{};
-            uint8_t status{};
-            auto rc = decode_platform_event_message_resp(
-                response, respMsgLen, &completionCode, &status);
-            if (rc || completionCode)
-            {
-                std::cerr << "Failed to decode_platform_event_message_resp: "
-                          << " for code update event rc=" << rc
-                          << ", cc=" << static_cast<unsigned>(completionCode)
-                          << std::endl;
-            }
-        };
+    auto oemPlatformEventMessageResponseHandler = [](mctp_eid_t /*eid*/,
+                                                     const pldm_msg* response,
+                                                     size_t respMsgLen) {
+        uint8_t completionCode{};
+        uint8_t status{};
+        auto rc = decode_platform_event_message_resp(response, respMsgLen,
+                                                     &completionCode, &status);
+        if (rc || completionCode)
+        {
+            error(
+                "Failed to decode_platform_event_message_resp: for code update event rc={RC}, cc={CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
+        }
+    };
     auto rc = handler->registerRequest(
         mctp_eid, instanceId, PLDM_PLATFORM, PLDM_PLATFORM_EVENT_MESSAGE,
         std::move(requestMsg),
         std::move(oemPlatformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send BIOS attribute change event message \n";
+        error("Failed to send BIOS attribute change event message");
     }
 
     return rc;
@@ -915,51 +922,50 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
             request);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr
-                << " Set state effecter state command failure. PLDM error code ="
-                << rc << std::endl;
+            error(
+                " Set state effecter state command failure. PLDM error code ={RC}",
+                "RC", rc);
             requester.markFree(mctp_eid, instanceId);
             return;
         }
-        auto setStateEffecterStatesRespHandler =
-            [=, this](mctp_eid_t /*eid*/, const pldm_msg* response,
-                      size_t respMsgLen) {
-                if (response == nullptr || !respMsgLen)
-                {
-                    std::cerr << "Failed to receive response for "
-                              << "setstateEffecterSates command\n";
-                    return;
-                }
-                uint8_t completionCode{};
-                auto rc = decode_set_state_effecter_states_resp(
-                    response, respMsgLen, &completionCode);
-                if (rc)
-                {
-                    std::cerr
-                        << "Failed to decode setStateEffecterStates response,"
-                        << " rc " << rc << "\n";
-                    pldm::utils::reportError(
-                        "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                        pldm::PelSeverity::ERROR);
-                }
-                if (completionCode)
-                {
-                    std::cerr
-                        << "Failed to set a Host effecter "
-                        << ", cc=" << static_cast<unsigned>(completionCode)
-                        << "\n";
-                    pldm::utils::reportError(
-                        "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                        pldm::PelSeverity::ERROR);
-                }
-            };
+        auto setStateEffecterStatesRespHandler = [=, this](
+                                                     mctp_eid_t /*eid*/,
+                                                     const pldm_msg* response,
+                                                     size_t respMsgLen) {
+            if (response == nullptr || !respMsgLen)
+            {
+                error(
+                    "Failed to receive response for setstateEffecterSates command");
+                return;
+            }
+            uint8_t completionCode{};
+            auto rc = decode_set_state_effecter_states_resp(
+                response, respMsgLen, &completionCode);
+            if (rc)
+            {
+                error(
+                    "Failed to decode setStateEffecterStates response,rc= {RC}",
+                    "RC", static_cast<unsigned>(rc));
+                pldm::utils::reportError(
+                    "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
+                    pldm::PelSeverity::ERROR);
+            }
+            if (completionCode)
+            {
+                error("Failed to set a Host effecter, cc={CC}", "CC",
+                      static_cast<unsigned>(completionCode));
+                pldm::utils::reportError(
+                    "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
+                    pldm::PelSeverity::ERROR);
+            }
+        };
         rc = handler->registerRequest(
             mctp_eid, instanceId, PLDM_PLATFORM, PLDM_SET_STATE_EFFECTER_STATES,
             std::move(requestMsg),
             std::move(setStateEffecterStatesRespHandler));
         if (rc)
         {
-            std::cerr << "Failed to send request to set an effecter on Host \n";
+            error("Failed to send request to set an effecter on Host");
         }
     }
 }
@@ -1032,9 +1038,9 @@ int pldm::responder::oem_ibm_platform::Handler::setNumericEffecter(
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Failed to make a DBus call as the dump policy is disabled,ERROR= "
-            << e.what() << "\n";
+        error(
+            "Failed to make a DBus call as the dump policy is disabled,ERROR= {ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         // case when the dump policy is disabled but we set the host effecter as
         // true and the host moves on
         setHostEffecterState(true);
@@ -1084,16 +1090,14 @@ void pldm::responder::oem_ibm_platform::Handler::sendStateSensorEvent(
                              instanceId);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to encode state sensor event, rc = " << rc
-                  << std::endl;
+        error("Failed to encode state sensor event, rc = {RC}", "RC", rc);
         requester.markFree(mctp_eid, instanceId);
         return;
     }
     rc = sendEventToHost(requestMsg, instanceId);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to send event to host: "
-                  << "rc=" << rc << std::endl;
+        error("Failed to send event to host: rc={RC}", "RC", rc);
     }
     return;
 }
@@ -1102,7 +1106,7 @@ void pldm::responder::oem_ibm_platform::Handler::_processEndUpdate(
     sdeventplus::source::EventBase& /*source */)
 {
     assembleImageEvent.reset();
-    std::cout << "Starting assembleCodeUpdateImage \n";
+    info("Starting assembleCodeUpdateImage");
     int retc = codeUpdate->assembleCodeUpdateImage();
     if (retc != PLDM_SUCCESS)
     {
@@ -1122,11 +1126,11 @@ void pldm::responder::oem_ibm_platform::Handler::_processStartUpdate(
     auto rc = codeUpdate->setRequestedApplyTime();
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "setRequestedApplyTime failed \n";
+        error("setRequestedApplyTime failed");
         state = CodeUpdateState::FAIL;
     }
     auto sensorId = codeUpdate->getFirmwareUpdateSensor();
-    std::cout << "Sending Start Update sensor event to PHYP\n";
+    info("Sending Start Update sensor event to PHYP");
     sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0, uint8_t(state),
                          uint8_t(CodeUpdateState::END));
 }
@@ -1166,14 +1170,14 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                                          "RequestedPowerTransition", "string"};
     try
     {
-        std::cout << "InbandCodeUpdate: ChassifOff the host\n";
+        info("InbandCodeUpdate: ChassifOff the host");
         dBusIntf->setDbusProperty(dbusMapping, value);
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Chassis State transition to Off failed,"
-                  << "unable to set property RequestedPowerTransition"
-                  << "ERROR=" << e.what() << "\n";
+        error(
+            "Chassis State transition to Off failed, unable to set property RequestedPowerTransition ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
 
     using namespace sdbusplus::bus::match::rules;
@@ -1202,15 +1206,15 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                             "Policy.AlwaysOn";
                     try
                     {
-                        std::cout
-                            << "InbandCodeUpdate: Setting the one time APR policy\n";
+                        info(
+                            "InbandCodeUpdate: Setting the one time APR policy");
                         dBusIntf->setDbusProperty(dbusMapping, value);
                     }
                     catch (const std::exception& e)
                     {
-                        std::cerr << "Setting one-time restore policy failed,"
-                                  << "unable to set property PowerRestorePolicy"
-                                  << "ERROR=" << e.what() << "\n";
+                        error(
+                            "Setting one-time restore policy failed, unable to set property PowerRestorePolicy ERROR={ERR_EXCEP}",
+                            "ERR_EXCEP", e.what());
                     }
                     dbusMapping = pldm::utils::DBusMapping{
                         "/xyz/openbmc_project/state/bmc0",
@@ -1219,15 +1223,14 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                     value = "xyz.openbmc_project.State.BMC.Transition.Reboot";
                     try
                     {
-                        std::cout << "InbandCodeUpdate: Rebooting the BMC\n";
+                        info("InbandCodeUpdate: Rebooting the BMC");
                         dBusIntf->setDbusProperty(dbusMapping, value);
                     }
                     catch (const std::exception& e)
                     {
-                        std::cerr << "BMC state transition to reboot failed,"
-                                  << "unable to set property "
-                                     "RequestedBMCTransition"
-                                  << "ERROR=" << e.what() << "\n";
+                        error(
+                            "BMC state transition to reboot failed, unable to set property RequestedBMCTransition ERROR={ERR_EXCEP}",
+                            "ERR_EXCEP", e.what());
                     }
                 }
             }
@@ -1289,8 +1292,9 @@ void pldm::responder::oem_ibm_platform::Handler::resetWatchDogTimer()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To reset watchdog timer"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed To reset watchdog timer ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
+
         return;
     }
 }
@@ -1313,8 +1317,8 @@ void pldm::responder::oem_ibm_platform::Handler::disableWatchDogTimer()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To disable watchdog timer"
-                  << "ERROR=" << e.what() << "\n";
+        error("Failed To disable watchdog timer ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
     }
 }
 int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
@@ -1329,14 +1333,14 @@ int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
         if (std::get<std::string>(propertyValue) !=
             "xyz.openbmc_project.State.BMC.BMCState.Ready")
         {
-            std::cerr << "GetPDR : PLDM stack is not ready for PDR exchange"
-                      << std::endl;
+            error("GetPDR : PLDM stack is not ready for PDR exchange");
+
             return PLDM_ERROR_NOT_READY;
         }
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error getting the current BMC state" << std::endl;
+        error("Error getting the current BMC state");
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;
@@ -1357,8 +1361,9 @@ void pldm::responder::oem_ibm_platform::Handler::setBitmapMethodCall(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to call the D-Bus Method"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed to call the D-Bus Method ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
+
         return;
     }
 }
@@ -1451,8 +1456,8 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtChassisOff()
     auto bootType = getBiosAttrValue("pvm_boot_type");
     if (bootInitiator.empty() || bootType.empty())
     {
-        std::cerr
-            << "ERROR in fetching the pvm_boot_initiator and pvm_boot_type BIOS attribute values\n";
+        error(
+            "ERROR in fetching the pvm_boot_initiator and pvm_boot_type BIOS attribute values");
         return;
     }
     else if (bootInitiator != "Host")
@@ -1474,8 +1479,8 @@ void pldm::responder::oem_ibm_platform::Handler::turnOffRealSAIEffecter()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to turn off partition SAI effecter"
-                  << "ERROR=" << e.what() << "\n";
+        error("Failed to turn off partition SAI effecter ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
     try
     {
@@ -1486,8 +1491,8 @@ void pldm::responder::oem_ibm_platform::Handler::turnOffRealSAIEffecter()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to turn off platform SAI effecter"
-                  << "ERROR=" << e.what() << "\n";
+        error("Failed to turn off platform SAI effecter ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 }
 
@@ -1516,8 +1521,8 @@ uint8_t pldm::responder::oem_ibm_platform::Handler::fetchRealSAIStatus()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to fetch Real SAI sensor status"
-                  << "ERROR=" << e.what() << "\n";
+        error("Failed to fetch Real SAI sensor status ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
     return PLDM_SENSOR_NORMAL;
 }
@@ -1525,7 +1530,7 @@ uint8_t pldm::responder::oem_ibm_platform::Handler::fetchRealSAIStatus()
 void pldm::responder::oem_ibm_platform::Handler::
     processPowerCycleOffSoftGraceful()
 {
-    std::cerr << "Received soft graceful power cycle request" << std::endl;
+    error("Received soft graceful power cycle request");
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot";
     pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/host0",
@@ -1537,15 +1542,15 @@ void pldm::responder::oem_ibm_platform::Handler::
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Error to do a ForceWarmReboot, chassis power remains on, and boot the host back up. Unable to set property RequestedHostTransition. ERROR="
-            << e.what() << "\n";
+        error(
+            "Error to do a ForceWarmReboot, chassis power remains on, and boot the host back up. Unable to set property RequestedHostTransition. ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
 }
 
 void pldm::responder::oem_ibm_platform::Handler::processPowerOffSoftGraceful()
 {
-    std::cerr << "Received soft power off graceful request" << std::endl;
+    error("Received soft power off graceful request");
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.State.Chassis.Transition.Off";
     pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/chassis0",
@@ -1557,15 +1562,15 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffSoftGraceful()
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Error in powering down the host. Unable to set property RequestedPowerTransition. ERROR="
-            << e.what() << "\n";
+        error(
+            "Error in powering down the host. Unable to set property RequestedPowerTransition. ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
 }
 
 void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
 {
-    std::cerr << "Received hard power off graceful request" << std::endl;
+    error("Received hard power off graceful request");
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn";
     pldm::utils::DBusMapping dbusMapping{
@@ -1578,9 +1583,9 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Setting one-time restore policy failed, Unable to set property PowerRestorePolicy. ERROR="
-            << e.what() << "\n";
+        error(
+            "Setting one-time restore policy failed, Unable to set property PowerRestorePolicy. ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
     processPowerOffSoftGraceful();
 }
@@ -1616,9 +1621,10 @@ void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
     }
     else if (!value && timer.isEnabled())
     {
-        std::cout << "setSurvTimer:LogginPel:hostOff=" << (bool)hostOff
-                  << " hostTransitioningToOff=" << (bool)hostTransitioningToOff
-                  << " tid=" << (uint16_t)tid << std::endl;
+        info(
+            "setSurvTimer:LogginPel:hostOff={HOST_OFF} hostTransitioningToOff={HOST_TRANST_OFF} tid={TID}",
+            "HOST_OFF", (bool)hostOff, "HOST_TRANST_OFF",
+            (bool)hostTransitioningToOff, "TID", (uint16_t)tid);
         startStopTimer(false);
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.setSurvTimer.RecvSurveillancePingFail",
@@ -1629,7 +1635,8 @@ void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
 void pldm::responder::oem_ibm_platform::Handler::propertyChanged(
     const DbusChangedProps& chProperties, std::string objPath)
 {
-    std::cerr << "Got a link reset set for CEC path: " << objPath << std::endl;
+    error("Got a link reset set for CEC path: {OBJ_PATH}", "OBJ_PATH",
+          objPath.c_str());
     static constexpr auto propName = "linkReset";
     const auto it = chProperties.find(propName);
     if (it == chProperties.end())
@@ -1688,9 +1695,9 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
 
         if (stateEffecterPDRs.empty())
         {
-            std::cerr
-                << "PCIe CEC LinkReset: The state set PDR can not be found, entityType = "
-                << entityType << std::endl;
+            error(
+                "PCIe CEC LinkReset: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+                "ENTITY_TYP", entityType);
             return;
         }
 
@@ -1706,8 +1713,9 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to fetch the BusID of the slot. ERROR= "
-                      << e.what() << std::endl;
+            error("Failed to fetch the BusID of the slot. ERROR= {ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
+
             return;
         }
 
@@ -1721,13 +1729,14 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
             }
         }
 
-        std::cerr << "Sending effecter call to host with effecter ID : "
-                  << effecterID << "and BusID : " << instanceId << std::endl;
+        error(
+            "Sending effecter call to host with effecter ID : {EFFECTER_ID} and BusID : {BUS_ID}",
+            "EFFECTER_ID", effecterID, "BUS_ID", instanceId);
         hostEffecterParser->sendSetStateEffecterStates(
             mctp_eid, effecterID, 1, stateField, nullptr, value);
-
-        std::cerr << "Setting link reset on link: " << path
-                  << " is successful setting it back to false" << std::endl;
+        error(
+            "Setting link reset on link: {LINK_PATH} is successful setting it back to false",
+            "LINK_PATH", path.c_str());
         pldm::utils::DBusMapping dbusMapping;
         dbusMapping.objectPath = path;
         dbusMapping.interface = "com.ibm.Control.Host.PCIeLink";
@@ -1740,8 +1749,8 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to set the link reset property. ERROR = "
-                      << e.what() << std::endl;
+            error("Failed to set the link reset property. ERROR = {ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
             return;
         }
     }

--- a/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
@@ -6,9 +6,12 @@
 #include "common/utils.hpp"
 #include "libpldmresponder/pdr.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -16,7 +19,6 @@ namespace responder
 {
 namespace platform
 {
-
 int sendBiosAttributeUpdateEvent(
     uint8_t eid, dbus_api::Requester* requester,
     const std::vector<uint16_t>& handles,
@@ -68,8 +70,8 @@ int sendBiosAttributeUpdateEvent(
         requestMsg.size() - sizeof(pldm_msg_hdr), request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message encode failure 1. PLDM error code = " << std::hex
-                  << std::showbase << rc << "\n";
+        error("Message encode failure 1. PLDM error code = {RC}", "RC",
+              lg2::hex, rc);
         requester->markFree(eid, instanceId);
         return rc;
     }
@@ -90,8 +92,7 @@ int sendBiosAttributeUpdateEvent(
                                                   size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr
-                << "Failed to receive response for platform event message \n";
+            error("Failed to receive response for platform event message");
             return;
         }
         uint8_t completionCode{};
@@ -100,10 +101,9 @@ int sendBiosAttributeUpdateEvent(
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: RC = {RC}, cc = {CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
     rc = handler->registerRequest(
@@ -111,7 +111,7 @@ int sendBiosAttributeUpdateEvent(
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send the platform event message \n";
+        error("Failed to send the platform event message");
     }
 
     return rc;

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -5,6 +5,10 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace requester
@@ -37,8 +41,8 @@ void DbusToFileHandler::sendNewFileAvailableCmd(uint64_t fileSize)
 {
     if (requester == NULL)
     {
-        std::cerr << "Failed to send resource dump parameters as requester is "
-                     "not set";
+        error(
+            "Failed to send resource dump parameters as requester is not set");
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.sendNewFileAvailableCmd.SendDumpParametersFail",
             pldm::PelSeverity::ERROR);
@@ -57,7 +61,7 @@ void DbusToFileHandler::sendNewFileAvailableCmd(uint64_t fileSize)
     if (rc != PLDM_SUCCESS)
     {
         requester->markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_new_file_req, rc = " << rc << std::endl;
+        error("Failed to encode_new_file_req, rc = {RC}", "RC", rc);
         return;
     }
 
@@ -66,19 +70,16 @@ void DbusToFileHandler::sendNewFileAvailableCmd(uint64_t fileSize)
                                               size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr
-                << "Failed to receive response for NewFileAvailable command \n";
+            error("Failed to receive response for NewFileAvailable command");
             return;
         }
         uint8_t completionCode{};
         auto rc = decode_new_file_resp(response, respMsgLen, &completionCode);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_new_file_resp or"
-                      << " Host returned error for new_file_available"
-                      << " rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << "\n";
+            error(
+                "Failed to decode_new_file_resp or Host returned error for new_file_available rc={RC}, cc = {CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
             reportResourceDumpFailure("decodeNewFileResp");
         }
     };
@@ -87,7 +88,7 @@ void DbusToFileHandler::sendNewFileAvailableCmd(uint64_t fileSize)
         std::move(requestMsg), std::move(newFileAvailableRespHandler));
     if (rc)
     {
-        std::cerr << "Failed to send NewFileAvailable Request to Host \n";
+        error("Failed to send NewFileAvailable Request to Host");
         reportResourceDumpFailure("newFileAvailableRequest");
     }
 }
@@ -108,9 +109,8 @@ void DbusToFileHandler::reportResourceDumpFailure(std::string str)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to set resource dump operation status, "
-                     "ERROR="
-                  << e.what() << "\n";
+        error("failed to set resource dump operation status, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 }
 
@@ -132,7 +132,7 @@ void DbusToFileHandler::processNewResourceDump(
     }
     catch (const sdbusplus::exception::exception& e)
     {
-        std::cerr << "Error in getting current resource dump status \n";
+        error("Error in getting current resource dump status");
         return;
     }
 
@@ -153,8 +153,8 @@ void DbusToFileHandler::processNewResourceDump(
 
     if (!fileHandleFd)
     {
-        std::cerr << "resource dump file open error: " << resDumpFilePath
-                  << "\n";
+        error("resource dump file open error:{RES_DUMP_PATH}", "RES_DUMP_PATH",
+              resDumpFilePath);
         PropertyValue value{resDumpStatus};
         DBusMapping dbusMapping{resDumpCurrentObjPath, resDumpProgressIntf,
                                 "Status", "string"};
@@ -164,9 +164,9 @@ void DbusToFileHandler::processNewResourceDump(
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set resource dump operation status, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set resource dump operation status, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
         }
         return;
     }
@@ -231,7 +231,8 @@ void DbusToFileHandler::newCsrFileAvailable(const std::string& csr,
 
     if (!certFile)
     {
-        std::cerr << "cert file open error: " << certFilePath << "\n";
+        error("cert file open error: {CERT_FILE}", "CERT_FILE",
+              certFilePath.c_str());
         return;
     }
 
@@ -265,7 +266,8 @@ void DbusToFileHandler::newLicFileAvailable(const std::string& licenseStr)
 
     if (!licFile)
     {
-        std::cerr << "License file open error: " << licFilePath << "\n";
+        error("License file open error: {LIC_FILE}", "LIC_FILE",
+              licFilePath.c_str());
         return;
     }
 
@@ -284,7 +286,7 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
 {
     if (requester == NULL)
     {
-        std::cerr << "newFileAvailableSendToHost:Failed to send file to host.";
+        error("newFileAvailableSendToHost:Failed to send file to host.");
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.SendFileToHostFail",
             pldm::PelSeverity::ERROR);
@@ -300,22 +302,21 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
     if (rc != PLDM_SUCCESS)
     {
         requester->markFree(mctp_eid, instanceId);
-        std::cerr
-            << "newFileAvailableSendToHost:Failed to encode_new_file_req, rc = "
-            << rc << std::endl;
+        error(
+            "newFileAvailableSendToHost:Failed to encode_new_file_req, rc = {RC}",
+            "RC", rc);
         return;
     }
-    std::cout
-        << "newFileAvailableSendToHost:Sending Sign CSR request to Host for fileHandle: "
-        << fileHandle << std::endl;
+    info(
+        "newFileAvailableSendToHost:Sending Sign CSR request to Host for fileHandle: {FILE_HNDL}",
+        "FILE_HNDL", fileHandle);
     auto newFileAvailableRespHandler = [fileHandle,
                                         type](mctp_eid_t /*eid*/,
                                               const pldm_msg* response,
                                               size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for NewFileAvailable "
-                         "command\n";
+            error("Failed to receive response for NewFileAvailable command");
             if (type == PLDM_FILE_TYPE_CERT_SIGNING_REQUEST)
             {
                 std::string filePath = certFilePath;
@@ -334,10 +335,9 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr
-                        << "newFileAvailableSendToHost:Failed to set status property of certicate entry, "
-                           "ERROR="
-                        << e.what() << "\n";
+                    error(
+                        "newFileAvailableSendToHost:Failed to set status property of certicate entry, ERROR={ERR_EXCEP}",
+                        "ERR_EXCEP", e.what());
                 }
 
                 pldm::utils::reportError(
@@ -350,11 +350,9 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
         auto rc = decode_new_file_resp(response, respMsgLen, &completionCode);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_new_file_resp for file, or"
-                      << " Host returned error for new_file_available"
-                      << " rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << "\n";
+            error(
+                "Failed to decode_new_file_resp for file, or Host returned error for new_file_available rc = {RC}, cc= {CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
             if (rc)
             {
                 pldm::utils::reportError(
@@ -368,8 +366,8 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
         std::move(requestMsg), std::move(newFileAvailableRespHandler));
     if (rc)
     {
-        std::cerr
-            << "newFileAvailableSendToHost:Failed to send NewFileAvailable Request to Host\n";
+        error(
+            "newFileAvailableSendToHost:Failed to send NewFileAvailable Request to Host");
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.NewFileAvailableRequestFail",
             pldm::PelSeverity::ERROR);

--- a/pldmd/instance_id.cpp
+++ b/pldmd/instance_id.cpp
@@ -2,11 +2,14 @@
 
 #include "instance_id.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <stdexcept>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
-
 uint8_t InstanceId::next()
 {
     uint8_t idx = 0;
@@ -19,7 +22,7 @@ uint8_t InstanceId::next()
     {
         // check all the instance ids and free up the one
         // that is acquired oldest
-        std::cerr << "all the Instance ids are exhausted \n";
+        error("lg2 all the Instance ids are exhausted");
 
         auto instance = returnOldestId();
         if (instance.has_value())
@@ -63,8 +66,8 @@ std::optional<uint8_t> InstanceId::returnOldestId()
     }
     if (skipInstance)
     {
-        std::cerr
-            << "None of the instance id's are older then the pldm instance id expiration time\n";
+        error(
+            "lg2 None of the instance id's are older then the pldm instance id expiration time");
         return std::nullopt;
     }
     const std::time_t t_c =

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -22,6 +22,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/source/io.hpp>
 #include <sdeventplus/source/signal.hpp>
@@ -73,11 +74,12 @@ using namespace pldm::responder;
 using namespace pldm::utils;
 using sdeventplus::source::Signal;
 using namespace pldm::flightrecorder;
+PHOSPHOR_LOG2_USING;
 
 void interruptFlightRecorderCallBack(Signal& /*signal*/,
                                      const struct signalfd_siginfo*)
 {
-    std::cerr << "\nReceived SIGUR1(10) Signal interrupt\n";
+    info("Received SIGUR1(10) Signal interrupt");
 
     // obtain the flight recorder instance and dump the recorder
     FlightRecorder::GetInstance().playRecorder();
@@ -96,7 +98,7 @@ static std::optional<Response>
         requestMsg.data() + sizeof(eid) + sizeof(type));
     if (PLDM_SUCCESS != unpack_pldm_header(hdr, &hdrFields))
     {
-        std::cerr << "Empty PLDM request header \n";
+        info("Empty PLDM request header");
         return std::nullopt;
     }
 
@@ -132,7 +134,7 @@ static std::optional<Response>
             header.command = hdrFields.command;
             if (PLDM_SUCCESS != pack_pldm_header(&header, responseHdr))
             {
-                std::cerr << "Failed adding response header \n";
+                error("Failed adding response header");
                 return std::nullopt;
             }
             response.insert(response.end(), completion_code);
@@ -152,9 +154,9 @@ static std::optional<Response>
 
 void optionUsage(void)
 {
-    std::cerr << "Usage: pldmd [options]\n";
-    std::cerr << "Options:\n";
-    std::cerr << "  [--verbose] - would enable verbosity\n";
+    error("Usage: pldmd [options]");
+    error("Options:");
+    error(" [--verbose] - would enable verbosity");
 }
 
 int main(int argc, char** argv)
@@ -181,7 +183,7 @@ int main(int argc, char** argv)
     if (-1 == sockfd)
     {
         returnCode = -errno;
-        std::cerr << "Failed to create the socket, RC= " << returnCode << "\n";
+        error("Failed to create the socket, RC={RC}", "RC", returnCode);
         exit(EXIT_FAILURE);
     }
     socklen_t optlen;
@@ -194,8 +196,8 @@ int main(int argc, char** argv)
                          &optlen);
     if (res == -1)
     {
-        std::cerr << "Error calling setsockopt. RC = " << res
-                  << ", errno = " << errno << std::endl;
+        error("Error calling setsockopt. RC = {RC}, errno = {ERR}", "RC", res,
+              "ERR", errno);
     }
     auto event = Event::get_default();
     auto& bus = pldm::utils::DBusHandler::getBus();
@@ -338,8 +340,7 @@ int main(int argc, char** argv)
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Failed to connect to the socket, RC= " << returnCode
-                  << "\n";
+        error("Failed to connect to the socket, RC= {RC}", "RC", returnCode);
         exit(EXIT_FAILURE);
     }
 
@@ -347,8 +348,9 @@ int main(int argc, char** argv)
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Failed to send message type as pldm to mctp, RC= "
-                  << returnCode << "\n";
+        error("Failed to send message type as pldm to mctp, RC= {RC}", "RC",
+              returnCode);
+
         exit(EXIT_FAILURE);
     }
 
@@ -386,7 +388,7 @@ int main(int argc, char** argv)
         else if (peekedLength <= -1)
         {
             returnCode = -errno;
-            std::cerr << "recv system call failed, RC= " << returnCode << "\n";
+            error("recv system call failed, RC= {RC}", "RC", returnCode);
         }
         else
         {
@@ -404,8 +406,7 @@ int main(int argc, char** argv)
                 if (MCTP_MSG_TYPE_PLDM != requestMsg[1])
                 {
                     // Skip this message and continue.
-                    std::cerr << "Encountered Non-PLDM type message"
-                              << "\n";
+                    error("Encountered Non-PLDM type message");
                 }
                 else
                 {
@@ -439,13 +440,11 @@ int main(int argc, char** argv)
                                                  sizeof(currentSendbuffSize));
                             if (res == -1)
                             {
-                                std::cerr
-                                    << "Responder : Failed to set the new send buffer size [bytes] : "
-                                    << currentSendbuffSize
-                                    << " from current size [bytes] : "
-                                    << oldBuffSize
-                                    << ", Error : " << strerror(errno)
-                                    << std::endl;
+                                error(
+                                    "Responder : Failed to set the new send buffer size [bytes] : {CUR_BUFF_SIZE} from current size [bytes] : {OLD_BUFF_SIZE}, Error : {ERR}",
+                                    "CUR_BUFF_SIZE", currentSendbuffSize,
+                                    "OLD_BUFF_SIZE", oldBuffSize, "ERR",
+                                    strerror(errno));
                                 return;
                             }
                         }
@@ -454,18 +453,17 @@ int main(int argc, char** argv)
                         if (-1 == result)
                         {
                             returnCode = -errno;
-                            std::cerr << "sendto system call failed, RC= "
-                                      << returnCode << "\n";
+                            error("sendto system call failed, RC= {RC}", "RC",
+                                  returnCode);
                         }
                     }
                 }
             }
             else
             {
-                std::cerr
-                    << "Failure to read peeked length packet. peekedLength= "
-                    << peekedLength << " recvDataLength=" << recvDataLength
-                    << "\n";
+                error(
+                    "Failure to read peeked length packet. peekedLength = {PEEK_LEN}, recvDataLength= {RECV_DATA}",
+                    "PEEK_LEN", peekedLength, "RECV_DATA", recvDataLength);
             }
         }
     };
@@ -486,7 +484,7 @@ int main(int argc, char** argv)
 
     if (shutdown(sockfd, SHUT_RDWR))
     {
-        std::perror("Failed to shutdown the socket");
+        error("Failed to shutdown the socket");
     }
     if (returnCode)
     {

--- a/pldmtool/meson.build
+++ b/pldmtool/meson.build
@@ -27,6 +27,7 @@ executable(
     libpldmutils,
     nlohmann_json,
     phosphor_dbus_interfaces,
+    phosphor_logging_dep,
     sdbusplus,
   ],
   install: true,

--- a/pldmtool/pldm_base_cmd.cpp
+++ b/pldmtool/pldm_base_cmd.cpp
@@ -4,6 +4,8 @@
 
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #ifdef OEM_IBM
 #include "libpldm/file_io.h"
 #include "libpldm/host.h"
@@ -109,8 +111,8 @@ class GetPLDMTypes : public CommandInterface
                                         types.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 
@@ -180,8 +182,8 @@ class GetPLDMVersion : public CommandInterface
                                     &transferHandle, &transferFlag, &version);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         char buffer[16] = {0};
@@ -230,8 +232,8 @@ class GetTID : public CommandInterface
         auto rc = decode_get_tid_resp(responsePtr, payloadLength, &cc, &tid);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << "\n";
+            lg2::error("Response Message Error:rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         ordered_json data;
@@ -278,8 +280,8 @@ class GetPLDMCommands : public CommandInterface
                                            cmdTypes.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         printPldmCommands(cmdTypes, pldmType);

--- a/pldmtool/pldm_bios_cmd.cpp
+++ b/pldmtool/pldm_bios_cmd.cpp
@@ -7,6 +7,8 @@
 #include "common/utils.hpp"
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <map>
 #include <optional>
 
@@ -29,6 +31,12 @@ const std::map<const char*, pldm_bios_table_types> pldmBIOSTableTypes{
     {"StringTable", PLDM_BIOS_STRING_TABLE},
     {"AttributeTable", PLDM_BIOS_ATTR_TABLE},
     {"AttributeValueTable", PLDM_BIOS_ATTR_VAL_TABLE},
+};
+
+const std::map<pldm_bios_table_types, const char*> pldmBIOSTableMap{
+    {PLDM_BIOS_STRING_TABLE, "String Table"},
+    {PLDM_BIOS_ATTR_TABLE, "Attribute Table"},
+    {PLDM_BIOS_ATTR_VAL_TABLE, "Attribute Value Table"},
 };
 
 } // namespace
@@ -65,8 +73,8 @@ class GetDateTime : public CommandInterface
                                       &minutes, &hours, &day, &month, &year);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 
@@ -123,8 +131,7 @@ class SetDateTime : public CommandInterface
         if (!uintToDate(tmData, &year, &month, &day, &hours, &minutes,
                         &seconds))
         {
-            std::cerr << "decode date Error: "
-                      << "tmData=" << tmData << std::endl;
+            lg2::error("decode date Error: tmData={KEY0}", "KEY0", tmData);
 
             return {PLDM_ERROR_INVALID_DATA, requestMsg};
         }
@@ -144,9 +151,9 @@ class SetDateTime : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode
-                      << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
+
             return;
         }
 
@@ -204,15 +211,16 @@ class GetBIOSTableHandler : public CommandInterface
                                             tableType, request);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "Encode GetBIOSTable Error, tableType=," << tableType
-                      << " ,rc=" << rc << std::endl;
+            lg2::error(
+                "Encode GetBIOSTable Error, tableType= {KEY0}, rc = {KEY1}",
+                "KEY0", pldmBIOSTableMap.at(tableType), "KEY1", rc);
             return std::nullopt;
         }
         std::vector<uint8_t> responseMsg;
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "PLDM: Communication Error, rc =" << rc << std::endl;
+            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return std::nullopt;
         }
 
@@ -229,8 +237,10 @@ class GetBIOSTableHandler : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "GetBIOSTable Response Error: tableType=" << tableType
-                      << ", rc=" << rc << ", cc=" << (int)cc << std::endl;
+            lg2::error(
+                "GetBIOSTable Response Error: tableType={KEY0}, rc ={KEY1}, cc={KEY2}",
+                "KEY0", pldmBIOSTableMap.at(tableType), "KEY1", rc, "KEY2",
+                (int)cc);
             return std::nullopt;
         }
         auto tableData =
@@ -361,7 +371,7 @@ class GetBIOSTableHandler : public CommandInterface
             }
             else
             {
-                std::cout << "Get AttributeType failed.\n";
+                lg2::info("Get AttributeType failed.");
             }
         }
         switch (attrType)
@@ -436,7 +446,7 @@ class GetBIOSTableHandler : public CommandInterface
             case PLDM_BIOS_PASSWORD:
             case PLDM_BIOS_PASSWORD_READ_ONLY:
             {
-                std::cout << "Password attribute: Not Supported" << std::endl;
+                lg2::info("Password attribute: Not Supported");
                 break;
             }
         }
@@ -501,7 +511,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!stringTable)
         {
-            std::cerr << "GetBIOSStringTable Error" << std::endl;
+            lg2::error("GetBIOSStringTable Error");
             return;
         }
         ordered_json stringdata;
@@ -521,7 +531,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!stringTable)
         {
-            std::cerr << "GetBIOSAttributeTable Error" << std::endl;
+            lg2::error("GetBIOSAttributeTable Error");
             return;
         }
         ordered_json output;
@@ -547,7 +557,7 @@ class GetBIOSTable : public GetBIOSTableHandler
             }
             else
             {
-                std::cout << "Get AttributeType failed.\n";
+                lg2::error("Get AttributeType failed.");
             }
 
             switch (attrType)
@@ -630,8 +640,7 @@ class GetBIOSTable : public GetBIOSTableHandler
                 }
                 case PLDM_BIOS_PASSWORD:
                 case PLDM_BIOS_PASSWORD_READ_ONLY:
-                    std::cout << "Password attribute: Not Supported"
-                              << std::endl;
+                    lg2::alert("Password attribute: Not Supported");
             }
             output.emplace_back(std::move(attrdata));
         }
@@ -643,7 +652,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!attrValTable)
         {
-            std::cerr << "GetBIOSAttributeValueTable Error" << std::endl;
+            lg2::error("GetBIOSAttributeValueTable Error");
             return;
         }
         ordered_json output;
@@ -688,14 +697,14 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
 
         if (!stringTable || !attrTable)
         {
-            std::cout << "StringTable/AttrTable Unavaliable" << std::endl;
+            lg2::info("StringTable/AttrTable Unavaliable");
             return;
         }
 
         auto handle = findAttrHandleByName(attrName, *attrTable, *stringTable);
         if (!handle)
         {
-            std::cerr << "Can not find the attribute " << attrName << std::endl;
+            lg2::error("Can not find the attribute {KEY0}", "KEY0", attrName);
             return;
         }
 
@@ -708,7 +717,7 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
             instanceId, 0, PLDM_GET_FIRSTPART, *handle, request);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "PLDM: Request Message Error, rc =" << rc << std::endl;
+            lg2::error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
 
@@ -716,7 +725,7 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "PLDM: Communication Error, rc =" << rc << std::endl;
+            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
 
@@ -732,8 +741,9 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
             &attributeData);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
+
             return;
         }
 
@@ -782,7 +792,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
 
         if (!stringTable || !attrTable)
         {
-            std::cout << "StringTable/AttrTable Unavaliable" << std::endl;
+            lg2::info("StringTable/AttrTable Unavaliable");
             return;
         }
 
@@ -790,7 +800,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
             findAttrEntryByName(attrName, *attrTable, *stringTable);
         if (attrEntry == nullptr)
         {
-            std::cout << "Could not find attribute :" << attrName << std::endl;
+            lg2::info("Could not find attribute :{KEY0}", "KEY0", attrName);
             return;
         }
 
@@ -818,9 +828,8 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                     attrValue.c_str());
                 if (stringEntry == nullptr)
                 {
-                    std::cout
-                        << "Set Attribute Error: It's not a possible value"
-                        << std::endl;
+                    lg2::info("Set Attribute Error: It's not a possible value");
+
                     return;
                 }
                 auto valueHandle =
@@ -834,9 +843,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                 }
                 if (i == pvNum)
                 {
-                    std::cout
-                        << "Set Attribute Error: It's not a possible value"
-                        << std::endl;
+                    lg2::info("Set Attribute Error: It's not a possible value");
                     return;
                 }
 
@@ -886,14 +893,14 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
 
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "PLDM: Request Message Error, rc =" << rc << std::endl;
+            lg2::error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
         std::vector<uint8_t> responseMsg;
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "PLDM: Communication Error, rc =" << rc << std::endl;
+            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
         uint8_t cc = 0;
@@ -906,8 +913,8 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
             responsePtr, payloadLength, &cc, &nextTransferHandle);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 

--- a/pldmtool/pldm_cmd_helper.cpp
+++ b/pldmtool/pldm_cmd_helper.cpp
@@ -6,6 +6,7 @@
 
 #include <systemd/sd-bus.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
 
@@ -32,7 +33,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == sockFd)
     {
         returnCode = -errno;
-        std::cerr << "Failed to create the socket : RC = " << sockFd << "\n";
+        lg2::error("Failed to create the socket : RC = {KEY0}", "KEY0", sockFd);
         return returnCode;
     }
     Logger(pldmVerbose, "Success in creating the socket : RC = ", sockFd);
@@ -49,8 +50,9 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Failed to connect to socket : RC = " << returnCode
-                  << "\n";
+        lg2::error("Failed to connect to socket : RC = {KEY0}", "KEY0",
+                   returnCode);
+
         return returnCode;
     }
     Logger(pldmVerbose, "Success in connecting to socket : RC = ", returnCode);
@@ -60,8 +62,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Failed to send message type as pldm to mctp : RC = "
-                  << returnCode << "\n";
+        lg2::error("Failed to send message type as pldm to mctp : RC = {KEY0}",
+                   "KEY0", returnCode);
         return returnCode;
     }
     Logger(
@@ -72,7 +74,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Write to socket failure : RC = " << returnCode << "\n";
+        lg2::error("Write to socket failure : RC = {KEY0}", "KEY0", returnCode);
         return returnCode;
     }
     Logger(pldmVerbose, "Write to socket successful : RC = ", result);
@@ -81,14 +83,16 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     ssize_t peekedLength = recv(socketFd(), nullptr, 0, MSG_TRUNC | MSG_PEEK);
     if (0 == peekedLength)
     {
-        std::cerr << "Socket is closed : peekedLength = " << peekedLength
-                  << "\n";
+        lg2::error("Socket is closed : peekedLength = {KEY0}", "KEY0",
+                   peekedLength);
+
         return returnCode;
     }
     else if (peekedLength <= -1)
     {
         returnCode = -errno;
-        std::cerr << "recv() system call failed : RC = " << returnCode << "\n";
+        lg2::error("recv() system call failed : RC = {KEY0}", "KEY0",
+                   returnCode);
         return returnCode;
     }
     else
@@ -113,8 +117,9 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
             }
             else if (recvDataLength != peekedLength)
             {
-                std::cerr << "Failure to read response length packet: length = "
-                          << recvDataLength << "\n";
+                lg2::error(
+                    "Failure to read response length packet: length = {KEY0}",
+                    "KEY0", recvDataLength);
                 return returnCode;
             }
         } while (1);
@@ -124,8 +129,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == returnCode)
     {
         returnCode = -errno;
-        std::cerr << "Failed to shutdown the socket : RC = " << returnCode
-                  << "\n";
+        lg2::error("Failed to shutdown the socket : RC ={KEY0}", "KEY0",
+                   returnCode);
         return returnCode;
     }
 
@@ -150,15 +155,17 @@ void CommandInterface::exec()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "GetInstanceId D-Bus call failed, MCTP id = "
-                  << (unsigned)mctp_eid << ", error = " << e.what() << "\n";
+        lg2::error(
+            "GetInstanceId D-Bus call failed, MCTP id = {KEY0}, error = {KEY1}",
+            "KEY0", (unsigned)mctp_eid, "KEY1", e.what());
         return;
     }
     auto [rc, requestMsg] = createRequestMsg();
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to encode request message for " << pldmType << ":"
-                  << commandName << " rc = " << rc << "\n";
+        lg2::error(
+            "Failed to encode request message for {KEY0} : {KEY1}, rc = {KEY1}",
+            "KEY0", pldmType, "KEY1", commandName, "KEY1", rc);
         return;
     }
 
@@ -167,7 +174,7 @@ void CommandInterface::exec()
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "pldmSendRecv: Failed to receive RC = " << rc << "\n";
+        lg2::error("pldmSendRecv: Failed to receive RC = {KEY0}", "KEY0", rc);
         return;
     }
 
@@ -202,8 +209,8 @@ int CommandInterface::pldmSendRecv(std::vector<uint8_t>& requestMsg,
         int fd = pldm_open();
         if (-1 == fd)
         {
-            std::cerr << "failed to init mctp "
-                      << "\n";
+            lg2::error("failed to init mctp ");
+
             return -1;
         }
         uint8_t* responseMessage = nullptr;

--- a/pldmtool/pldm_fru_cmd.cpp
+++ b/pldmtool/pldm_fru_cmd.cpp
@@ -2,6 +2,8 @@
 
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #ifdef OEM_IBM
 #include "libpldm/fru_oem_ibm.h"
 #endif
@@ -63,8 +65,9 @@ class GetFruRecordTableMetadata : public CommandInterface
             &total_record_set_identifiers, &total_table_records, &checksum);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
+
             return;
         }
         ordered_json output;
@@ -382,8 +385,8 @@ class GetFRURecordByOption : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 
@@ -434,8 +437,9 @@ class GetFruRecordTable : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
+
             return;
         }
 

--- a/pldmtool/pldm_fw_update_cmd.cpp
+++ b/pldmtool/pldm_fw_update_cmd.cpp
@@ -5,6 +5,8 @@
 #include "common/utils.hpp"
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 namespace pldmtool
 {
 
@@ -92,8 +94,8 @@ class GetStatus : public CommandInterface
             &reasonCode, &updateOptionFlagsEnabled);
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
             return;
         }
 
@@ -177,9 +179,9 @@ class GetFwParams : public CommandInterface
             &pendingCompImageSetVersion, &compParameterTable);
         if (rc != PLDM_SUCCESS || fwParams.completion_code != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)fwParams.completion_code
-                      << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)fwParams.completion_code);
+
             return;
         }
 
@@ -267,9 +269,9 @@ class GetFwParams : public CommandInterface
                 &pendingCompVerStr);
             if (rc)
             {
-                std::cerr
-                    << "Decoding component parameter table entry failed, RC="
-                    << rc << "\n";
+                lg2::error(
+                    "Decoding component parameter table entry failed, RC={KEY0}",
+                    "KEY0", rc);
                 return;
             }
 

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -4,6 +4,8 @@
 #include "common/types.hpp"
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cstddef>
 #include <map>
 
@@ -122,10 +124,10 @@ class GetPDR : public CommandInterface
                     recordsSeen.emplace(recordHandle, prevRecordHandle);
                 if (!result.second)
                 {
-                    std::cerr
-                        << "Record handle " << recordHandle
-                        << " has multiple references: " << result.first->second
-                        << ", " << prevRecordHandle << "\n";
+                    lg2::error(
+                        "Record handle {KEY0} has multiple references: {KEY1}, {KEY2}",
+                        "KEY0", recordHandle, "KEY1", result.first->second,
+                        "KEY2", prevRecordHandle);
                     return;
                 }
                 prevRecordHandle = recordHandle;
@@ -175,9 +177,8 @@ class GetPDR : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode
-                      << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
             return;
         }
 
@@ -733,7 +734,7 @@ class GetPDR : public CommandInterface
             reinterpret_cast<pldm_pdr_fru_record_set*>(data);
         if (!pdr)
         {
-            std::cerr << "Failed to get the FRU record set PDR" << std::endl;
+            lg2::error("Failed to get the FRU record set PDR");
             return;
         }
 
@@ -761,8 +762,7 @@ class GetPDR : public CommandInterface
             reinterpret_cast<pldm_pdr_entity_association*>(data);
         if (!pdr)
         {
-            std::cerr << "Failed to get the PDR eneity association"
-                      << std::endl;
+            lg2::error("Failed to get the PDR eneity association");
             return;
         }
 
@@ -774,7 +774,7 @@ class GetPDR : public CommandInterface
         }
         else
         {
-            std::cout << "Get associationType failed.\n";
+            lg2::info("Get associationType failed.");
         }
         output["containerEntityType"] =
             getEntityName(pdr->container.entity_type);
@@ -807,7 +807,7 @@ class GetPDR : public CommandInterface
             (struct pldm_numeric_effecter_value_pdr*)data;
         if (!pdr)
         {
-            std::cerr << "Failed to get numeric effecter PDR" << std::endl;
+            lg2::error("Failed to get numeric effecter PDR");
             return;
         }
 
@@ -1002,7 +1002,7 @@ class GetPDR : public CommandInterface
     {
         if (data == NULL)
         {
-            std::cerr << "Failed to get PDR message" << std::endl;
+            lg2::error("Failed to get PDR message");
             return;
         }
 
@@ -1022,8 +1022,9 @@ class GetPDR : public CommandInterface
             // is not supported
             if (!strToPdrType.contains(pdrRecType))
             {
-                std::cerr << "PDR type '" << pdrRecType
-                          << "' is not supported or invalid\n";
+                lg2::error("PDR type {KEY0} is not supported or invalid",
+                           "KEY0", pdrRecType);
+
                 // PDR type not supported, setting next record handle to 0
                 // to avoid looping through all PDR records
                 nextRecordHndl = 0;
@@ -1115,16 +1116,18 @@ class SetStateEffecter : public CommandInterface
         if (effecterCount > maxEffecterCount ||
             effecterCount < minEffecterCount)
         {
-            std::cerr << "Request Message Error: effecterCount size "
-                      << effecterCount << "is invalid\n";
+            lg2::error(
+                "Request Message Error: effecterCount size {KEY0} is invalid",
+                "KEY0", effecterCount);
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
 
         if (effecterData.size() > maxEffecterDataSize)
         {
-            std::cerr << "Request Message Error: effecterData size "
-                      << effecterData.size() << "is invalid\n";
+            lg2::error(
+                "Request Message Error: effecterData size {KEY0} is invalid",
+                "KEY0", effecterData.size());
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
@@ -1132,8 +1135,9 @@ class SetStateEffecter : public CommandInterface
         auto stateField = parseEffecterData(effecterData, effecterCount);
         if (!stateField)
         {
-            std::cerr << "Failed to parse effecter data, effecterCount size "
-                      << effecterCount << "\n";
+            lg2::error(
+                "Failed to parse effecter data, effecterCount size {KEY0}",
+                "KEY0", effecterCount);
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
@@ -1151,8 +1155,9 @@ class SetStateEffecter : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
+
             return;
         }
 
@@ -1232,9 +1237,9 @@ class SetNumericEffecterValue : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode
-                      << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
+
             return;
         }
 
@@ -1299,9 +1304,9 @@ class GetStateSensorReadings : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode
-                      << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
+
             return;
         }
         ordered_json output;

--- a/requester/handler.hpp
+++ b/requester/handler.hpp
@@ -12,6 +12,7 @@
 #include <sys/socket.h>
 
 #include <function2/function2.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/timer.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/source/event.hpp>
@@ -22,12 +23,12 @@
 #include <tuple>
 #include <unordered_map>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace requester
 {
-
 /** @struct RequestKey
  *
  *  RequestKey uniquely identifies the PLDM request message to match it with the
@@ -133,21 +134,20 @@ class Handler
         auto instanceIdExpiryCallBack = [key, this](void) {
             if (this->handlers.contains(key))
             {
-                std::cerr << "Response not received for the request, instance "
-                             "ID expired."
-                          << " EID = " << (unsigned)key.eid
-                          << " INSTANCE_ID = " << (unsigned)key.instanceId
-                          << " TYPE = " << (unsigned)key.type
-                          << " COMMAND = " << (unsigned)key.command << "\n";
+                error(
+                    "Response not received for the request, instance ID expired. EID = {EID} INSTANCE_ID = {INST_ID} TYPE = {KEY_TYP} COMMAND = {CMD}",
+                    "EID", (unsigned)key.eid, "INST_ID",
+                    (unsigned)key.instanceId, "KEY_TYP", (unsigned)key.type,
+                    "CMD", (unsigned)key.command);
                 auto& [request, responseHandler, timerInstance] =
                     this->handlers[key];
                 request->stop();
                 auto rc = timerInstance->stop();
                 if (rc)
                 {
-                    std::cerr
-                        << "Failed to stop the instance ID expiry timer. RC = "
-                        << rc << "\n";
+                    error(
+                        "Failed to stop the instance ID expiry timer. RC = {RC}",
+                        "RC", rc);
                 }
                 // Call response handler with an empty response to indicate no
                 // response
@@ -176,8 +176,7 @@ class Handler
         if (rc)
         {
             requester.markFree(eid, instanceId);
-            std::cerr << "Failure to send the PLDM request message"
-                      << "\n";
+            error("Failure to send the PLDM request message");
             return rc;
         }
 
@@ -189,8 +188,9 @@ class Handler
         catch (const std::runtime_error& e)
         {
             requester.markFree(eid, instanceId);
-            std::cerr << "Failed to start the instance ID expiry timer. RC = "
-                      << e.what() << "\n";
+            error(
+                "Failed to start the instance ID expiry timer. RC = {ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
 
@@ -221,9 +221,8 @@ class Handler
             auto rc = timerInstance->stop();
             if (rc)
             {
-                std::cerr
-                    << "Failed to stop the instance ID expiry timer. RC = "
-                    << rc << "\n";
+                error("Failed to stop the instance ID expiry timer. RC = {RC}",
+                      "RC", rc);
             }
             responseHandler(eid, response, respMsgLen);
             requester.markFree(key.eid, key.instanceId);

--- a/requester/request.hpp
+++ b/requester/request.hpp
@@ -9,6 +9,7 @@
 
 #include <sys/socket.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/timer.hpp>
 #include <sdeventplus/event.hpp>
 
@@ -16,12 +17,12 @@
 #include <functional>
 #include <iostream>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace requester
 {
-
 /** @class RequestRetryTimer
  *
  *  The abstract base class for implementing the PLDM request retry logic. This
@@ -75,8 +76,8 @@ class RequestRetryTimer
         }
         catch (const std::runtime_error& e)
         {
-            std::cerr << "Failed to start the request timer. RC = " << e.what()
-                      << "\n";
+            error("Failed to start the request timer. RC = {RC}", "RC",
+                  e.what());
             return PLDM_ERROR;
         }
 
@@ -89,8 +90,8 @@ class RequestRetryTimer
         auto rc = timer.stop();
         if (rc)
         {
-            std::cerr << "Failed to stop the request timer. RC = " << rc
-                      << "\n";
+            error("Failed to stop the request timer. RC = {RC}", "RC",
+                  static_cast<int>(rc));
         }
     }
 
@@ -188,11 +189,10 @@ class Request final : public RequestRetryTimer
                            sizeof(currentSendbuffSize));
             if (res == -1)
             {
-                std::cerr
-                    << "Requester : Failed to set the new send buffer size [bytes] : "
-                    << currentSendbuffSize
-                    << " from current size [bytes]: " << oldSendbuffSize
-                    << " , Error : " << strerror(errno) << std::endl;
+                error(
+                    "Requester : Failed to set the new send buffer size [bytes] : {CUR_SND_BUFF_SIZE} from current size [bytes]: {OLD_BUF_SIZE} , Error : {ERR}",
+                    "CUR_SND_BUFF_SIZE", currentSendbuffSize, "OLD_BUF_SIZE",
+                    oldSendbuffSize, "ERR", strerror(errno));
                 return PLDM_ERROR;
             }
         }
@@ -201,8 +201,8 @@ class Request final : public RequestRetryTimer
         auto rc = pldm_send(eid, fd, requestMsg.data(), requestMsg.size());
         if (rc < 0)
         {
-            std::cerr << "Failed to send PLDM message. RC = " << rc
-                      << ", errno = " << errno << "\n";
+            error("Failed to send PLDM message. RC = {RC}, errno = {ERR}", "RC",
+                  static_cast<int>(rc), "ERR", errno);
             return PLDM_ERROR;
         }
         return PLDM_SUCCESS;

--- a/requester/test/meson.build
+++ b/requester/test/meson.build
@@ -19,6 +19,7 @@ foreach t : tests
                          gtest,
                          gmock,
                          libpldm_dep,
+			 phosphor_logging_dep,
                          nlohmann_json,
                          phosphor_dbus_interfaces,
                          sdbusplus,

--- a/softoff/main.cpp
+++ b/softoff/main.cpp
@@ -3,7 +3,11 @@
 
 #include <getopt.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 int main(int argc, char* argv[])
 {
@@ -16,7 +20,7 @@ int main(int argc, char* argv[])
     {
         case 't':
             noTimeOut = true;
-            std::cout << "Not applying any time outs\n";
+            info("Not applying any time outs");
             break;
         case -1:
             break;
@@ -37,15 +41,15 @@ int main(int argc, char* argv[])
 
     if (softPower.isError())
     {
-        std::cerr << "Host failed to gracefully shutdown, exiting "
-                     "pldm-softpoweroff app\n";
+        error(
+            "Host failed to gracefully shutdown, exiting pldm-softpoweroff app");
         return -1;
     }
 
     if (softPower.isCompleted())
     {
-        std::cerr << "Host current state is not Running, exiting "
-                     "pldm-softpoweroff app\n";
+        error(
+            "Host current state is not Running, exiting pldm-softpoweroff app");
         return 0;
     }
 
@@ -53,9 +57,8 @@ int main(int argc, char* argv[])
     // wait the host gracefully shutdown.
     if (softPower.hostSoftOff(event))
     {
-        std::cerr << "pldm-softpoweroff:Failure in sending soft off request to "
-                     "the host. Exiting pldm-softpoweroff app\n";
-
+        error(
+            "pldm-softpoweroff:Failure in sending soft off request to the host. Exiting pldm-softpoweroff app");
         return -1;
     }
 
@@ -77,14 +80,12 @@ int main(int argc, char* argv[])
         }
         catch (const sdbusplus::exception::exception& e)
         {
-            std::cerr << "SoftPowerOff:Failed to create BMC dump, ERROR="
-                      << e.what() << std::endl;
+            error("SoftPowerOff:Failed to create BMC dump, ERROR={ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
         }
 
-        std::cerr
-            << "PLDM host soft off: ERROR! Wait for the host soft off timeout."
-            << "Exit the pldm-softpoweroff "
-            << "\n";
+        error(
+            "PLDM host soft off: ERROR! Wait for the host soft off timeout. Exit the pldm-softpoweroff");
         return -1;
     }
 

--- a/softoff/meson.build
+++ b/softoff/meson.build
@@ -5,6 +5,7 @@ deps = [
     sdeventplus,
     sdbusplus,
     phosphor_dbus_interfaces,
+    phosphor_logging_dep,
     ]
 
 source = ['main.cpp','softoff.cpp']

--- a/softoff/softoff.cpp
+++ b/softoff/softoff.cpp
@@ -9,6 +9,7 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
 #include <sdeventplus/clock.hpp>
 #include <sdeventplus/exception.hpp>
@@ -18,9 +19,10 @@
 #include <array>
 #include <iostream>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 using namespace sdeventplus;
 using namespace sdeventplus::source;
 constexpr auto clockId = sdeventplus::ClockId::RealTime;
@@ -50,8 +52,7 @@ SoftPowerOff::SoftPowerOff(sdbusplus::bus_t& bus, sd_event* event,
     auto rc = getEffecterID();
     if (completed)
     {
-        std::cerr
-            << "pldm-softpoweroff: effecter to initiate softoff not found \n";
+        error("pldm-softpoweroff: effecter to initiate softoff not found");
         return;
     }
     else if (rc != PLDM_SUCCESS)
@@ -63,9 +64,8 @@ SoftPowerOff::SoftPowerOff(sdbusplus::bus_t& bus, sd_event* event,
     rc = getSensorInfo();
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message get Sensor PDRs error. PLDM "
-                     "error code = "
-                  << std::hex << std::showbase << rc << "\n";
+        error("Message get Sensor PDRs error. PLDM error code = {RC}", "RC",
+              lg2::hex, (int)rc);
         hasError = true;
         return;
     }
@@ -101,7 +101,7 @@ int SoftPowerOff::getHostState()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "PLDM host soft off: Can't get current host state.\n";
+        error("PLDM host soft off: Can't get current host state.");
         hasError = true;
         return PLDM_ERROR;
     }
@@ -124,7 +124,7 @@ void SoftPowerOff::hostSoftOffComplete(sdbusplus::message_t& msg)
     if (msgSensorID == sensorID && msgSensorOffset == sensorOffset &&
         msgEventState == PLDM_SW_TERM_GRACEFUL_SHUTDOWN && msgTID == TID)
     {
-        std::cout << "Recieved the graceful shutdown signal from host\n";
+        info("Recieved the graceful shutdown signal from host");
         if (!noTimeOut)
         {
             // Receive Graceful shutdown completion event message. Disable the
@@ -132,8 +132,8 @@ void SoftPowerOff::hostSoftOffComplete(sdbusplus::message_t& msg)
             auto rc = timer.stop();
             if (rc < 0)
             {
-                std::cerr << "PLDM soft off: Failure to STOP the timer. ERRNO="
-                          << rc << "\n";
+                error("PLDM soft off: Failure to STOP the timer. ERRNO={RC}",
+                      "RC", rc);
             }
         }
 
@@ -178,8 +178,8 @@ int SoftPowerOff::getEffecterID()
     }
     catch (const sdbusplus::exception_t& e)
     {
-        std::cerr << "PLDM soft off: Error get VMM PDR,ERROR=" << e.what()
-                  << "\n";
+        error("PLDM soft off: Error get VMM PDR,ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
         VMMPdrExist = false;
     }
 
@@ -208,9 +208,7 @@ int SoftPowerOff::getEffecterID()
 
         if (sysFwResponse.size() == 0)
         {
-            std::cerr
-                << "No effecter ID has been found that matches the criteria"
-                << "\n";
+            error("No effecter ID has been found that matches the criteria");
             return PLDM_ERROR;
         }
 
@@ -224,8 +222,8 @@ int SoftPowerOff::getEffecterID()
     }
     catch (const sdbusplus::exception_t& e)
     {
-        std::cerr << "PLDM soft off: Error get system firmware PDR,ERROR="
-                  << e.what() << "\n";
+        error("PLDM soft off: Error get system firmware PDR,ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         completed = true;
         return PLDM_ERROR;
     }
@@ -256,9 +254,7 @@ int SoftPowerOff::getSensorInfo()
 
         if (Response.size() == 0)
         {
-            std::cerr
-                << "No sensor PDR has been found that matches the criteria"
-                << "\n";
+            error("No sensor PDR has been found that matches the criteria");
             return PLDM_ERROR;
         }
 
@@ -268,7 +264,7 @@ int SoftPowerOff::getSensorInfo()
             pdr = reinterpret_cast<pldm_state_sensor_pdr*>(rep.data());
             if (!pdr)
             {
-                std::cerr << "Failed to get state sensor PDR.\n";
+                error("Failed to get state sensor PDR.");
                 return PLDM_ERROR;
             }
         }
@@ -297,8 +293,8 @@ int SoftPowerOff::getSensorInfo()
     }
     catch (const sdbusplus::exception_t& e)
     {
-        std::cerr << "PLDM soft off: Error get State Sensor PDR,ERROR="
-                  << e.what() << "\n";
+        error("PLDM soft off: Error get State Sensor PDR,ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -343,8 +339,8 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
     }
     catch (const sdbusplus::exception_t& e)
     {
-        std::cerr << "PLDM soft off: Error get instanceID,ERROR=" << e.what()
-                  << "\n";
+        error("PLDM soft off: Error get instanceID,ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -358,8 +354,8 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
         instanceID, effecterID, effecterCount, &stateField, request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message encode failure. PLDM error code = " << std::hex
-                  << std::showbase << rc << "\n";
+        error("Message encode failure. PLDM error code = {RC}", "RC", lg2::hex,
+              static_cast<int>(rc));
         return PLDM_ERROR;
     }
 
@@ -367,8 +363,7 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
     int fd = pldm_open();
     if (-1 == fd)
     {
-        std::cerr << "Failed to connect to mctp demux daemon"
-                  << "\n";
+        error("Failed to connect to mctp demux daemon");
         return PLDM_ERROR;
     }
 
@@ -377,9 +372,8 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
                                    Timer::TimePoint /*time*/) {
         if (!responseReceived)
         {
-            std::cerr << "PLDM soft off: ERROR! Can't get the response for the "
-                         "PLDM request msg. Time out!\n"
-                      << "Exit the pldm-softpoweroff\n";
+            error(
+                "PLDM soft off: ERROR! Can't get the response for the PLDM request msg. Time out! Exit the pldm-softpoweroff");
             exit(-1);
         }
         return;
@@ -401,8 +395,8 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
                             &responseMsgSize);
         if (rc)
         {
-            std::cerr << "Soft off: failed to recv pldm data. PLDM RC = " << rc
-                      << "\n";
+            error("Soft off: failed to recv pldm data. PLDM RC = {RC}", "RC",
+                  static_cast<int>(rc));
             return;
         }
 
@@ -415,16 +409,15 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
         auto response = reinterpret_cast<pldm_msg*>(responseMsgPtr.get());
         if (response->payload[0] != PLDM_SUCCESS)
         {
-            std::cerr
-                << "Got a bad respose for soft off seteffecter states command . PLDM RC = "
-                << (unsigned)response->payload[0] << "\n";
+            error(
+                "Got a bad respose for soft off seteffecter states command . PLDM RC = {RC}",
+                "RC", static_cast<uint16_t>(response->payload[0]));
             exit(-1);
         }
 
-        std::cerr
-            << "Got the response for set effecter states command, PLDM RC = "
-            << std::hex << std::showbase
-            << static_cast<uint16_t>(response->payload[0]) << "\n";
+        error(
+            "Got the response for set effecter states command, PLDM RC = {RC}",
+            "RC", lg2::hex, static_cast<uint16_t>(response->payload[0]));
         std::vector<uint8_t> responseMessage;
         responseMessage.resize(responseMsgSize);
         memcpy(responseMessage.data(), responseMsg, responseMessage.size());
@@ -442,16 +435,16 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
             auto ret = startTimer(timeMicroseconds);
             if (ret < 0)
             {
-                std::cerr
-                    << "Failure to start Host soft off wait timer, ERRNO = "
-                    << ret << "Exit the pldm-softpoweroff\n";
+                error(
+                    "Failure to start Host soft off wait timer, ERRNO = {ERR} Exit the pldm-softpoweroff",
+                    "ERR", ret);
                 exit(-1);
             }
             else
             {
-                std::cerr
-                    << "Timer started waiting for host soft off, TIMEOUT_IN_SEC = "
-                    << SOFTOFF_TIMEOUT_SECONDS << "\n";
+                error(
+                    "Timer started waiting for host soft off, TIMEOUT_IN_SEC = {TIMEOUT_IN_SEC}",
+                    "TIMEOUT_IN_SEC", SOFTOFF_TIMEOUT_SECONDS);
             }
         }
         return;
@@ -462,8 +455,9 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
     rc = pldm_send(mctpEID, fd, requestMsg.data(), requestMsg.size());
     if (0 > rc)
     {
-        std::cerr << "Failed to send message/receive response. RC = " << rc
-                  << ", errno = " << errno << "\n";
+        error(
+            "Failed to send message/receive response. RC = {RC}, errno = {ERR}",
+            "RC", static_cast<int>(rc), "ERR", errno);
         return PLDM_ERROR;
     }
     std::vector<uint8_t> requestbuffer(requestMsg.begin(), requestMsg.end());
@@ -478,9 +472,9 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
         }
         catch (const sdeventplus::SdEventError& e)
         {
-            std::cerr
-                << "PLDM host soft off: Failure in processing request.ERROR= "
-                << e.what() << "\n";
+            error(
+                "PLDM host soft off: Failure in processing request.ERROR= {ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }

--- a/subprojects/phosphor-logging.wrap
+++ b/subprojects/phosphor-logging.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/openbmc/phosphor-logging.git
+revision = HEAD
+
+[provide]
+phosphor-logging = phosphor_logging_dep

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,7 @@ foreach t : tests
                      build_rpath: get_option('oe-sdk').enabled() ? rpath : '',
                      dependencies: [
                          libpldm_dep,
+			 phosphor_logging_dep,
                          nlohmann_json,
                          gtest,
                          test_src]),

--- a/utilities/meson.build
+++ b/utilities/meson.build
@@ -1,4 +1,4 @@
-deps = [ CLI11_dep, libpldm_dep, sdeventplus ]
+deps = [ CLI11_dep, libpldm_dep, sdeventplus, phosphor_logging_dep ]
 
 executable('set-state-effecter', 'requester/set_state_effecter.cpp',
            implicit_include_directories: false,

--- a/utilities/requester/set_state_effecter.cpp
+++ b/utilities/requester/set_state_effecter.cpp
@@ -2,9 +2,12 @@
 #include "libpldm/pldm.h"
 
 #include <CLI/CLI.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <array>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 int main(int argc, char** argv)
 {
@@ -29,8 +32,8 @@ int main(int argc, char** argv)
                                                    &stateField, request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message encode failure. PLDM error code = " << std::hex
-                  << std::showbase << rc << "\n";
+        error("Message encode failure. PLDM error code = {RC}", "RC", lg2::hex,
+              rc);
         return -1;
     }
 
@@ -38,8 +41,7 @@ int main(int argc, char** argv)
     int fd = pldm_open();
     if (-1 == fd)
     {
-        std::cerr << "Failed to init mctp"
-                  << "\n";
+        error("Failed to init mctp");
         return -1;
     }
 
@@ -50,13 +52,14 @@ int main(int argc, char** argv)
                         &responseMsg, &responseMsgSize);
     if (0 > rc)
     {
-        std::cerr << "Failed to send message/receive response. RC = " << rc
-                  << ", errno = " << errno << "\n";
+        error(
+            "Failed to send message/receive response. RC = {RC}, errno = {ERR}",
+            "RC", rc, "ERR", errno);
         return -1;
     }
     pldm_msg* response = reinterpret_cast<pldm_msg*>(responseMsg);
-    std::cout << "Done. PLDM RC = " << std::hex << std::showbase
-              << static_cast<uint16_t>(response->payload[0]) << std::endl;
+    info("Done. PLDM RC = {RC}", "RC", lg2::hex,
+         static_cast<uint16_t>(response->payload[0]));
     free(responseMsg);
 
     return 0;

--- a/utilities/requester/set_state_effecter_async.cpp
+++ b/utilities/requester/set_state_effecter_async.cpp
@@ -3,11 +3,14 @@
 #include "libpldm/pldm.h"
 
 #include <CLI/CLI.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/source/io.hpp>
 
 #include <array>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace sdeventplus;
 using namespace sdeventplus::source;
@@ -35,8 +38,8 @@ int main(int argc, char** argv)
                                                    &stateField, request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message encode failure. PLDM error code = " << std::hex
-                  << std::showbase << rc << "\n";
+        error("Message encode failure. PLDM error code = {RC}", "RC", lg2::hex,
+              rc);
         return -1;
     }
 
@@ -44,8 +47,7 @@ int main(int argc, char** argv)
     int fd = pldm_open();
     if (-1 == fd)
     {
-        std::cerr << "Failed to init mctp"
-                  << "\n";
+        error("Failed to init mctp");
         return -1;
     }
 
@@ -67,9 +69,8 @@ int main(int argc, char** argv)
             // sent out
             io.set_enabled(Enabled::Off);
             pldm_msg* response = reinterpret_cast<pldm_msg*>(responseMsg);
-            std::cout << "Done. PLDM RC = " << std::hex << std::showbase
-                      << static_cast<uint16_t>(response->payload[0])
-                      << std::endl;
+            info("Done. PLDM RC = {RC}", "RC", lg2::hex,
+                 static_cast<uint16_t>(response->payload[0]));
             free(responseMsg);
             exit(EXIT_SUCCESS);
         }
@@ -80,8 +81,9 @@ int main(int argc, char** argv)
     rc = pldm_send(mctpEid, fd, requestMsg.data(), requestMsg.size());
     if (0 > rc)
     {
-        std::cerr << "Failed to send message/receive response. RC = " << rc
-                  << ", errno = " << errno << "\n";
+        error(
+            "Failed to send message/receive response. RC = {RC}, errno = {ERR}",
+            "RC", rc, "ERR", errno);
         return -1;
     }
 


### PR DESCRIPTION
This commit adds changes in PLDM for implementing
structured LG2 logging, thereby moving away from
std::cout/cerr practice of logging which are
output streams and not logging mechanism.

PLDM now can make use of lg2 features like accurate CODE LINE Number and CODE_FUNCTION Name and better detailing in json object values which can be used in log tracking.

More detailed logging change:
https://gist.github.com/riyadixitagra/c251685c1ba84248181891f7bc282395

Tested:
Ran a power off, on, cycle, and reset-reload.