### PR TITLE
Populate correct Terminus Id

### DIFF
--- a/host-bmc/dbus_to_event_handler.cpp
+++ b/host-bmc/dbus_to_event_handler.cpp
@@ -6,7 +6,6 @@
 
 namespace pldm
 {
-
 using namespace pldm::dbus_api;
 using namespace pldm::responder;
 using namespace pldm::responder::pdr;
@@ -35,7 +34,7 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
 
     auto rc = encode_platform_event_message_req(
-        instanceId, 1 /*formatVersion*/, 0 /*tId*/, eventType,
+        instanceId, 1 /*formatVersion*/, TERMINUS_ID /*tId*/, eventType,
         eventDataVec.data(), eventDataVec.size(), request,
         eventDataVec.size() + PLDM_PLATFORM_EVENT_MESSAGE_MIN_REQ_BYTES);
     if (rc != PLDM_SUCCESS)

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -649,8 +649,8 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
                                     actualSize);
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
     rc = encode_platform_event_message_req(
-        instanceId, 1, 0, PLDM_PDR_REPOSITORY_CHG_EVENT, eventDataVec.data(),
-        actualSize, request,
+        instanceId, 1, TERMINUS_ID, PLDM_PDR_REPOSITORY_CHG_EVENT,
+        eventDataVec.data(), actualSize, request,
         actualSize + PLDM_PLATFORM_EVENT_MESSAGE_MIN_REQ_BYTES);
     if (rc != PLDM_SUCCESS)
     {

--- a/libpldmresponder/base.cpp
+++ b/libpldmresponder/base.cpp
@@ -237,13 +237,10 @@ void Handler::processSetEventReceiver(
 
 Response Handler::getTID(const pldm_msg* request, size_t /*payloadLength*/)
 {
-    // assigned 1 to the bmc as the PLDM terminus
-    uint8_t tid = 1;
-
     Response response(sizeof(pldm_msg_hdr) + PLDM_GET_TID_RESP_BYTES, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
-    auto rc = encode_get_tid_resp(request->hdr.instance_id, PLDM_SUCCESS, tid,
-                                  responsePtr);
+    auto rc = encode_get_tid_resp(request->hdr.instance_id, PLDM_SUCCESS,
+                                  TERMINUS_ID, responsePtr);
     if (rc != PLDM_SUCCESS)
     {
         return ccOnlyResponse(request, rc);

--- a/libpldmresponder/base.hpp
+++ b/libpldmresponder/base.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config.h"
+
 #include "libpldm/base.h"
 
 #include "libpldmresponder/platform.hpp"
@@ -21,7 +23,6 @@ namespace responder
 {
 namespace base
 {
-
 class Handler : public CmdHandler
 {
   public:

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -977,8 +977,8 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
                                     actualSize);
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
     rc = encode_platform_event_message_req(
-        instanceId, 1, 0, PLDM_PDR_REPOSITORY_CHG_EVENT, eventDataVec.data(),
-        actualSize, request,
+        instanceId, 1, TERMINUS_ID, PLDM_PDR_REPOSITORY_CHG_EVENT,
+        eventDataVec.data(), actualSize, request,
         actualSize + PLDM_PLATFORM_EVENT_MESSAGE_MIN_REQ_BYTES);
     if (rc != PLDM_SUCCESS)
     {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -868,7 +868,7 @@ int encodeEventMsg(uint8_t eventType, const std::vector<uint8_t>& eventDataVec,
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
 
     auto rc = encode_platform_event_message_req(
-        instanceId, 1 /*formatVersion*/, 0 /*tId*/, eventType,
+        instanceId, 1 /*formatVersion*/, TERMINUS_ID, eventType,
         eventDataVec.data(), eventDataVec.size(), request,
         eventDataVec.size() + PLDM_PLATFORM_EVENT_MESSAGE_MIN_REQ_BYTES);
 


### PR DESCRIPTION
Hardcoded terminus id 0 is used at multiple places in the current code. Made changes to populate correct terminus id instead of hardcoded one.