### PR TITLE
1030: Change the default partition mode to A_Mode (#420)

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -271,7 +271,7 @@
             "D_Mode"
          ],
          "default_values":[
-            "D_Mode"
+            "A_Mode"
          ],
          "helpText" : "Select the IBMi partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
          "displayName" : "IBMi Partition Boot Mode"
@@ -285,7 +285,7 @@
             "D_Mode"
          ],
          "default_values":[
-            "D_Mode"
+            "A_Mode"
          ],
          "helpText" : "Specifies the current IBMi partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
          "displayName" : "IBMi Partition Boot Mode (current)",


### PR DESCRIPTION
#### Change the default partition mode to A_Mode (#420)
```
Traditional IBM systems since 1988 used to ship with A_Mode
as the default partition mode for iBMi. Changing the default
value from D_Mode to A_Mode to match the behaviour of our systems
and align them with the earlier behaviour.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
```