### PR TITLE
oem-ibm : Support for VPD record PSPD via file I/O with offset

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
@@ -63,8 +63,8 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
                         fs::perms::others_read | fs::perms::owner_write);
     }
 
-    std::ofstream keywrdFile("vpdKeywrd.bin");
-    keywrdFile.open(keywrdFilePath, std::ios::out | std::ofstream::binary);
+    std::ofstream keywrdFile(keywrdFilePath);
+    auto fd = open(keywrdFilePath, std::ios::out | std::ofstream::binary);
     if (!keywrdFile)
     {
         std::cerr << "VPD keyword file open error: " << keywrdFilePath
@@ -74,6 +74,24 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
             pldm::PelSeverity::ERROR);
         return PLDM_ERROR;
     }
+
+    if (offset > keywrdSize)
+    {
+        std::cerr << "Offset exceeds file size, OFFSET=" << offset
+                  << " FILE_SIZE=" << keywrdSize << std::endl;
+        return PLDM_DATA_OUT_OF_RANGE;
+    }
+    // length of keyword data should be same as keyword data size in dbus object
+    length = static_cast<uint32_t>(keywrdSize) - offset;
+    auto returnCode = lseek(fd, offset, SEEK_SET);
+    if (returnCode == -1)
+    {
+        std::cerr
+            << "Could not find keyword data at given offset. File Seek failed"
+            << std::endl;
+        return PLDM_ERROR;
+    }
+
     keywrdFile.write((const char*)std::get<std::vector<byte>>(keywrd).data(),
                      keywrdSize);
     if (keywrdFile.bad())
@@ -82,9 +100,6 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
                   << std::endl;
     }
     keywrdFile.close();
-
-    // length of keyword data should be same as keyword data size in dbus object
-    length = (uint32_t)keywrdSize;
 
     auto rc = readFile(keywrdFilePath, offset, keywrdSize, response);
     fs::remove(keywrdFilePath);


### PR DESCRIPTION
This commits allows transfer of PSPD record data via PLDM with offset included. Host can now send the keyword data with non zero offset in request message.
Tested by using pldmtool to send read request command to PLDM