### PR TITLE
Association between fabric adapter and slots

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -24,6 +24,21 @@ constexpr auto itemPCIeSlot = "xyz.openbmc_project.Inventory.Item.PCIeSlot";
 constexpr auto itemPCIeDevice = "xyz.openbmc_project.Inventory.Item.PCIeDevice";
 constexpr auto itemConnector = "xyz.openbmc_project.Inventory.Item.Connector";
 
+// Slot location code structure contains multiple slot location code
+// suffix structures.
+// Each slot location code suffix structure is as follows
+// {Slot location code suffix size(uint8_t),
+//  Slot location code suffix(variable size)}
+constexpr auto sizeOfSuffixSizeDataMember = 1;
+
+// Each slot location structure contains
+// {
+//   Number of slot location codes (1byte),
+//   Slot location code Common part size (1byte)
+//   Slot location common part (Var)
+// }
+constexpr auto slotLocationDataMemberSize = 2;
+
 namespace fs = std::filesystem;
 std::unordered_map<uint16_t, bool> PCIeInfoHandler::receivedFiles;
 std::unordered_map<linkId_t,
@@ -602,6 +617,20 @@ void PCIeInfoHandler::parseSecondaryLink(
         std::filesystem::path mexConnecter(mexConnecterPath);
         auto mexSlotandAdapter = getMexSlotandAdapter(mexConnecter);
 
+        std::cout << "Creating associations under "
+                  << std::get<1>(mexSlotandAdapter) << std::endl;
+        std::vector<std::tuple<std::string, std::string, std::string>>
+            associations;
+        for (auto slot : ioSlotLocationCode)
+        {
+            associations.emplace_back(
+                "containing", "contained_by",
+                getMexObjectFromLocationCode(slot, PLDM_ENTITY_SLOT));
+        }
+
+        pldm::dbus::CustomDBus::getCustomDBus().setAssociations(
+            std::get<1>(mexSlotandAdapter), associations);
+
         // set topology info on both the slot and adapter object
         setTopologyOnSlotAndAdapter(linkType, mexSlotandAdapter, linkId,
                                     linkStatus, linkSpeed, linkWidth, true);
@@ -928,10 +957,10 @@ void PCIeInfoHandler::parseTopologyData()
         std::string slot_location_code(slot_location.begin(),
                                        slot_location.end());
 
-        struct SlotLocCodeSuf_t* slot_loc_suf_data =
-            (struct SlotLocCodeSuf_t*)(((uint8_t*)slot_data) + 2 +
-                                       slot_data->slotLocCodesCmnPrtSize);
-        if (slot_loc_suf_data == nullptr)
+        uint8_t* suffix_data = (uint8_t*)slot_data +
+                               slotLocationDataMemberSize +
+                               slot_data->slotLocCodesCmnPrtSize;
+        if (suffix_data == nullptr)
         {
             std::cerr << "slot location suffix data is nullptr \n";
             return;
@@ -944,6 +973,15 @@ void PCIeInfoHandler::parseTopologyData()
         for ([[maybe_unused]] const auto& slot :
              std::views::iota(0) | std::views::take(no_of_slots))
         {
+
+            struct SlotLocCodeSuf_t* slot_loc_suf_data =
+                (struct SlotLocCodeSuf_t*)suffix_data;
+            if (slot_loc_suf_data == nullptr)
+            {
+                std::cerr << "slot location suffix data is nullptr \n";
+                break;
+            }
+
             size_t slot_loccode_suffix_size = slot_loc_suf_data->slotLocCodeSz;
             if (slot_loccode_suffix_size > 0)
             {
@@ -961,7 +999,8 @@ void PCIeInfoHandler::parseTopologyData()
             slot_final_location_code.push_back(slot_full_location_code);
 
             // move the pointer to next slot
-            slot_loc_suf_data += 2;
+            suffix_data +=
+                sizeOfSuffixSizeDataMember + slot_loccode_suffix_size;
         }
 
         // store the information into a map


### PR DESCRIPTION
Association between fabric adapter and slots

As per current design, while displaying the topology data under GUI, bmcweb
looks for the fabric adapter location code to be the start of the IO Slot
Location codes(Fabric adapter and slots are in the same planar) Example: Fabric
Adapter location code - U78CD.001.FZH1277-P1 IO Slot location code -
U78CD.001.FZH1277-P1-C3

But in case of splitter, the Slots are connected to the Midplane (Planar 3) and
not to the fabric adapter (P1 and P2).  Fabric Adapter location code -
U50EE.001.WZS000P-P2-C1 IO Slot location code - U50EE.001.WZS000P-P3-C10

To create a generic way to get the IO slots location codes in PCIeTopology,
creating association as below:

 FabricAdapters -> PCIe Slots

The association between Fabric adapters and slots is created while parsing the
topology data.

Fixes: 481314

Tested using busctl command:

busctl get-property xyz.openbmc_project.PLDM
/xyz/openbmc_project/inventory/system/chassis15363/logical_slot2/io_module2
xyz.openbmc_project.Association.Definitions Associations a(sss) 7
"identify_led_group" "identify_inventory_object"
"/xyz/openbmc_project/led/groups/system/chassis15363/logical_slot2/io_module2"
"containing" "contained_by"
"/xyz/openbmc_project/inventory/system/chassis15363/logical_slot2/io_module2/slot2"
"containing" "contained_by"
"/xyz/openbmc_project/inventory/system/chassis15363/logical_slot2/io_module2/slot3"
"containing" "contained_by"
"/xyz/openbmc_project/inventory/system/chassis15363/logical_slot2/io_module2/slot4"
"containing" "contained_by"
"/xyz/openbmc_project/inventory/system/chassis15363/logical_slot2/io_module2/slot1"
"containing" "contained_by"
"/xyz/openbmc_project/inventory/system/chassis15363/logical_slot2/io_module2/slot5"
"containing" "contained_by"
"/xyz/openbmc_project/inventory/system/chassis15363/logical_slot2/io_module2/slot6"
