### PR TITLE
1050 no osstart

### DIFF
--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -165,8 +165,6 @@ void HostEffecterParser::processHostEffecterChangeNotification(
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
                               "ProgressStages.OSRunning") &&
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
-                              "ProgressStages.OSStart") &&
-            (currHostState != "xyz.openbmc_project.State.Boot.Progress."
                               "ProgressStages.SystemSetup"))
         {
             std::cout << "Host is not up. Current host state: "

--- a/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
@@ -37,8 +37,6 @@ int sendBiosAttributeUpdateEvent(
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
                               "ProgressStages.OSRunning") &&
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
-                              "ProgressStages.OSStart") &&
-            (currHostState != "xyz.openbmc_project.State.Boot.Progress."
                               "ProgressStages.SystemSetup"))
         {
             return PLDM_SUCCESS;


### PR DESCRIPTION
Two merged upstream commits to remove OSStart from PLDM:
- https://gerrit.openbmc.org/c/openbmc/pldm/+/63138
- https://gerrit.openbmc.org/c/openbmc/pldm/+/63139