### PR TITLE
Change the default partition mode to A_Mode

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -196,14 +196,14 @@
         {
             "attribute_name": "pvm_os_boot_type",
             "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
-            "default_values": ["D_Mode"],
+            "default_values": ["A_Mode"],
             "helpText": "Select the IBMi partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
             "displayName": "IBMi Partition Boot Mode"
         },
         {
             "attribute_name": "pvm_os_boot_type_current",
             "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
-            "default_values": ["D_Mode"],
+            "default_values": ["A_Mode"],
             "helpText": "Specifies the current IBMi partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
             "displayName": "IBMi Partition Boot Mode (current)",
             "readOnly": true


### PR DESCRIPTION
Traditional IBM systems since 1988 used to ship with A_Mode as the default partition mode for iBMi. Changing the default value from D_Mode to A_Mode to match the behaviour of our systems and align them with the earlier behaviour.