### PR TITLE
pldm-create-phyp-nvram*: Use `truncate(1)` instead of `dd(1)`

### DIFF
--- a/oem/ibm/service_files/pldm-create-phyp-nvram-cksum.service
+++ b/oem/ibm/service_files/pldm-create-phyp-nvram-cksum.service
@@ -7,7 +7,7 @@ After=obmc-flash-bios-init.service
 ConditionPathExists=!/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM-CKSUM
 
 [Service]
-ExecStart=/bin/sh -c "if [ -f /var/lib/pldm/PHYP-NVRAM-CKSUM ]; then mv /var/lib/pldm/PHYP-NVRAM-CKSUM /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM-CKSUM; else dd if=/dev/zero of=/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM-CKSUM bs=16 count=1; fi"
+ExecStart=/bin/sh -c "if [ -f /var/lib/pldm/PHYP-NVRAM-CKSUM ]; then mv /var/lib/pldm/PHYP-NVRAM-CKSUM /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM-CKSUM; else truncate -s 16 /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM-CKSUM; fi"
 Type=oneshot
 RemainAfterExit=no
 

--- a/oem/ibm/service_files/pldm-create-phyp-nvram.service
+++ b/oem/ibm/service_files/pldm-create-phyp-nvram.service
@@ -7,7 +7,7 @@ After=obmc-flash-bios-init.service
 ConditionPathExists=!/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM
 
 [Service]
-ExecStart=/bin/sh -c "if [ -f /var/lib/pldm/PHYP-NVRAM ]; then mv /var/lib/pldm/PHYP-NVRAM /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; else dd if=/dev/zero of=/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM bs=1024 count=145408; fi"
+ExecStart=/bin/sh -c "if [ -f /var/lib/pldm/PHYP-NVRAM ]; then mv /var/lib/pldm/PHYP-NVRAM /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; else truncate -s $((1024 * 145408)) /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; fi"
 Type=oneshot
 RemainAfterExit=no
 


### PR DESCRIPTION
Use of `dd(1)` to create large "empty" files can cause significant performance issues. Poor application of the `bs=` parameter can cause a huge amount of syscall overhead with many back-to-back `read(2)`, `write(2)` syscalls issued.

Using `truncate(1)` is much more effective as it can be used to expand the size of a file without invoking `write(2)`. By example, switching `pldm-create-phyp-nvram.service` from `dd(1)` to `truncate(1)` reduces the CPU time consumed from 15.898s to 0.032s under QEMU, yielding a 496x increase in performance.