### PR TITLE
Check customer APR policy before setting one_time APR

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1627,7 +1627,16 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
         "string"};
     try
     {
-        dBusIntf->setDbusProperty(dbusMapping, value);
+        auto customerPolicy =
+            pldm::utils::DBusHandler().getDbusProperty<std::string>(
+                "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "PowerRestorePolicy",
+                "xyz.openbmc_project.Control.Power.RestorePolicy");
+        if (customerPolicy !=
+            "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff")
+        {
+            dBusIntf->setDbusProperty(dbusMapping, value);
+        }
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
This commits adds change to check for the customer PowerRestorePolicy before setting the one_time
PowerRestorePolicy when PHYP sends down the set state effecter call to Hard power off the host.

Previously, we werent checking if the customer APR policy is set to "AlwaysOff" and this broke the UPS usecase when after an AC loss, even though the customer set the IBM i OS value to stay off, as well as setting the Always Off setting in Power restore policy on ASMI. And they expect that if the system loses power, it will not automatically power on when power is restored.

Defect: 556277
TESTED: on rainier, setting the customer policy to "AlwaysOff" busctl get-property xyz.openbmc_project.Settings /xyz/openbmc_project/control/host0/power_restore_policy xyz.openbmc_project.Control.Power.RestorePolicy PowerRestorePolicy s "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff"

And, tried to do a setStateEffecterState call to set the one_time Policy root@rain118bmc:~# pldmtool platform SetStateEffecterStates -v -i 29 -c 1 -d 1 10 pldmtool: Tx: 08 01 84 02 39 1d 00 01 01 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 Success in creating the socket : RC = 4
Success in connecting to socket : RC = 0
Success in sending message type as pldm to mctp : RC = 0 Write to socket successful : RC = 24
Total length:6
Shutdown Socket successful :  RC = 0
pldmtool: Rx: 08 01 04 02 39 00
{
    "Response": "SUCCESS"
}

busctl get-property xyz.openbmc_project.Settings /xyz/openbmc_project/control/host0/power_restore_policy/one_time xyz.openbmc_project.Control.Power.RestorePolicy PowerRestorePolicy s "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None"