### PR TITLE
Marker Lid validate for Inband updates

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -4,6 +4,8 @@
 
 #include "file_io_by_type.hpp"
 
+#include <xyz/openbmc_project/Software/Version/error.hpp>
+
 #include <filesystem>
 #include <sstream>
 #include <string>
@@ -12,10 +14,15 @@ namespace pldm
 {
 namespace responder
 {
-
 namespace fs = std::filesystem;
 
 using MarkerLIDremainingSize = uint64_t;
+
+constexpr auto markerLidName = "80a00001.lid";
+constexpr auto accessKeyExpired =
+    "sdbusplus::xyz::openbmc_project::Software::Version::Error::ExpiredAccessKey";
+constexpr auto incompatibleErr =
+    "sdbusplus::xyz::openbmc_project::Software::Version::Error::Incompatible";
 
 /** @class LidHandler
  *
@@ -113,6 +120,60 @@ class LidHandler : public FileHandler
         return true;
     }
 
+    int validateMarkerLid(oem_platform::Handler* oemPlatformHandler,
+                          const std::string& lidPath)
+    {
+        int rc = PLDM_SUCCESS;
+        if (oemPlatformHandler != nullptr)
+        {
+            pldm::responder::oem_ibm_platform::Handler* oemIbmPlatformHandler =
+                dynamic_cast<pldm::responder::oem_ibm_platform::Handler*>(
+                    oemPlatformHandler);
+            auto sensorId =
+                oemIbmPlatformHandler->codeUpdate->getMarkerLidSensor();
+            using namespace pldm::responder::oem_ibm_platform;
+            auto markerLidDirPath = fs::path(LID_STAGING_DIR) / "lid" /
+                                    markerLidName;
+            try
+            {
+                auto& bus = pldm::utils::DBusHandler::getBus();
+                rc = processCodeUpdateLid(lidPath);
+                if (rc != PLDM_SUCCESS)
+                {
+                    return rc;
+                }
+                auto method = bus.new_method_call(
+                    "xyz.openbmc_project.Software.BMC.Updater",
+                    "/xyz/openbmc_project/software",
+                    "xyz.openbmc_project.Software.LID", "Validate");
+                method.append(markerLidDirPath.c_str());
+                bus.call(method);
+            }
+            catch (const sdbusplus::exception::exception& e)
+            {
+                uint8_t validateStatus = 0;
+                if (strcmp(e.name(), accessKeyExpired) != 0)
+                {
+                    validateStatus = ENTITLEMENT_FAIL;
+                }
+                else if (strcmp(e.name(), incompatibleErr) != 0)
+                {
+                    validateStatus = MIN_MIF_FAIL;
+                }
+                std::cerr << "Marker lid validate error, "
+                          << "ERROR=" << e.what() << std::endl;
+                oemIbmPlatformHandler->sendStateSensorEvent(
+                    sensorId, PLDM_STATE_SENSOR_STATE, 0, validateStatus,
+                    VALID);
+                return PLDM_ERROR;
+            }
+            oemIbmPlatformHandler->sendStateSensorEvent(
+                sensorId, PLDM_STATE_SENSOR_STATE, 0, VALID, VALID);
+            rc = PLDM_SUCCESS;
+        }
+        return rc;
+    }
+
     virtual int writeFromMemory(uint32_t offset, uint32_t length,
                                 uint64_t address,
                                 oem_platform::Handler* oemPlatformHandler)
@@ -165,17 +226,7 @@ class LidHandler : public FileHandler
             markerLIDremainingSize -= length;
             if (markerLIDremainingSize == 0)
             {
-                pldm::responder::oem_ibm_platform::Handler*
-                    oemIbmPlatformHandler = dynamic_cast<
-                        pldm::responder::oem_ibm_platform::Handler*>(
-                        oemPlatformHandler);
-                auto sensorId =
-                    oemIbmPlatformHandler->codeUpdate->getMarkerLidSensor();
-                using namespace pldm::responder::oem_ibm_platform;
-                oemIbmPlatformHandler->sendStateSensorEvent(
-                    sensorId, PLDM_STATE_SENSOR_STATE, 0, VALID, VALID);
-                // rc = validate api;
-                rc = PLDM_SUCCESS;
+                rc = validateMarkerLid(oemPlatformHandler, lidPath);
             }
         }
         else if (codeUpdateInProgress)
@@ -274,17 +325,7 @@ class LidHandler : public FileHandler
             markerLIDremainingSize -= length;
             if (markerLIDremainingSize == 0)
             {
-                pldm::responder::oem_ibm_platform::Handler*
-                    oemIbmPlatformHandler = dynamic_cast<
-                        pldm::responder::oem_ibm_platform::Handler*>(
-                        oemPlatformHandler);
-                auto sensorId =
-                    oemIbmPlatformHandler->codeUpdate->getMarkerLidSensor();
-                using namespace pldm::responder::oem_ibm_platform;
-                oemIbmPlatformHandler->sendStateSensorEvent(
-                    sensorId, PLDM_STATE_SENSOR_STATE, 0, VALID, VALID);
-                // validate api
-                rc = PLDM_SUCCESS;
+                rc = validateMarkerLid(oemPlatformHandler, lidPath);
             }
         }
         else if (codeUpdateInProgress)


### PR DESCRIPTION
This commit adds changes to call the validate API
from phosphor-software-manager to validate the
marker lid. And further send the status of the validation to PHYP through a sensor event.