### PR TITLE
1030: oem-ibm: Support new UTIL keywords (#419)

### DIFF
--- a/oem/ibm/configurations/fru/Motherboard_UTIL.json
+++ b/oem/ibm/configurations/fru/Motherboard_UTIL.json
@@ -1,0 +1,33 @@
+{
+    "record_details": {
+        "fru_record_type": 254,
+        "fru_encoding_type": 1,
+        "dbus_interface_name": "xyz.openbmc_project.Inventory.Item.Board.Motherboard"
+    },
+    "fru_fields": [
+        {
+            "fru_field_type": 2,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.UTIL",
+                "property_name": "RT",
+                "property_type": "bytearray"
+            }
+        },
+        {
+            "fru_field_type": 18,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.UTIL",
+                "property_name": "F5",
+                "property_type": "bytearray"
+            }
+        },
+        {
+            "fru_field_type": 19,
+            "dbus": {
+                "interface": "com.ibm.ipzvpd.UTIL",
+                "property_name": "F6",
+                "property_type": "bytearray"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
#### oem-ibm: Support new UTIL keywords (#419)
```
This commit adds new UTIL record keywords RT, F5 and F6 under the
motherboard. F5 and F6 keywords are used to fill up the desired
host splash screen name displayed at the host console. The RT
keyword is used to hold the record name.

Resolves: ibm-openbmc/dev#3616

Tested: Verified that the name filled up through the F5 and F6
keywords are displayed at the host splash screen

Change-Id: I26f1c03db3e9f6a5b8cdc435d9e80d7c92563e16

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>```