### PR TITLE
BIOS check APIs, Part 1

### DIFF
--- a/common/flight_recorder.hpp
+++ b/common/flight_recorder.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <config.h>
-
 #include <common/utils.hpp>
 
 #include <fstream>

--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "utils.hpp"
 
 #include "libpldm/pdr.h"

--- a/host-bmc/dbus/serialize.hpp
+++ b/host-bmc/dbus/serialize.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/pdr.h"
-
 #include "license_entry.hpp"
 #include "type.hpp"
+
+#include <libpldm/pdr.h>
 
 #include <filesystem>
 #include <fstream>

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "host_pdr_handler.hpp"
 
 #include "libpldm/fru.h"

--- a/host-bmc/test/dbus_to_host_effecter_test.cpp
+++ b/host-bmc/test/dbus_to_host_effecter_test.cpp
@@ -21,14 +21,14 @@ class MockHostEffecterParser : public HostEffecterParser
         HostEffecterParser(nullptr, fd, repo, dbusHandler, jsonPath, nullptr)
     {}
 
-    MOCK_METHOD(void, setHostStateEffecter,
+    MOCK_METHOD(int, setHostStateEffecter,
                 (size_t, std::vector<set_effecter_state_field>&, uint16_t),
-                (const override));
+                (override));
 
     MOCK_METHOD(void, createHostEffecterMatch,
                 (const std::string&, const std::string&, size_t, size_t,
                  uint16_t),
-                (const override));
+                (override));
 
     const std::vector<EffecterInfo>& gethostEffecterInfo()
     {

--- a/libpldmresponder/base.cpp
+++ b/libpldmresponder/base.cpp
@@ -1,15 +1,18 @@
-#include "config.h"
-
-#include "libpldm/base.h"
-
-#include "libpldm/bios.h"
-#include "libpldm/fru.h"
-#include "libpldm/platform.h"
-#include "libpldm/pldm.h"
-
 #include "base.hpp"
+
 #include "common/utils.hpp"
 #include "libpldmresponder/pdr.hpp"
+
+#include <libpldm/base.h>
+#include <libpldm/bios.h>
+#include <libpldm/fru.h>
+#include <libpldm/platform.h>
+#include <libpldm/pldm.h>
+
+#ifdef OEM_IBM
+#include <libpldm/file_io.h>
+#include <libpldm/host.h>
+#endif
 
 #include <array>
 #include <cstring>
@@ -17,11 +20,6 @@
 #include <map>
 #include <stdexcept>
 #include <vector>
-
-#ifdef OEM_IBM
-#include "libpldm/file_io.h"
-#include "libpldm/host.h"
-#endif
 
 namespace pldm
 {

--- a/libpldmresponder/base.hpp
+++ b/libpldmresponder/base.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/base.h"
-
 #include "libpldmresponder/platform.hpp"
 #include "pldmd/handler.hpp"
 #include "requester/handler.hpp"
 
+#include <libpldm/base.h>
 #include <stdint.h>
 
 #include <sdeventplus/source/event.hpp>

--- a/libpldmresponder/bios.hpp
+++ b/libpldmresponder/bios.hpp
@@ -1,16 +1,13 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/bios.h"
-#include "libpldm/bios_table.h"
-
 #include "bios_config.hpp"
 #include "bios_table.hpp"
 #include "pldmd/dbus_impl_requester.hpp"
 #include "pldmd/handler.hpp"
 #include "requester/handler.hpp"
 
+#include <libpldm/bios.h>
+#include <libpldm/bios_table.h>
 #include <stdint.h>
 
 #include <ctime>

--- a/libpldmresponder/bios_attribute.cpp
+++ b/libpldmresponder/bios_attribute.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "bios_attribute.hpp"
 
 #include "bios_config.hpp"

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -167,13 +167,17 @@ int BIOSConfig::checkAttributeTable(const Table& table)
             case PLDM_BIOS_ENUMERATION:
             case PLDM_BIOS_ENUMERATION_READ_ONLY:
             {
-                auto pvNum =
-                    pldm_bios_table_attr_entry_enum_decode_pv_num(entry);
+                uint8_t pvNum;
+                // Preconditions are upheld therefore no error check necessary
+                pldm_bios_table_attr_entry_enum_decode_pv_num_check(entry,
+                                                                    &pvNum);
                 std::vector<uint16_t> pvHandls(pvNum);
-                pldm_bios_table_attr_entry_enum_decode_pv_hdls(
+                // Preconditions are upheld therefore no error check necessary
+                pldm_bios_table_attr_entry_enum_decode_pv_hdls_check(
                     entry, pvHandls.data(), pvHandls.size());
-                auto defNum =
-                    pldm_bios_table_attr_entry_enum_decode_def_num(entry);
+                uint8_t defNum;
+                pldm_bios_table_attr_entry_enum_decode_def_num_check(entry,
+                                                                     &defNum);
                 std::vector<uint8_t> defIndices(defNum);
                 pldm_bios_table_attr_entry_enum_decode_def_indices(
                     entry, defIndices.data(), defIndices.size());
@@ -262,8 +266,10 @@ int BIOSConfig::checkAttributeValueTable(const Table& table)
         auto strLength =
             pldm_bios_table_string_entry_decode_string_length(stringEntry);
         std::vector<char> buffer(strLength + 1 /* sizeof '\0' */);
-        pldm_bios_table_string_entry_decode_string(stringEntry, buffer.data(),
-                                                   buffer.size());
+        // Preconditions are upheld therefore no error check necessary
+        pldm_bios_table_string_entry_decode_string_check(
+            stringEntry, buffer.data(), buffer.size());
+
         attributeName = std::string(buffer.data(), buffer.data() + strLength);
 
         if (!biosAttributes.empty())
@@ -290,7 +296,9 @@ int BIOSConfig::checkAttributeValueTable(const Table& table)
                         pldm_bios_table_string_entry_decode_string_length(
                             stringEntry);
                     std::vector<char> buffer(strLength + 1 /* sizeof '\0' */);
-                    pldm_bios_table_string_entry_decode_string(
+                    // Preconditions are upheld therefore no error check
+                    // necessary
+                    pldm_bios_table_string_entry_decode_string_check(
                         stringEntry, buffer.data(), buffer.size());
 
                     return std::string(buffer.data(),
@@ -300,10 +308,13 @@ int BIOSConfig::checkAttributeValueTable(const Table& table)
                 attributeType = "xyz.openbmc_project.BIOSConfig.Manager."
                                 "AttributeType.Enumeration";
 
-                auto pvNum =
-                    pldm_bios_table_attr_entry_enum_decode_pv_num(attrEntry);
+                uint8_t pvNum;
+                // Preconditions are upheld therefore no error check necessary
+                pldm_bios_table_attr_entry_enum_decode_pv_num_check(attrEntry,
+                                                                    &pvNum);
                 std::vector<uint16_t> pvHandls(pvNum);
-                pldm_bios_table_attr_entry_enum_decode_pv_hdls(
+                // Preconditions are upheld therefore no error check necessary
+                pldm_bios_table_attr_entry_enum_decode_pv_hdls_check(
                     attrEntry, pvHandls.data(), pvHandls.size());
 
                 // get possible_value
@@ -328,8 +339,10 @@ int BIOSConfig::checkAttributeValueTable(const Table& table)
                     currentValue = getValue(pvHandls[handles[i]], *stringTable);
                 }
 
-                auto defNum =
-                    pldm_bios_table_attr_entry_enum_decode_def_num(attrEntry);
+                uint8_t defNum;
+                // Preconditions are upheld therefore no error check necessary
+                pldm_bios_table_attr_entry_enum_decode_def_num_check(attrEntry,
+                                                                     &defNum);
                 std::vector<uint8_t> defIndices(defNum);
                 pldm_bios_table_attr_entry_enum_decode_def_indices(
                     attrEntry, defIndices.data(), defIndices.size());
@@ -386,9 +399,10 @@ int BIOSConfig::checkAttributeValueTable(const Table& table)
                     attrEntry);
                 auto max = pldm_bios_table_attr_entry_string_decode_max_length(
                     attrEntry);
-                auto def =
-                    pldm_bios_table_attr_entry_string_decode_def_string_length(
-                        attrEntry);
+                uint16_t def;
+                // Preconditions are upheld therefore no error check necessary
+                pldm_bios_table_attr_entry_string_decode_def_string_length_check(
+                    attrEntry, &def);
                 std::vector<char> defString(def + 1);
                 pldm_bios_table_attr_entry_string_decode_def_string(
                     attrEntry, defString.data(), defString.size());
@@ -652,8 +666,9 @@ std::string BIOSConfig::decodeStringFromStringEntry(
     auto strLength =
         pldm_bios_table_string_entry_decode_string_length(stringEntry);
     std::vector<char> buffer(strLength + 1 /* sizeof '\0' */);
-    pldm_bios_table_string_entry_decode_string(stringEntry, buffer.data(),
-                                               buffer.size());
+    // Preconditions are upheld therefore no error check necessary
+    pldm_bios_table_string_entry_decode_string_check(stringEntry, buffer.data(),
+                                                     buffer.size());
     return std::string(buffer.data(), buffer.data() + strLength);
 }
 
@@ -664,10 +679,19 @@ std::string
 {
     auto attrEntry = pldm_bios_table_attr_find_by_handle(
         attrTable->data(), attrTable->size(), handle);
-    auto pvNum = pldm_bios_table_attr_entry_enum_decode_pv_num(attrEntry);
+    uint8_t pvNum;
+    int rc = pldm_bios_table_attr_entry_enum_decode_pv_num_check(attrEntry,
+                                                                 &pvNum);
+    if (rc != PLDM_SUCCESS)
+    {
+        throw std::runtime_error(
+            "Failed to decode BIOS table possible values for attribute entry");
+    }
+
     std::vector<uint16_t> pvHandls(pvNum);
-    pldm_bios_table_attr_entry_enum_decode_pv_hdls(attrEntry, pvHandls.data(),
-                                                   pvHandls.size());
+    // Preconditions are upheld therefore no error check necessary
+    pldm_bios_table_attr_entry_enum_decode_pv_hdls_check(
+        attrEntry, pvHandls.data(), pvHandls.size());
 
     std::string displayString = std::to_string(pvHandls[index]);
 

--- a/libpldmresponder/bios_enum_attribute.cpp
+++ b/libpldmresponder/bios_enum_attribute.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "bios_enum_attribute.hpp"
 
 #include "common/utils.hpp"

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -1,17 +1,16 @@
 #include "fru.hpp"
 
-#include "libpldm/entity.h"
-#include "libpldm/utils.h"
-
 #include "common/utils.hpp"
 #include "pdr.hpp"
-#ifdef OEM_IBM
-#include "libpldm/pdr_oem_ibm.h"
 
+#ifdef OEM_IBM
 #include "oem/ibm/libpldmresponder/utils.hpp"
+
+#include <libpldm/pdr_oem_ibm.h>
 #endif
 
-#include <config.h>
+#include <libpldm/entity.h>
+#include <libpldm/utils.h>
 #include <systemd/sd-journal.h>
 
 #include <sdbusplus/bus.hpp>

--- a/libpldmresponder/fru.hpp
+++ b/libpldmresponder/fru.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/fru.h"
-#include "libpldm/pdr.h"
-
 #include "common/utils.hpp"
 #include "fru_parser.hpp"
 #include "host-bmc/dbus_to_event_handler.hpp"
@@ -13,6 +8,9 @@
 #include "pldmd/dbus_impl_requester.hpp"
 #include "pldmd/handler.hpp"
 #include "requester/handler.hpp"
+
+#include <libpldm/fru.h>
+#include <libpldm/pdr.h>
 
 #include <sdbusplus/message.hpp>
 

--- a/libpldmresponder/pdr.hpp
+++ b/libpldmresponder/pdr.hpp
@@ -3,7 +3,6 @@
 #include "common/utils.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
 
-#include <config.h>
 #include <stdint.h>
 
 namespace pldm

--- a/libpldmresponder/pdr_state_effecter.hpp
+++ b/libpldmresponder/pdr_state_effecter.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "libpldm/platform.h"
-
 #include "pdr.hpp"
 #include "pdr_utils.hpp"
 
-#include <config.h>
+#include <libpldm/platform.h>
 
 namespace pldm
 {

--- a/libpldmresponder/pdr_utils.cpp
+++ b/libpldmresponder/pdr_utils.cpp
@@ -3,7 +3,7 @@
 
 #include "pdr.hpp"
 
-#include <config.h>
+#include <libpldm/platform.h>
 
 #include <bitset>
 #include <climits>

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -17,7 +17,8 @@
 #include "platform_state_effecter.hpp"
 #include "platform_state_sensor.hpp"
 
-#include <config.h>
+#include <libpldm/entity.h>
+#include <libpldm/state_set.h>
 
 using namespace pldm::utils;
 using namespace pldm::responder::pdr;

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -1,11 +1,5 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/pdr.h"
-#include "libpldm/platform.h"
-#include "libpldm/states.h"
-
 #include "common/utils.hpp"
 #include "event_parser.hpp"
 #include "fru.hpp"
@@ -16,6 +10,9 @@
 #include "oem_handler.hpp"
 #include "pldmd/handler.hpp"
 
+#include <libpldm/pdr.h>
+#include <libpldm/platform.h>
+#include <libpldm/states.h>
 #include <stdint.h>
 
 #include <map>

--- a/libpldmresponder/platform_numeric_effecter.hpp
+++ b/libpldmresponder/platform_numeric_effecter.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/platform.h"
-#include "libpldm/states.h"
-
 #include "common/utils.hpp"
 #include "libpldmresponder/pdr.hpp"
 #include "pdr_utils.hpp"
 #include "pldmd/handler.hpp"
 
+#include <libpldm/platform.h>
+#include <libpldm/states.h>
 #include <math.h>
 #include <stdint.h>
 

--- a/libpldmresponder/platform_state_effecter.hpp
+++ b/libpldmresponder/platform_state_effecter.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/platform.h"
-#include "libpldm/states.h"
-
 #include "common/utils.hpp"
 #include "libpldmresponder/pdr.hpp"
 #include "pdr_utils.hpp"
 #include "pldmd/handler.hpp"
+
+#include <libpldm/platform.h>
+#include <libpldm/states.h>
 
 #include <cstdint>
 #include <map>

--- a/libpldmresponder/platform_state_sensor.hpp
+++ b/libpldmresponder/platform_state_sensor.hpp
@@ -1,14 +1,11 @@
 #pragma once
-
-#include "config.h"
-
-#include "libpldm/platform.h"
-#include "libpldm/states.h"
-
 #include "common/utils.hpp"
 #include "libpldmresponder/pdr.hpp"
 #include "pdr_utils.hpp"
 #include "pldmd/handler.hpp"
+
+#include <libpldm/platform.h>
+#include <libpldm/states.h>
 
 #include <cstdint>
 #include <map>

--- a/meson.build
+++ b/meson.build
@@ -61,9 +61,11 @@ conf_data.set('RESPONSE_TIME_OUT',get_option('response-time-out'))
 conf_data.set('FLIGHT_RECORDER_MAX_ENTRIES',get_option('flightrecorder-max-entries'))
 conf_data.set_quoted('HOST_EID_PATH', join_paths(package_datadir, 'host_eid'))
 conf_data.set('MAXIMUM_TRANSFER_SIZE', get_option('maximum-transfer-size'))
-configure_file(output: 'config.h',
+config = configure_file(output: 'config.h',
   configuration: conf_data
 )
+
+add_project_arguments('-include', '@0@'.format(config), language: 'cpp')
 
 cpp = meson.get_compiler('cpp')
 

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "file_io.hpp"
 
 #include "libpldm/base.h"

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -1,11 +1,5 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/base.h"
-#include "libpldm/file_io.h"
-#include "libpldm/host.h"
-
 #include "common/utils.hpp"
 #include "oem/ibm/requester/dbus_to_file_handler.hpp"
 #include "oem_ibm_handler.hpp"
@@ -13,6 +7,9 @@
 #include "requester/handler.hpp"
 
 #include <fcntl.h>
+#include <libpldm/base.h>
+#include <libpldm/file_io.h>
+#include <libpldm/host.h>
 #include <stdint.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "file_io_by_type.hpp"
 
 #include "libpldm/base.h"

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "config.h"
-
 #include "file_io_by_type.hpp"
 
 #include <xyz/openbmc_project/Software/Version/error.hpp>

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "file_io_type_pel.hpp"
 
 #include "libpldm/base.h"

--- a/pldmd/instance_id.cpp
+++ b/pldmd/instance_id.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "instance_id.hpp"
 
 #include <stdexcept>

--- a/pldmtool/pldm_bios_cmd.cpp
+++ b/pldmtool/pldm_bios_cmd.cpp
@@ -285,8 +285,9 @@ class GetBIOSTableHandler : public CommandInterface
         auto strLength =
             pldm_bios_table_string_entry_decode_string_length(stringEntry);
         std::vector<char> buffer(strLength + 1 /* sizeof '\0' */);
-        pldm_bios_table_string_entry_decode_string(stringEntry, buffer.data(),
-                                                   buffer.size());
+        // Preconditions are upheld therefore no error check necessary
+        pldm_bios_table_string_entry_decode_string_check(
+            stringEntry, buffer.data(), buffer.size());
 
         return std::string(buffer.data(), buffer.data() + strLength);
     }
@@ -332,9 +333,16 @@ class GetBIOSTableHandler : public CommandInterface
         {
             return displayString;
         }
-        auto pvNum = pldm_bios_table_attr_entry_enum_decode_pv_num(attrEntry);
+        uint8_t pvNum;
+        int rc = pldm_bios_table_attr_entry_enum_decode_pv_num_check(attrEntry,
+                                                                     &pvNum);
+        if (rc != PLDM_SUCCESS)
+        {
+            return displayString;
+        }
         std::vector<uint16_t> pvHandls(pvNum);
-        pldm_bios_table_attr_entry_enum_decode_pv_hdls(
+        // Preconditions are upheld therefore no error check necessary
+        pldm_bios_table_attr_entry_enum_decode_pv_hdls_check(
             attrEntry, pvHandls.data(), pvHandls.size());
         return displayStringHandle(pvHandls[index], stringTable, false);
     }
@@ -554,13 +562,21 @@ class GetBIOSTable : public GetBIOSTableHandler
                 case PLDM_BIOS_ENUMERATION:
                 case PLDM_BIOS_ENUMERATION_READ_ONLY:
                 {
-                    auto pvNum =
-                        pldm_bios_table_attr_entry_enum_decode_pv_num(entry);
+                    uint8_t pvNum;
+                    // Preconditions are upheld therefore no error check
+                    // necessary
+                    pldm_bios_table_attr_entry_enum_decode_pv_num_check(entry,
+                                                                        &pvNum);
                     std::vector<uint16_t> pvHandls(pvNum);
-                    pldm_bios_table_attr_entry_enum_decode_pv_hdls(
+                    // Preconditions are upheld therefore no error check
+                    // necessary
+                    pldm_bios_table_attr_entry_enum_decode_pv_hdls_check(
                         entry, pvHandls.data(), pvHandls.size());
-                    auto defNum =
-                        pldm_bios_table_attr_entry_enum_decode_def_num(entry);
+                    uint8_t defNum;
+                    // Preconditions are upheld therefore no error check
+                    // necessary
+                    pldm_bios_table_attr_entry_enum_decode_def_num_check(
+                        entry, &defNum);
                     std::vector<uint8_t> defIndices(defNum);
                     pldm_bios_table_attr_entry_enum_decode_def_indices(
                         entry, defIndices.data(), defIndices.size());
@@ -609,9 +625,11 @@ class GetBIOSTable : public GetBIOSTableHandler
                     auto max =
                         pldm_bios_table_attr_entry_string_decode_max_length(
                             entry);
-                    auto def =
-                        pldm_bios_table_attr_entry_string_decode_def_string_length(
-                            entry);
+                    uint16_t def;
+                    // Preconditions are upheld therefore no error check
+                    // necessary
+                    pldm_bios_table_attr_entry_string_decode_def_string_length_check(
+                        entry, &def);
                     std::vector<char> defString(def + 1);
                     pldm_bios_table_attr_entry_string_decode_def_string(
                         entry, defString.data(), defString.size());
@@ -807,10 +825,13 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
             {
                 entryLength =
                     pldm_bios_table_attr_value_entry_encode_enum_length(1);
-                auto pvNum =
-                    pldm_bios_table_attr_entry_enum_decode_pv_num(attrEntry);
+                uint8_t pvNum;
+                // Preconditions are upheld therefore no error check necessary
+                pldm_bios_table_attr_entry_enum_decode_pv_num_check(attrEntry,
+                                                                    &pvNum);
                 std::vector<uint16_t> pvHdls(pvNum, 0);
-                pldm_bios_table_attr_entry_enum_decode_pv_hdls(
+                // Preconditions are upheld therefore no error check necessary
+                pldm_bios_table_attr_entry_enum_decode_pv_hdls_check(
                     attrEntry, pvHdls.data(), pvNum);
                 auto stringEntry = pldm_bios_table_string_find_by_string(
                     stringTable->data(), stringTable->size(),

--- a/pldmtool/pldm_cmd_helper.cpp
+++ b/pldmtool/pldm_cmd_helper.cpp
@@ -1,11 +1,8 @@
-#include "config.h"
-
 #include "pldm_cmd_helper.hpp"
-
-#include "libpldm/pldm.h"
 
 #include "xyz/openbmc_project/Common/error.hpp"
 
+#include <libpldm/pldm.h>
 #include <systemd/sd-bus.h>
 
 #include <sdbusplus/server.hpp>

--- a/requester/handler.hpp
+++ b/requester/handler.hpp
@@ -1,14 +1,11 @@
 #pragma once
 
-#include "config.h"
-
-#include "libpldm/base.h"
-#include "libpldm/pldm.h"
-
 #include "common/types.hpp"
 #include "pldmd/dbus_impl_requester.hpp"
 #include "request.hpp"
 
+#include <libpldm/base.h>
+#include <libpldm/pldm.h>
 #include <sys/socket.h>
 
 #include <function2/function2.hpp>

--- a/softoff/softoff.cpp
+++ b/softoff/softoff.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "softoff.hpp"
 
 #include "libpldm/entity.h"


### PR DESCRIPTION
This begins migrating the pldm code base off of the libpldm APIs that sanitize their parameters with only assert(). There will be more of these cleanups to come.

The last two changes are backports of patches that have been merged upstream. The first patch simply fixes some bad mocking and has no behavioural impact.