### PR TITLE
PLDM: Implementing Phosphor-Logging/LG2 logging

### DIFF
--- a/common/flight_recorder.hpp
+++ b/common/flight_recorder.hpp
@@ -1,16 +1,19 @@
 #pragma once
 
 #include <common/utils.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace flightrecorder
 {
-
 using ReqOrResponse = bool;
 using FlightRecorderData = std::vector<uint8_t>;
 using FlightRecorderTimeStamp = std::string;
@@ -89,8 +92,8 @@ class FlightRecorder
         if (flightRecorderPolicy)
         {
             std::ofstream recorderOutputFile(flightRecorderDumpPath);
-            std::cout << "Dumping the flight recorder into : "
-                      << flightRecorderDumpPath << "\n";
+            info("Dumping the flight recorder into : {FLIGHT_REC_DUMP}",
+                 "FLIGHT_REC_DUMP", flightRecorderDumpPath);
 
             for (const auto& message : tapeRecorder)
             {
@@ -115,7 +118,7 @@ class FlightRecorder
         }
         else
         {
-            std::cerr << "Fight recorder policy is disabled\n";
+            error("Fight recorder policy is disabled");
         }
     }
 };

--- a/common/test/meson.build
+++ b/common/test/meson.build
@@ -17,6 +17,7 @@ foreach t : tests
                          libpldm_dep,
                          nlohmann_json,
                          phosphor_dbus_interfaces,
+                         phosphor_logging_dep,
                          libpldmutils,
                          sdbusplus]),
        workdir: meson.current_source_dir())

--- a/fw-update/device_updater.cpp
+++ b/fw-update/device_updater.cpp
@@ -5,14 +5,16 @@
 #include "activation.hpp"
 #include "update_manager.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <functional>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
-
 namespace fw_update
 {
-
 void DeviceUpdater::startFwUpdateFlow()
 {
     auto instanceId = updateManager->requester.getInstanceId(eid);
@@ -45,8 +47,8 @@ void DeviceUpdater::startFwUpdateFlow()
     if (rc)
     {
         updateManager->requester.markFree(eid, instanceId);
-        std::cerr << "encode_request_update_req failed, EID=" << unsigned(eid)
-                  << ", RC=" << rc << "\n";
+        error("encode_request_update_req failed, EID = {EID}, RC = {RC}", "EID",
+              unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 
@@ -55,8 +57,8 @@ void DeviceUpdater::startFwUpdateFlow()
         std::move(std::bind_front(&DeviceUpdater::requestUpdate, this)));
     if (rc)
     {
-        std::cerr << "Failed to send RequestUpdate request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error("Failed to send RequestUpdate request, EID = {EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 }
@@ -67,8 +69,8 @@ void DeviceUpdater::requestUpdate(mctp_eid_t eid, const pldm_msg* response,
     if (response == nullptr || !respMsgLen)
     {
         // Handle error scenario
-        std::cerr << "No response received for RequestUpdate, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for RequestUpdate, EID = {EID}", "EID",
+              unsigned(eid));
         return;
     }
 
@@ -80,16 +82,15 @@ void DeviceUpdater::requestUpdate(mctp_eid_t eid, const pldm_msg* response,
                                          &fdMetaDataLen, &fdWillSendPkgData);
     if (rc)
     {
-        std::cerr << "Decoding RequestUpdate response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding RequestUpdate response failed, EID = {EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return;
     }
     if (completionCode)
     {
-        std::cerr << "RequestUpdate response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "RequestUpdate response failed with error completion code, EID = {EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
 
@@ -168,8 +169,8 @@ void DeviceUpdater::sendPassCompTableRequest(size_t offset)
     if (rc)
     {
         updateManager->requester.markFree(eid, instanceId);
-        std::cerr << "encode_pass_component_table_req failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("encode_pass_component_table_req failed, EID = {EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 
@@ -179,8 +180,9 @@ void DeviceUpdater::sendPassCompTableRequest(size_t offset)
         std::move(std::bind_front(&DeviceUpdater::passCompTable, this)));
     if (rc)
     {
-        std::cerr << "Failed to send PassComponentTable request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error(
+            "Failed to send PassComponentTable request, EID = {EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 }
@@ -191,8 +193,8 @@ void DeviceUpdater::passCompTable(mctp_eid_t eid, const pldm_msg* response,
     if (response == nullptr || !respMsgLen)
     {
         // Handle error scenario
-        std::cerr << "No response received for PassComponentTable, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for PassComponentTable, EID = {EID}", "EID",
+              unsigned(eid));
         return;
     }
 
@@ -206,17 +208,17 @@ void DeviceUpdater::passCompTable(mctp_eid_t eid, const pldm_msg* response,
     if (rc)
     {
         // Handle error scenario
-        std::cerr << "Decoding PassComponentTable response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Decoding PassComponentTable response failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         return;
     }
     if (completionCode)
     {
         // Handle error scenario
-        std::cerr << "PassComponentTable response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "PassComponentTable response failed with error completion code, EID = {EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
     // Handle ComponentResponseCode
@@ -294,8 +296,8 @@ void DeviceUpdater::sendUpdateComponentRequest(size_t offset)
     if (rc)
     {
         updateManager->requester.markFree(eid, instanceId);
-        std::cerr << "encode_update_component_req failed, EID=" << unsigned(eid)
-                  << ", RC=" << rc << "\n";
+        error("encode_update_component_req failed, EID={EID}, RC = {RC}", "EID",
+              unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 
@@ -304,8 +306,8 @@ void DeviceUpdater::sendUpdateComponentRequest(size_t offset)
         std::move(std::bind_front(&DeviceUpdater::updateComponent, this)));
     if (rc)
     {
-        std::cerr << "Failed to send UpdateComponent request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error("Failed to send UpdateComponent request, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         // Handle error scenario
     }
 }
@@ -316,8 +318,8 @@ void DeviceUpdater::updateComponent(mctp_eid_t eid, const pldm_msg* response,
     if (response == nullptr || !respMsgLen)
     {
         // Handle error scenario
-        std::cerr << "No response received for updateComponent, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for updateComponent, EID={EID}", "EID",
+              unsigned(eid));
         return;
     }
 
@@ -333,16 +335,15 @@ void DeviceUpdater::updateComponent(mctp_eid_t eid, const pldm_msg* response,
         &timeBeforeReqFWData);
     if (rc)
     {
-        std::cerr << "Decoding UpdateComponent response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding UpdateComponent response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return;
     }
     if (completionCode)
     {
-        std::cerr << "UpdateComponent response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "UpdateComponent response failed with error completion code, EID = {EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
 }
@@ -359,15 +360,17 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
                                                &length);
     if (rc)
     {
-        std::cerr << "Decoding RequestFirmwareData request failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Decoding RequestFirmwareData request failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         rc = encode_request_firmware_data_resp(
             request->hdr.instance_id, PLDM_ERROR_INVALID_DATA, responseMsg,
             sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding RequestFirmwareData response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding RequestFirmwareData response failed, EID = {EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -377,9 +380,8 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
     const auto& comp = compImageInfos[applicableComponents[componentIndex]];
     auto compOffset = std::get<5>(comp);
     auto compSize = std::get<6>(comp);
-    std::cerr << "offset = " << unsigned(offset)
-              << ", length = " << unsigned(length) << "\n";
-
+    error("offset = {OFFSET}, length = {LEN}", "OFFSET", unsigned(offset),
+          "LEN", unsigned(length));
     if (length < PLDM_FWUP_BASELINE_TRANSFER_SIZE || length > maxTransferSize)
     {
         rc = encode_request_firmware_data_resp(
@@ -387,8 +389,9 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
             responseMsg, sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding RequestFirmwareData response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding RequestFirmwareData response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -400,8 +403,9 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
             sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding RequestFirmwareData response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding RequestFirmwareData response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -424,8 +428,9 @@ Response DeviceUpdater::requestFwData(const pldm_msg* request,
                                            sizeof(completionCode));
     if (rc)
     {
-        std::cerr << "Encoding RequestFirmwareData response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Encoding RequestFirmwareData response failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         return response;
     }
 
@@ -444,15 +449,16 @@ Response DeviceUpdater::transferComplete(const pldm_msg* request,
                                            &transferResult);
     if (rc)
     {
-        std::cerr << "Decoding TransferComplete request failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding TransferComplete request failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         rc = encode_transfer_complete_resp(request->hdr.instance_id,
                                            PLDM_ERROR_INVALID_DATA, responseMsg,
                                            sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding TransferComplete response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding TransferComplete response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -464,22 +470,24 @@ Response DeviceUpdater::transferComplete(const pldm_msg* request,
 
     if (transferResult == PLDM_FWUP_TRANSFER_SUCCESS)
     {
-        std::cout << "Component Transfer complete, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion << "\n";
+        info(
+            "Component Transfer complete, EID = {EID}, COMPONENT_VERSION = {COMP_VERS}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion);
     }
     else
     {
-        std::cerr << "Transfer of the component failed, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion
-                  << ", TRANSFER_RESULT=" << unsigned(transferResult) << "\n";
+        error(
+            "Transfer of the component failed, EID={EID}, COMPONENT_VERSION = {COMP_VERS}, TRANSFER_RESULT = {TRANS_RES}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion, "TRANS_RES",
+            unsigned(transferResult));
     }
 
     rc = encode_transfer_complete_resp(request->hdr.instance_id, completionCode,
                                        responseMsg, sizeof(completionCode));
     if (rc)
     {
-        std::cerr << "Encoding TransferComplete response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Encoding TransferComplete response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return response;
     }
 
@@ -497,15 +505,16 @@ Response DeviceUpdater::verifyComplete(const pldm_msg* request,
     auto rc = decode_verify_complete_req(request, payloadLength, &verifyResult);
     if (rc)
     {
-        std::cerr << "Decoding VerifyComplete request failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding VerifyComplete request failed, EID = {EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         rc = encode_verify_complete_resp(request->hdr.instance_id,
                                          PLDM_ERROR_INVALID_DATA, responseMsg,
                                          sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding VerifyComplete response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding VerifyComplete response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -517,22 +526,24 @@ Response DeviceUpdater::verifyComplete(const pldm_msg* request,
 
     if (verifyResult == PLDM_FWUP_VERIFY_SUCCESS)
     {
-        std::cout << "Component verification complete, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion << "\n";
+        info(
+            "Component verification complete, EID={EID}, COMPONENT_VERSION={COMP_VERS}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion);
     }
     else
     {
-        std::cerr << "Component verification failed, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion
-                  << ", VERIFY_RESULT=" << unsigned(verifyResult) << "\n";
+        error(
+            "Component verification failed, EID={EID}, COMPONENT_VERSION={COMP_VERS}, VERIFY_RESULT={VERIFY_RES}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion, "VERIFY_RES",
+            unsigned(verifyResult));
     }
 
     rc = encode_verify_complete_resp(request->hdr.instance_id, completionCode,
                                      responseMsg, sizeof(completionCode));
     if (rc)
     {
-        std::cerr << "Encoding VerifyComplete response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Encoding VerifyComplete response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return response;
     }
 
@@ -552,15 +563,16 @@ Response DeviceUpdater::applyComplete(const pldm_msg* request,
                                         &compActivationModification);
     if (rc)
     {
-        std::cerr << "Decoding ApplyComplete request failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding ApplyComplete request failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         rc = encode_apply_complete_resp(request->hdr.instance_id,
                                         PLDM_ERROR_INVALID_DATA, responseMsg,
                                         sizeof(completionCode));
         if (rc)
         {
-            std::cerr << "Encoding ApplyComplete response failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Encoding ApplyComplete response failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
         return response;
     }
@@ -573,23 +585,25 @@ Response DeviceUpdater::applyComplete(const pldm_msg* request,
     if (applyResult == PLDM_FWUP_APPLY_SUCCESS ||
         applyResult == PLDM_FWUP_APPLY_SUCCESS_WITH_ACTIVATION_METHOD)
     {
-        std::cout << "Component apply complete, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion << "\n";
+        info(
+            "Component apply complete, EID = {EID}, COMPONENT_VERSION = {COMP_VERS}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion);
         updateManager->updateActivationProgress();
     }
     else
     {
-        std::cerr << "Component apply failed, EID=" << unsigned(eid)
-                  << ", COMPONENT_VERSION=" << compVersion
-                  << ", APPLY_RESULT=" << unsigned(applyResult) << "\n";
+        error(
+            "Component apply failed, EID = {EID}, COMPONENT_VERSION = {COMP_VERS}, APPLY_RESULT = {APPLY_RES}",
+            "EID", unsigned(eid), "COMP_VERS", compVersion, "APPLY_RES",
+            unsigned(applyResult));
     }
 
     rc = encode_apply_complete_resp(request->hdr.instance_id, completionCode,
                                     responseMsg, sizeof(completionCode));
     if (rc)
     {
-        std::cerr << "Encoding ApplyComplete response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Encoding ApplyComplete response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return response;
     }
 
@@ -626,8 +640,8 @@ void DeviceUpdater::sendActivateFirmwareRequest()
     if (rc)
     {
         updateManager->requester.markFree(eid, instanceId);
-        std::cerr << "encode_activate_firmware_req failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("encode_activate_firmware_req failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
     }
 
     rc = updateManager->handler.registerRequest(
@@ -635,8 +649,8 @@ void DeviceUpdater::sendActivateFirmwareRequest()
         std::move(std::bind_front(&DeviceUpdater::activateFirmware, this)));
     if (rc)
     {
-        std::cerr << "Failed to send ActivateFirmware request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error("Failed to send ActivateFirmware request, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
     }
 }
 
@@ -646,8 +660,8 @@ void DeviceUpdater::activateFirmware(mctp_eid_t eid, const pldm_msg* response,
     if (response == nullptr || !respMsgLen)
     {
         // Handle error scenario
-        std::cerr << "No response received for ActivateFirmware, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for ActivateFirmware, EID={EID}", "EID",
+              unsigned(eid));
         return;
     }
 
@@ -659,17 +673,16 @@ void DeviceUpdater::activateFirmware(mctp_eid_t eid, const pldm_msg* response,
     if (rc)
     {
         // Handle error scenario
-        std::cerr << "Decoding ActivateFirmware response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("Decoding ActivateFirmware response failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return;
     }
     if (completionCode)
     {
         // Handle error scenario
-        std::cerr << "ActivateFirmware response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "ActivateFirmware response failed with error completion code, EID = {EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
 

--- a/fw-update/inventory_manager.cpp
+++ b/fw-update/inventory_manager.cpp
@@ -5,14 +5,15 @@
 #include "common/utils.hpp"
 #include "xyz/openbmc_project/Software/Version/server.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <functional>
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
-
 namespace fw_update
 {
-
 void InventoryManager::discoverFDs(const std::vector<mctp_eid_t>& eids)
 {
     for (const auto& eid : eids)
@@ -26,8 +27,9 @@ void InventoryManager::discoverFDs(const std::vector<mctp_eid_t>& eids)
         if (rc)
         {
             requester.markFree(eid, instanceId);
-            std::cerr << "encode_query_device_identifiers_req failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "encode_query_device_identifiers_req failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
             continue;
         }
 
@@ -38,8 +40,9 @@ void InventoryManager::discoverFDs(const std::vector<mctp_eid_t>& eids)
                                       this)));
         if (rc)
         {
-            std::cerr << "Failed to send QueryDeviceIdentifiers request, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n ";
+            error(
+                "Failed to send QueryDeviceIdentifiers request, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
         }
     }
 }
@@ -50,8 +53,8 @@ void InventoryManager::queryDeviceIdentifiers(mctp_eid_t eid,
 {
     if (response == nullptr || !respMsgLen)
     {
-        std::cerr << "No response received for QueryDeviceIdentifiers, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for QueryDeviceIdentifiers, EID={EID}",
+              "EID", unsigned(eid));
         return;
     }
 
@@ -65,17 +68,17 @@ void InventoryManager::queryDeviceIdentifiers(mctp_eid_t eid,
         &descriptorCount, &descriptorPtr);
     if (rc)
     {
-        std::cerr << "Decoding QueryDeviceIdentifiers response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Decoding QueryDeviceIdentifiers response failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         return;
     }
 
     if (completionCode)
     {
-        std::cerr << "QueryDeviceIdentifiers response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid) << ", CC=" << unsigned(completionCode)
-                  << "\n";
+        error(
+            "QueryDeviceIdentifiers response failed with error completion code, EID={EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(completionCode));
         return;
     }
 
@@ -90,9 +93,9 @@ void InventoryManager::queryDeviceIdentifiers(mctp_eid_t eid,
             &descriptorData);
         if (rc)
         {
-            std::cerr
-                << "Decoding descriptor type, length and value failed, EID="
-                << unsigned(eid) << ", RC=" << rc << "\n ";
+            error(
+                "Decoding descriptor type, length and value failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
             return;
         }
 
@@ -114,9 +117,9 @@ void InventoryManager::queryDeviceIdentifiers(mctp_eid_t eid,
                 &vendorDefinedDescriptorData);
             if (rc)
             {
-                std::cerr
-                    << "Decoding Vendor-defined descriptor value failed, EID="
-                    << unsigned(eid) << ", RC=" << rc << "\n ";
+                error(
+                    "Decoding Vendor-defined descriptor value failed, EID={EID}, RC = {RC}",
+                    "EID", unsigned(eid), "RC", rc);
                 return;
             }
 
@@ -155,8 +158,8 @@ void InventoryManager::sendGetFirmwareParametersRequest(mctp_eid_t eid)
     if (rc)
     {
         requester.markFree(eid, instanceId);
-        std::cerr << "encode_get_firmware_parameters_req failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error("encode_get_firmware_parameters_req failed, EID={EID}, RC = {RC}",
+              "EID", unsigned(eid), "RC", rc);
         return;
     }
 
@@ -167,8 +170,9 @@ void InventoryManager::sendGetFirmwareParametersRequest(mctp_eid_t eid)
             std::bind_front(&InventoryManager::getFirmwareParameters, this)));
     if (rc)
     {
-        std::cerr << "Failed to send GetFirmwareParameters request, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n ";
+        error(
+            "Failed to send GetFirmwareParameters request, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
     }
 }
 
@@ -178,8 +182,8 @@ void InventoryManager::getFirmwareParameters(mctp_eid_t eid,
 {
     if (response == nullptr || !respMsgLen)
     {
-        std::cerr << "No response received for GetFirmwareParameters, EID="
-                  << unsigned(eid) << "\n";
+        error("No response received for GetFirmwareParameters, EID={EID}",
+              "EID", unsigned(eid));
         descriptorMap.erase(eid);
         return;
     }
@@ -194,17 +198,17 @@ void InventoryManager::getFirmwareParameters(mctp_eid_t eid,
         &pendingCompImageSetVerStr, &compParamTable);
     if (rc)
     {
-        std::cerr << "Decoding GetFirmwareParameters response failed, EID="
-                  << unsigned(eid) << ", RC=" << rc << "\n";
+        error(
+            "Decoding GetFirmwareParameters response failed, EID={EID}, RC = {RC}",
+            "EID", unsigned(eid), "RC", rc);
         return;
     }
 
     if (fwParams.completion_code)
     {
-        std::cerr << "GetFirmwareParameters response failed with error "
-                     "completion code, EID="
-                  << unsigned(eid)
-                  << ", CC=" << unsigned(fwParams.completion_code) << "\n";
+        error(
+            "GetFirmwareParameters response failed with error completion code, EID={EID}, CC = {CC}",
+            "EID", unsigned(eid), "CC", unsigned(fwParams.completion_code));
         return;
     }
 
@@ -222,8 +226,9 @@ void InventoryManager::getFirmwareParameters(mctp_eid_t eid,
             &pendingCompVerStr);
         if (rc)
         {
-            std::cerr << "Decoding component parameter table entry failed, EID="
-                      << unsigned(eid) << ", RC=" << rc << "\n";
+            error(
+                "Decoding component parameter table entry failed, EID={EID}, RC = {RC}",
+                "EID", unsigned(eid), "RC", rc);
             return;
         }
 

--- a/fw-update/package_parser.cpp
+++ b/fw-update/package_parser.cpp
@@ -5,17 +5,18 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <iostream>
 #include <memory>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace fw_update
 {
-
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
 
@@ -39,8 +40,8 @@ size_t PackageParser::parseFDIdentificationArea(
             &compImageSetVersionStr, &recordDescriptors, &fwDevicePkgData);
         if (rc)
         {
-            std::cerr << "Decoding firmware device ID record failed, RC=" << rc
-                      << "\n";
+            error("Decoding firmware device ID record failed, RC={RC}", "RC",
+                  rc);
             throw InternalFailure();
         }
 
@@ -56,9 +57,9 @@ size_t PackageParser::parseFDIdentificationArea(
                 &descriptorType, &descriptorData);
             if (rc)
             {
-                std::cerr
-                    << "Decoding descriptor type, length and value failed, RC="
-                    << rc << "\n";
+                error(
+                    "Decoding descriptor type, length and value failed, RC={RC}",
+                    "RC", rc);
                 throw InternalFailure();
             }
 
@@ -80,9 +81,9 @@ size_t PackageParser::parseFDIdentificationArea(
                     &descTitleStrType, &descTitleStr, &vendorDefinedDescData);
                 if (rc)
                 {
-                    std::cerr << "Decoding Vendor-defined descriptor value "
-                                 "failed, RC="
-                              << rc << "\n";
+                    error(
+                        "Decoding Vendor-defined descriptor value failed, RC={RC}",
+                        "RC", rc);
                     throw InternalFailure();
                 }
 
@@ -151,8 +152,8 @@ size_t PackageParser::parseCompImageInfoArea(ComponentImageCount compImageCount,
                                               &compImageInfo, &compVersion);
         if (rc)
         {
-            std::cerr << "Decoding component image information failed, RC="
-                      << rc << "\n";
+            error("Decoding component image information failed, RC={RC}", "RC",
+                  rc);
             throw InternalFailure();
         }
 
@@ -194,12 +195,12 @@ void PackageParser::validatePkgTotalSize(uintmax_t pkgSize)
 
         if (compLocOffset != calcPkgSize)
         {
-            std::cerr << "Validating the component location offset failed, "
-                         "COMP_VERSION="
-                      << std::get<static_cast<size_t>(
-                             ComponentImageInfoPos::CompVersionPos)>(
-                             componentImageInfo)
-                      << "\n";
+            error(
+                "Validating the component location offset failed, COMP_VERSION={COMP_VERS}",
+                "COMP_VERS",
+                std::get<static_cast<size_t>(
+                    ComponentImageInfoPos::CompVersionPos)>(
+                    componentImageInfo));
             throw InternalFailure();
         }
 
@@ -208,9 +209,9 @@ void PackageParser::validatePkgTotalSize(uintmax_t pkgSize)
 
     if (calcPkgSize != pkgSize)
     {
-        std::cerr
-            << "Package size does not match calculated package size, PKG_SIZE="
-            << pkgSize << " ,CALC_PKG_SIZE=" << calcPkgSize << "\n";
+        error(
+            "Package size does not match calculated package size, PKG_SIZE={PKG_SIZE}, CALC_PKG_SIZE={CALC_PKG_SIZE}",
+            "PKG_SIZE", pkgSize, "CALC_PKG_SIZE", calcPkgSize);
         throw InternalFailure();
     }
 }
@@ -220,16 +221,16 @@ void PackageParserV1::parse(const std::vector<uint8_t>& pkgHdr,
 {
     if (pkgHeaderSize != pkgHdr.size())
     {
-        std::cerr << "Package header size is invalid, PKG_HDR_SIZE="
-                  << pkgHeaderSize << "\n";
+        error("Package header size is invalid, PKG_HDR_SIZE={PKG_HDR_SIZE}",
+              "PKG_HDR_SIZE", pkgHeaderSize);
         throw InternalFailure();
     }
 
     size_t offset = sizeof(pldm_package_header_information) + pkgVersion.size();
     if (offset + sizeof(DeviceIDRecordCount) >= pkgHeaderSize)
     {
-        std::cerr << "Parsing package header failed, PKG_HDR_SIZE="
-                  << pkgHeaderSize << "\n";
+        error("Parsing package header failed, PKG_HDR_SIZE={PKG_HDR_SIZE}",
+              "PKG_HDR_SIZE", pkgHeaderSize);
         throw InternalFailure();
     }
 
@@ -239,15 +240,15 @@ void PackageParserV1::parse(const std::vector<uint8_t>& pkgHdr,
     offset = parseFDIdentificationArea(deviceIdRecCount, pkgHdr, offset);
     if (deviceIdRecCount != fwDeviceIDRecords.size())
     {
-        std::cerr
-            << "DeviceIDRecordCount entries not found, DEVICE_ID_REC_COUNT="
-            << deviceIdRecCount << "\n";
+        error(
+            "DeviceIDRecordCount entries not found, DEVICE_ID_REC_COUNT={DEVICE_ID_REC_CNT}",
+            "DEVICE_ID_REC_CNT", deviceIdRecCount);
         throw InternalFailure();
     }
     if (offset + sizeof(ComponentImageCount) >= pkgHeaderSize)
     {
-        std::cerr << "Parsing package header failed, PKG_HDR_SIZE="
-                  << pkgHeaderSize << "\n";
+        error("Parsing package header failed, PKG_HDR_SIZE={PKG_HDR_SIZE}",
+              "PKG_HDR_SIZE", pkgHeaderSize);
         throw InternalFailure();
     }
 
@@ -258,15 +259,16 @@ void PackageParserV1::parse(const std::vector<uint8_t>& pkgHdr,
     offset = parseCompImageInfoArea(compImageCount, pkgHdr, offset);
     if (compImageCount != componentImageInfos.size())
     {
-        std::cerr << "ComponentImageCount entries not found, COMP_IMAGE_COUNT="
-                  << compImageCount << "\n";
+        error(
+            "ComponentImageCount entries not found, COMP_IMAGE_COUNT={COMP_IMAGE_COUNT}",
+            "COMP_IMAGE_COUNT", compImageCount);
         throw InternalFailure();
     }
 
     if (offset + sizeof(PackageHeaderChecksum) != pkgHeaderSize)
     {
-        std::cerr << "Parsing package header failed, PKG_HDR_SIZE="
-                  << pkgHeaderSize << "\n";
+        error("Parsing package header failed, PKG_HDR_SIZE={PKG_HDR_SIZE}",
+              "PKG_HDR_SIZE", pkgHeaderSize);
         throw InternalFailure();
     }
 
@@ -276,8 +278,9 @@ void PackageParserV1::parse(const std::vector<uint8_t>& pkgHdr,
                 (pkgHdr[offset + 2] << 16) | (pkgHdr[offset + 3] << 24)));
     if (calcChecksum != checksum)
     {
-        std::cerr << "Parsing package header failed, CALC_CHECKSUM="
-                  << calcChecksum << ", PKG_HDR_CHECKSUM=" << checksum << "\n";
+        error(
+            "Parsing package header failed, CALC_CHECKSUM={CALC_CHECKSUM}, PKG_HDR_CHECKSUM={KEY1}",
+            "CALC_CHECKSUM", calcChecksum, "PKG_HDR_CHECKSUM", checksum);
         throw InternalFailure();
     }
 
@@ -297,8 +300,8 @@ std::unique_ptr<PackageParser> parsePkgHeader(std::vector<uint8_t>& pkgData)
                                               &pkgHeader, &pkgVersion);
     if (rc)
     {
-        std::cerr << "Decoding PLDM package header information failed, RC="
-                  << rc << "\n";
+        error("Decoding PLDM package header information failed, RC={RC}", "RC",
+              rc);
         return nullptr;
     }
 

--- a/fw-update/test/meson.build
+++ b/fw-update/test/meson.build
@@ -23,6 +23,7 @@ foreach t : tests
                          fw_update_test_src,
                          gmock,
                          gtest,
+			 phosphor_logging_dep,
                          libpldm_dep,
                          libpldmutils,
                          nlohmann_json,

--- a/fw-update/update_manager.cpp
+++ b/fw-update/update_manager.cpp
@@ -4,11 +4,14 @@
 #include "common/utils.hpp"
 #include "package_parser.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cassert>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <string>
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -35,9 +38,9 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
         if (activation->activation() ==
             software::Activation::Activations::Activating)
         {
-            std::cerr
-                << "Activation of PLDM FW update package already in progress"
-                << ", PACKAGE_VERSION=" << parser->pkgVersion << "\n";
+            error(
+                "Activation of PLDM FW update package already in progress, PACKAGE_VERSION={PKG_VERS}",
+                "PKG_VERS", parser->pkgVersion);
             std::filesystem::remove(packageFilePath);
             return -1;
         }
@@ -51,9 +54,9 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
                  std::ios::binary | std::ios::in | std::ios::ate);
     if (!package.good())
     {
-        std::cerr << "Opening the PLDM FW update package failed, ERR="
-                  << unsigned(errno) << ", PACKAGEFILE=" << packageFilePath
-                  << "\n";
+        error(
+            "Opening the PLDM FW update package failed, ERR={ERR}, PACKAGEFILE={PKG_PATH}",
+            "ERR", unsigned(errno), "PKG_PATH", packageFilePath.c_str());
         package.close();
         std::filesystem::remove(packageFilePath);
         return -1;
@@ -62,9 +65,9 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
     uintmax_t packageSize = package.tellg();
     if (packageSize < sizeof(pldm_package_header_information))
     {
-        std::cerr << "PLDM FW update package length less than the length of "
-                     "the package header information, PACKAGESIZE="
-                  << packageSize << "\n";
+        error(
+            "PLDM FW update package length less than the length of the package header information, PACKAGESIZE={PKG_SIZE}",
+            "PKG_SIZE", packageSize);
         package.close();
         std::filesystem::remove(packageFilePath);
         return -1;
@@ -89,8 +92,7 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
     parser = parsePkgHeader(packageHeader);
     if (parser == nullptr)
     {
-        std::cerr << "Invalid PLDM package header information"
-                  << "\n";
+        error("Invalid PLDM package header information");
         package.close();
         std::filesystem::remove(packageFilePath);
         return -1;
@@ -110,8 +112,7 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Invalid PLDM package header"
-                  << "\n";
+        error("Invalid PLDM package header");
         activation = std::make_unique<Activation>(
             pldm::utils::DBusHandler::getBus(), objPath,
             software::Activation::Activations::Invalid, this);
@@ -125,9 +126,8 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
                               totalNumComponentUpdates);
     if (!deviceUpdaterInfos.size())
     {
-        std::cerr
-            << "No matching devices found with the PLDM firmware update package"
-            << "\n";
+        error(
+            "No matching devices found with the PLDM firmware update package");
         activation = std::make_unique<Activation>(
             pldm::utils::DBusHandler::getBus(), objPath,
             software::Activation::Activations::Invalid, this);
@@ -203,11 +203,9 @@ void UpdateManager::updateDeviceCompletion(mctp_eid_t eid, bool status)
         }
 
         auto endTime = std::chrono::steady_clock::now();
-        std::cerr << "Firmware update time: "
-                  << std::chrono::duration<double, std::milli>(endTime -
-                                                               startTime)
-                         .count()
-                  << " ms\n";
+        error("Firmware update time: {DUR} ms", "DUR",
+              std::chrono::duration<double, std::milli>(endTime - startTime)
+                  .count());
         activation->activation(software::Activation::Activations::Active);
     }
     return;

--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -5,6 +5,10 @@
 #include "serialize.hpp"
 #include "type.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace dbus
@@ -626,8 +630,8 @@ void CustomDBus::removeDBus(const std::vector<uint16_t> types)
             continue;
         }
 
-        std::cerr << "Deleting the dbus objects of type : " << (unsigned)type
-                  << std::endl;
+        error("Deleting the dbus objects of type : {DBUS_OBJ_TYP}",
+              "DBUS_OBJ_TYP", (unsigned)type);
         for (const auto& [path, entites] : savedObjs.at(type))
         {
             deleteObject(path);

--- a/host-bmc/dbus/deserialize.cpp
+++ b/host-bmc/dbus/deserialize.cpp
@@ -6,6 +6,9 @@
 #include "serialize.hpp"
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -179,8 +182,8 @@ std::pair<std::set<uint16_t>, std::set<uint16_t>>
 
     if (!fs::exists(path) || fs::is_empty(path))
     {
-        std::cerr << "The file does not exist or is empty, FILE_PATH = " << path
-                  << std::endl;
+        error("The file does not exist or is empty, FILE_PATH = {FILE_PATH}",
+              "FILE_PATH", path.c_str());
         return std::make_pair(restoreTypes, storeTypes);
     }
 
@@ -207,8 +210,9 @@ std::pair<std::set<uint16_t>, std::set<uint16_t>>
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to parse config file, FILE_PATH = " << path
-                  << ", ERROR = " << e.what() << std::endl;
+        error(
+            "Failed to parse config file, FILE_PATH = {FILE_PATH}, ERROR = {ERR_EXCEP}",
+            "FILE_PATH", path.c_str(), "ERR_EXCEP", e.what());
     }
 
     return std::make_pair(restoreTypes, storeTypes);
@@ -239,7 +243,7 @@ void restoreDbusObj(HostPDRHandler* hostPDRHandler)
             continue;
         }
 
-        std::cout << "Restoring dbus of type : " << type << std::endl;
+        info("Restoring dbus of type : {DBUS_TYP}", "DBUS_TYP", type);
         // updateObjectPathMaps();
         for (auto& [path, entites] : objs)
         {
@@ -253,9 +257,8 @@ void restoreDbusObj(HostPDRHandler* hostPDRHandler)
             {
                 if (!ibmDbusHandler.contains(name))
                 {
-                    std::cerr
-                        << "name is not in ibmDbusHandler, name = " << name
-                        << std::endl;
+                    error("name is not in ibmDbusHandler, name = {NAME}",
+                          "NAME", name);
                     continue;
                 }
                 ibmDbusHandler.at(name)(path, propertyValue);

--- a/host-bmc/dbus/led_group.cpp
+++ b/host-bmc/dbus/led_group.cpp
@@ -2,6 +2,10 @@
 
 #include "libpldm/state_set.h"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace dbus
@@ -41,13 +45,14 @@ bool LEDGroup::asserted(bool value)
                 hostEffecterParser->getPldmPDR(), entity.entity_type,
                 entity.entity_instance_num, entity.entity_container_id,
                 PLDM_STATE_SET_IDENTIFY_STATE, false);
-            std::cerr << "Setting the led on : [ " << objectPath << "] ,[ "
-                      << entity.entity_type << " , "
-                      << entity.entity_instance_num << " , "
-                      << entity.entity_container_id << " ] , effecter ID : [ "
-                      << effecterId << " ] , current value : [ "
-                      << std::boolalpha << asserted() << " ] new value : [ "
-                      << value << " ] " << std::endl;
+            auto curVal = asserted() ? "true" : "false";
+            error(
+                "Setting the led on : [ {OBJ_PATH} ], [{ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID}] effecter ID : [ {EFFECTER_ID} ] , current value : [ {CUR_VAL} ], new value : [ {NEW_VAL} ]",
+                "OBJ_PATH", objectPath, "ENTITY_TYP",
+                static_cast<unsigned>(entity.entity_type), "ENTITY_NUM",
+                static_cast<unsigned>(entity.entity_instance_num), "ENTITY_ID",
+                static_cast<unsigned>(entity.entity_container_id),
+                "EFFECTER_ID", effecterId, "CUR_VAL", curVal, "NEW_VAL", value);
             hostEffecterParser->sendSetStateEffecterStates(
                 mctpEid, effecterId, 1, stateField,
                 std::bind(std::mem_fn(&pldm::dbus::LEDGroup::updateAsserted),

--- a/host-bmc/dbus/linkreset.cpp
+++ b/host-bmc/dbus/linkreset.cpp
@@ -4,11 +4,14 @@
 #include "libpldm/state_set.h"
 #include "libpldm/states.h"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace dbus
 {
-
 bool Link::linkReset(bool value)
 {
     std::vector<set_effecter_state_field> stateField;
@@ -27,7 +30,7 @@ bool Link::linkReset(bool value)
 
     if (value && hostEffecterParser)
     {
-        std::cerr << "Got a link reset request on : " << path << std::endl;
+        error("Got a link reset request on : {PATH}", "PATH", path.c_str());
         uint16_t effecterID = getEffecterID();
 
         if (effecterID == 0)
@@ -35,13 +38,15 @@ bool Link::linkReset(bool value)
             return false;
         }
 
-        std::cerr
-            << "[link reset] : Sending a effecter call to host with effecter id: "
-            << effecterID << std::endl;
+        error(
+            "[link reset] : Sending a effecter call to host with effecter id: {EFFECTER_ID}",
+            "EFFECTER_ID", effecterID);
         hostEffecterParser->sendSetStateEffecterStates(
             mctpEid, effecterID, 1, stateField, nullptr, value);
-        std::cerr << "Link reset on path : " << path
-                  << " is successful setting it back to false" << std::endl;
+        error(
+            "Link reset on path : {PATH} is successful setting it back to false",
+            "PATH", path.c_str());
+
         return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset(
             false);
     }
@@ -60,9 +65,9 @@ uint16_t Link::getEffecterID()
 
     if (stateEffecterPDRs.empty())
     {
-        std::cerr
-            << "PCIe LinkReset: The state set PDR can not be found, entityType = "
-            << entityType << std::endl;
+        error(
+            "PCIe LinkReset: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+            "ENTITY_TYP", entityType);
         return effecterID;
     }
 
@@ -71,8 +76,8 @@ uint16_t Link::getEffecterID()
     entityInstance = pldm::responder::utils::getLinkResetInstanceNumber(path);
 #endif
 
-    std::cerr << "CustomDBus: BusID of the link is: " << entityInstance
-              << std::endl;
+    error("CustomDBus: BusID of the link is: {ENTITY_INST}", "ENTITY_INST",
+          entityInstance);
     for (auto& rep : stateEffecterPDRs)
     {
         auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(rep.data());

--- a/host-bmc/dbus/pcie_topology.cpp
+++ b/host-bmc/dbus/pcie_topology.cpp
@@ -5,11 +5,14 @@
 
 #include "host-bmc/dbus/custom_dbus.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace dbus
 {
-
 bool PCIETopology::pcIeTopologyRefresh() const
 {
     return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
@@ -157,9 +160,9 @@ uint16_t PCIETopology::getEffecterID()
         hostEffecterParser->getPldmPDR());
     if (stateEffecterPDRs.empty())
     {
-        std::cerr
-            << "PCIe Topology: The state set PDR can not be found, entityType = "
-            << entityType << std::endl;
+        error(
+            "PCIe Topology: The state set PDR can not be found, entityType = {ENTITY_TYPE}",
+            "ENTITY_TYPE", entityType);
         return effecterID;
     }
     for (auto& rep : stateEffecterPDRs)

--- a/host-bmc/dbus/serialize.cpp
+++ b/host-bmc/dbus/serialize.cpp
@@ -8,10 +8,13 @@
 #include <cereal/types/tuple.hpp>
 #include <cereal/types/variant.hpp>
 #include <cereal/types/vector.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 // Register class version with Cereal
 CEREAL_CLASS_VERSION(pldm::serialize::Serialize, 1)
@@ -91,8 +94,8 @@ bool Serialize::deserialize()
 {
     if (!fs::exists(filePath))
     {
-        std::cerr << "File does not exist, FILE_PATH = " << filePath
-                  << std::endl;
+        error("File does not exist, FILE_PATH = {FILE_PATH}", "FILE_PATH",
+              filePath.c_str());
         return false;
     }
 
@@ -107,8 +110,8 @@ bool Serialize::deserialize()
     }
     catch (const cereal::Exception& e)
     {
-        std::cerr << "Failed to restore groups, ERROR = " << e.what()
-                  << std::endl;
+        error("Failed to restore groups, ERROR = {ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
         fs::remove(filePath);
     }
 
@@ -140,8 +143,9 @@ void Serialize::reSerialize(const std::vector<uint16_t> types)
     {
         if (savedObjs.contains(type))
         {
-            std::cerr << "Removing objects of type : " << (unsigned)type
-                      << " from the persistent cache\n";
+            error(
+                "Removing objects of type : {OBJ_TYP} from the persistent cache",
+                "OBJ_TYP", (unsigned)type);
             savedObjs.erase(savedObjs.find(type));
         }
     }

--- a/host-bmc/dbus_to_event_handler.cpp
+++ b/host-bmc/dbus_to_event_handler.cpp
@@ -4,6 +4,10 @@
 
 #include "libpldmresponder/pdr.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 using namespace pldm::dbus_api;
@@ -40,8 +44,8 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_platform_event_message_req, rc = " << rc
-                  << std::endl;
+        error("Failed to encode_platform_event_message_req, rc = {RC}", "RC",
+              rc);
         return;
     }
 
@@ -49,8 +53,7 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
         [](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr
-                << "Failed to receive response for platform event message \n";
+            error("Failed to receive response for platform event message");
             return;
         }
         uint8_t completionCode{};
@@ -59,10 +62,9 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
 
@@ -71,7 +73,7 @@ void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send the platform event message \n";
+        error("Failed to send the platform event message");
     }
 }
 

--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -4,11 +4,14 @@
 #include "libpldm/platform.h"
 #include "libpldm/pldm.h"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/State/OperatingSystem/Status/server.hpp>
 
 #include <fstream>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::utils;
 
@@ -38,15 +41,16 @@ void HostEffecterParser::parseEffecterJson(const std::string& jsonPath)
     fs::path jsonDir(jsonPath);
     if (!fs::exists(jsonDir) || fs::is_empty(jsonDir))
     {
-        std::cerr << "Host Effecter json path does not exist, DIR=" << jsonPath
-                  << "\n";
+        error("Host Effecter json path does not exist, DIR = {JSON_PATH}",
+              "JSON_PATH", jsonPath.c_str());
         return;
     }
 
     fs::path jsonFilePath = jsonDir / hostEffecterJson;
     if (!fs::exists(jsonFilePath))
     {
-        std::cerr << "json does not exist, PATH=" << jsonFilePath << "\n";
+        error("json does not exist, PATH = {JSON_PATH}", "JSON_PATH",
+              jsonFilePath.c_str());
         throw InternalFailure();
     }
 
@@ -54,7 +58,8 @@ void HostEffecterParser::parseEffecterJson(const std::string& jsonPath)
     auto data = Json::parse(jsonFile, nullptr, false);
     if (data.is_discarded())
     {
-        std::cerr << "Parsing json file failed, FILE=" << jsonFilePath << "\n";
+        error("Parsing json file failed, FILE = {JSON_PATH}", "JSON_PATH",
+              jsonFilePath.c_str());
         throw InternalFailure();
     }
     const Json empty{};
@@ -96,11 +101,10 @@ void HostEffecterParser::parseEffecterJson(const std::string& jsonPath)
             auto states = state.value("state_values", emptyStates);
             if (dbusInfo.propertyValues.size() != states.size())
             {
-                std::cerr << "Number of states do not match with"
-                          << " number of D-Bus property values in the json. "
-                          << "Object path " << dbusInfo.dbusMap.objectPath
-                          << " and property " << dbusInfo.dbusMap.propertyName
-                          << " will not be monitored \n";
+                error(
+                    "Number of states do not match with number of D-Bus property values in the json. Object path {JSON_OBJ_PATH} and property {DBUS_PROP}  will not be monitored",
+                    "JSON_OBJ_PATH", dbusInfo.dbusMap.objectPath.c_str(),
+                    "DBUS_PROP", dbusInfo.dbusMap.propertyName);
                 continue;
             }
             for (const auto& s : states)
@@ -147,7 +151,7 @@ void HostEffecterParser::processHostEffecterChangeNotification(
             localOrRemote);
         if (effecterId == PLDM_INVALID_EFFECTER_ID)
         {
-            std::cerr << "Effecter id not found in pdr repo \n";
+            error("Effecter id not found in pdr repo");
             return;
         }
     }
@@ -167,16 +171,16 @@ void HostEffecterParser::processHostEffecterChangeNotification(
             (currHostState != "xyz.openbmc_project.State.Boot.Progress."
                               "ProgressStages.SystemSetup"))
         {
-            std::cout << "Host is not up. Current host state: "
-                      << currHostState.c_str() << "\n";
+            info("Host is not up. Current host state: {CURR_HOST_STATE}",
+                 "CURR_HOST_STATE", currHostState.c_str());
             return;
         }
     }
     catch (const sdbusplus::exception::exception& e)
     {
-        std::cerr << "Error in getting current host state. Will still "
-                     "continue to set the host effecter "
-                  << e.what() << std::endl;
+        error(
+            "Error in getting current host state. Will still continue to set the host effecter {ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
     uint8_t newState{};
     try
@@ -186,8 +190,7 @@ void HostEffecterParser::processHostEffecterChangeNotification(
     }
     catch (const std::out_of_range& e)
     {
-        std::cerr << "new state not found in json"
-                  << "\n";
+        error("new state not found in json");
         return;
     }
 
@@ -211,13 +214,12 @@ void HostEffecterParser::processHostEffecterChangeNotification(
     }
     catch (const std::runtime_error& e)
     {
-        std::cerr << "Could not set host state effecter \n";
+        error("Could not set host state effecter");
         return;
     }
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Could not set the host state effecter, rc= " << rc
-                  << " \n";
+        error("Could not set the host state effecter, rc= {RC}", "RC", rc);
     }
 }
 
@@ -262,9 +264,9 @@ int HostEffecterParser::sendSetStateEffecterStates(
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Message encode SetStateEffecterStates failure. PLDM error code = "
-            << std::hex << std::showbase << rc << "\n";
+        error(
+            "Message encode SetStateEffecterStates failure. PLDM error code = {RC}",
+            "RC", lg2::hex, rc);
         requester->markFree(mctpEid, instanceId);
         return rc;
     }
@@ -273,8 +275,8 @@ int HostEffecterParser::sendSetStateEffecterStates(
         [=](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for "
-                      << "setStateEffecterStates command \n";
+            error(
+                "Failed to receive response for setStateEffecterStates command");
             return;
         }
         uint8_t completionCode{};
@@ -282,19 +284,19 @@ int HostEffecterParser::sendSetStateEffecterStates(
                                                         &completionCode);
         if (rc)
         {
-            std::cerr
-                << "Failed to decode setStateEffecterStates response, effecter Id : "
-                << effecterId << " , rc " << rc << "\n";
+            error(
+                "Failed to decode setStateEffecterStates response, effecter Id : {EFFECTER_ID}, rc = {RC}",
+                "EFFECTER_ID", effecterId, "RC", rc);
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
                 pldm::PelSeverity::ERROR);
         }
         if (completionCode)
         {
-            std::cerr << "Failed to set a Host effecter, effecter Id :  "
-                      << effecterId
-                      << " , cc=" << static_cast<unsigned>(completionCode)
-                      << "\n";
+            error(
+                "Failed to set a Host effecter, effecter Id : {EFFECTER_ID}, cc = {CC}",
+                "EFFECTER_ID", effecterId, "CC",
+                static_cast<unsigned>(completionCode));
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
                 pldm::PelSeverity::ERROR);
@@ -313,7 +315,7 @@ int HostEffecterParser::sendSetStateEffecterStates(
         std::move(requestMsg), std::move(setStateEffecterStatesRespHandler));
     if (rc)
     {
-        std::cerr << "Failed to send request to set an effecter on Host \n";
+        error("Failed to send request to set an effecter on Host");
     }
     return rc;
 }

--- a/host-bmc/dbus_to_host_effecters.hpp
+++ b/host-bmc/dbus_to_host_effecters.hpp
@@ -5,16 +5,18 @@
 #include "pldmd/dbus_impl_requester.hpp"
 #include "requester/handler.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <string>
 #include <utility>
 #include <vector>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace host_effecters
 {
-
 using DbusChgHostEffecterProps =
     std::map<dbus::Property, pldm::utils::PropertyValue>;
 
@@ -91,8 +93,9 @@ class HostEffecterParser
         }
         catch (const std::exception& e)
         {
-            std::cerr << "The json file does not exist or malformed, ERROR="
-                      << e.what() << "\n";
+            error(
+                "The json file does not exist or malformed, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
         }
     }
 

--- a/host-bmc/host_associations_parser.cpp
+++ b/host-bmc/host_associations_parser.cpp
@@ -1,9 +1,12 @@
 #include "host_associations_parser.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <fstream>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::utils;
 
@@ -21,8 +24,8 @@ void HostAssociationsParser::parseHostAssociations(const std::string& jsonPath)
     fs::path jsonDir(jsonPath);
     if (!fs::exists(jsonDir) || fs::is_empty(jsonDir))
     {
-        std::cerr << "Host Associations json path does not exist, DIR="
-                  << jsonPath << "\n";
+        error("Host Associations json path does not exist, DIR = {JSON_PATH}",
+              "JSON_PATH", jsonPath.c_str());
         return;
     }
 
@@ -30,7 +33,8 @@ void HostAssociationsParser::parseHostAssociations(const std::string& jsonPath)
 
     if (!fs::exists(jsonFilePath))
     {
-        std::cerr << "json does not exist, PATH=" << jsonFilePath << "\n";
+        error("json does not exist, PATH = {JSON_PATH}", "JSON_PATH",
+              jsonFilePath.c_str());
         throw InternalFailure();
     }
 
@@ -38,7 +42,8 @@ void HostAssociationsParser::parseHostAssociations(const std::string& jsonPath)
     auto data = Json::parse(jsonFile, nullptr, false);
     if (data.is_discarded())
     {
-        std::cerr << "Parsing json file failed, FILE=" << jsonFilePath << "\n";
+        error("Parsing json file failed, FILE = {JSON_PATH}", "JSON_PATH",
+              jsonFilePath.c_str());
         throw InternalFailure();
     }
     const Json empty{};

--- a/host-bmc/host_associations_parser.hpp
+++ b/host-bmc/host_associations_parser.hpp
@@ -3,16 +3,18 @@
 #include "common/types.hpp"
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <string>
 #include <utility>
 #include <vector>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace host_associations
 {
-
 /** @class HostAssociationsParser
  *
  *  @brief This class parses the Host Effecter json file and monitors for the
@@ -40,8 +42,9 @@ class HostAssociationsParser
         }
         catch (const std::exception& e)
         {
-            std::cerr << "The json file does not exist or malformed, ERROR="
-                      << e.what() << "\n";
+            error(
+                "The json file does not exist or malformed, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
         }
     }
 

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -3,6 +3,8 @@
 #include "libpldm/fru.h"
 #include "libpldm/pldm.h"
 #include "libpldm/state_set.h"
+
+#include <phosphor-logging/lg2.hpp>
 #ifdef OEM_IBM
 #include "libpldm/fru_oem_ibm.h"
 #include "libpldm/pdr_oem_ibm.h"
@@ -22,6 +24,8 @@
 
 #include <fstream>
 #include <type_traits>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -118,7 +122,7 @@ HostPDRHandler::HostPDRHandler(
             auto data = Json::parse(jsonFile, nullptr, false);
             if (data.is_discarded())
             {
-                std::cerr << "Parsing Host FRU json file failed" << std::endl;
+                error("Parsing Host FRU json file failed");
             }
             else
             {
@@ -136,8 +140,8 @@ HostPDRHandler::HostPDRHandler(
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Parsing Host FRU json file failed, exception = "
-                      << e.what() << std::endl;
+            error("Parsing Host FRU json file failed, exception = {ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
         }
     }
 
@@ -256,9 +260,9 @@ HostPDRHandler::HostPDRHandler(
                     }
                     catch (const std::exception& e)
                     {
-                        std::cerr
-                            << "Unable to set the slot power state to Off "
-                            << "ERROR=" << e.what() << "\n";
+                        error(
+                            "Unable to set the slot power state to Off, ERROR = {ERR_EXCEP}",
+                            "ERR_EXCEP", e.what());
                     }
                 }
             }
@@ -356,7 +360,7 @@ void HostPDRHandler::getHostPDR(uint32_t nextRecordHandle)
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_get_pdr_req, rc = " << rc << std::endl;
+        error("Failed to encode_get_pdr_req, rc = {RC}", "RC", rc);
         return;
     }
 
@@ -366,7 +370,7 @@ void HostPDRHandler::getHostPDR(uint32_t nextRecordHandle)
         std::move(std::bind_front(&HostPDRHandler::processHostPDRs, this)));
     if (rc)
     {
-        std::cerr << "Failed to send the GetPDR request to Host \n";
+        error("Failed to send the GetPDR request to Host");
     }
 }
 std::string HostPDRHandler::updateLedGroupPath(const std::string& path)
@@ -404,16 +408,19 @@ int HostPDRHandler::handleStateSensorEvent(
                 auto ledGroupPath = updateLedGroupPath(entity.first);
                 if (!ledGroupPath.empty())
                 {
-                    std::cout
-                        << "led state event for [ " << ledGroupPath << " ] , [ "
-                        << node_entity.entity_type << " ,"
-                        << node_entity.entity_instance_num << " ,"
-                        << node_entity.entity_container_id
-                        << " ] , current value : [ " << std::boolalpha
-                        << CustomDBus::getCustomDBus().getAsserted(ledGroupPath)
-                        << " ] new value : [ "
-                        << bool(state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED)
-                        << " ]\n";
+                    auto currVal =
+                        CustomDBus::getCustomDBus().getAsserted(ledGroupPath)
+                            ? "true"
+                            : "false";
+                    auto newVal =
+                        bool(state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED);
+                    info(
+                        "led state event for [ {LED_GRP_PATH} ], [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID}] , current value : [ {CURR_VAL} ] new value : [ {NEW_VAL} ]",
+                        "LED_GRP_PATH", ledGroupPath, "ENTITY_TYP",
+                        (unsigned)node_entity.entity_type, "ENTITY_NUM",
+                        (unsigned)node_entity.entity_instance_num, "ENTITY_ID",
+                        (unsigned)node_entity.entity_container_id, "CURR_VAL",
+                        currVal, "NEW_VAL", (unsigned)newVal);
                     CustomDBus::getCustomDBus().setAsserted(
                         ledGroupPath, node_entity,
                         state == PLDM_STATE_SET_IDENTIFY_STATE_ASSERTED,
@@ -429,8 +436,8 @@ int HostPDRHandler::handleStateSensorEvent(
                 stateSetId[0] == PLDM_STATE_SET_HEALTH_STATE &&
                 strstr(entity.first.c_str(), "core"))
             {
-                std::cerr << "Guard event on CORE : [" << entity.first
-                          << "] \n";
+                error("Guard event on CORE : [{ENTITY_FIRST}]", "ENTITY_FIRST",
+                      entity.first.c_str());
             }
             CustomDBus::getCustomDBus().setOperationalStatus(
                 entity.first, state == PLDM_OPERATIONAL_NORMAL,
@@ -441,8 +448,7 @@ int HostPDRHandler::handleStateSensorEvent(
         else if (stateSetId[0] == PLDM_STATE_SET_VERSION)
         {
             // There is a version changed on any of the dbus objects
-            std::cout
-                << "Got a signal from Host about a possible change in Version\n";
+            info("Got a signal from Host about a possible change in Version");
             createDbusObjects();
             return PLDM_SUCCESS;
         }
@@ -451,8 +457,7 @@ int HostPDRHandler::handleStateSensorEvent(
     auto rc = stateSensorHandler.eventAction(entry, state);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to fetch and update D-bus property, rc = " << rc
-                  << std::endl;
+        error("Failed to fetch and update D-bus property, rc = {RC}", "RC", rc);
         return rc;
     }
 
@@ -526,8 +531,7 @@ void HostPDRHandler::mergeEntityAssociations(
         pldm_find_entity_ref_in_tree(entityTree, entities[0], &node);
         if (node == nullptr)
         {
-            std::cerr
-                << "\ncould not find referrence of the entity in the tree \n";
+            error("could not find referrence of the entity in the tree");
         }
         else
         {
@@ -569,9 +573,9 @@ void HostPDRHandler::mergeEntityAssociations(
 void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
                                                uint8_t eventDataFormat)
 {
-    std::cerr
-        << "Sending the repo change event after merging the PDRs, MCTP_ID:"
-        << (unsigned)mctp_eid << std::endl;
+    error(
+        "Sending the repo change event after merging the PDRs, MCTP_ID: {MCTP_ID}",
+        "MCTP_ID", (unsigned)mctp_eid);
     assert(eventDataFormat == FORMAT_IS_PDR_HANDLES);
 
     // Extract from the PDR repo record handles of PDRs we want the host
@@ -635,9 +639,8 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
         &firstEntry, eventData, &actualSize, maxSize);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to encode_pldm_pdr_repository_chg_event_data, rc = "
-            << rc << std::endl;
+        error("Failed to encode_pldm_pdr_repository_chg_event_data, rc = {RC}",
+              "RC", rc);
         return;
     }
     auto instanceId = requester.getInstanceId(mctp_eid);
@@ -652,8 +655,8 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_platform_event_message_req, rc = " << rc
-                  << std::endl;
+        error("Failed to encode_platform_event_message_req, rc = {RC}", "RC",
+              rc);
         return;
     }
 
@@ -661,9 +664,8 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
         [](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the PDR repository "
-                         "changed event"
-                      << "\n";
+            error(
+                "Failed to receive response for the PDR repository changed event");
             return;
         }
 
@@ -674,10 +676,9 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: {RC}, cc = {CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
 
@@ -686,8 +687,7 @@ void HostPDRHandler::sendPDRRepositoryChgEvent(std::vector<uint8_t>&& pdrTypes,
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send the PDR repository changed event request"
-                  << "\n";
+        error("Failed to send the PDR repository changed event request");
     }
 }
 
@@ -734,8 +734,7 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
     uint8_t transferCRC{};
     if (response == nullptr || !respMsgLen)
     {
-        std::cerr << "Failed to receive response for the GetPDR"
-                     " command \n";
+        error("Failed to receive response for the GetPDR command");
         return;
     }
 
@@ -748,7 +747,7 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
     memcpy(responsePDRMsg.data(), response, respMsgLen + sizeof(pldm_msg_hdr));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to decode_get_pdr_resp, rc = " << rc << std::endl;
+        error("Failed to decode_get_pdr_resp, rc = {RC}", "RC", rc);
         return;
     }
     else
@@ -760,11 +759,10 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
                                  respCount, &transferCRC);
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Failed to decode_get_pdr_resp: "
-                      << "rc= "
-                      << ", NextRecordhandle :" << rc << nextRecordHandle
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_get_pdr_resp: rc = {RC}, NextRecordhandle : {NXT_RECORD_HNDL}, cc = {CC}",
+                "RC", rc, "NXT_RECORD_HNDL", nextRecordHandle, "CC",
+                static_cast<unsigned>(completionCode));
             return;
         }
         else
@@ -803,12 +801,10 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
 
                     terminusHandle = tlpdr->terminus_handle;
                     tid = tlpdr->tid;
-                    std::cerr
-                        << "Got a terminus Locator PDR with TID:"
-                        << (unsigned)tid
-                        << " and Terminus handle:" << terminusHandle
-                        << " with Valid bit as:" << (unsigned)tlpdr->validity
-                        << std::endl;
+                    error(
+                        "Got a terminus Locator PDR with TID: {TID} and Terminus handle: {TERMINUS_HNDL} with Valid bit as: {VALID_BIT}",
+                        "TID", (unsigned)tid, "TERMINUS_HNDL", terminusHandle,
+                        "VALID_BIT", (unsigned)tlpdr->validity);
                     auto terminus_locator_type = tlpdr->terminus_locator_type;
                     if (terminus_locator_type ==
                         PLDM_TERMINUS_LOCATOR_TYPE_MCTP_EID)
@@ -949,11 +945,11 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
     {
         pldm_pdr_record* firstRecord = repo->first;
         pldm_pdr_record* lastRecord = repo->last;
-        std::cerr << "First Record in the repo after PDR exchange is: "
-                  << firstRecord->record_handle << std::endl;
-        std::cerr << "Last Record in the repo after PDR exchange is:"
-                  << lastRecord->record_handle << std::endl;
-
+        error(
+            "First Record in the repo after PDR exchange is: {FIRST_REC_HNDL}",
+            "FIRST_REC_HNDL", firstRecord->record_handle);
+        error("Last Record in the repo after PDR exchange is: {LAST_REC_HNDL}",
+              "LAST_REC_HNDL", lastRecord->record_handle);
         pldm::hostbmc::utils::updateEntityAssociation(
             entityAssociations, entityTree, objPathMap, oemPlatformHandler);
 
@@ -970,7 +966,7 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
         this->createDbusObjects();
         if (isHostUp())
         {
-            std::cout << "Host is UP & Completed the PDR Exchange with host\n";
+            info("Host is UP & Completed the PDR Exchange with host");
             this->setHostSensorState();
         }
 
@@ -1047,8 +1043,8 @@ void HostPDRHandler::setHostFirmwareCondition()
                                      PLDM_BASE, request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "GetPLDMVersion encode failure. PLDM error code = "
-                  << std::hex << std::showbase << rc << "\n";
+        error("GetPLDMVersion encode failure. PLDM error code = {RC}", "RC",
+              lg2::hex, rc);
         requester.markFree(mctp_eid, instanceId);
         return;
     }
@@ -1058,13 +1054,12 @@ void HostPDRHandler::setHostFirmwareCondition()
                                         size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for "
-                      << "getPLDMVersion command, Host seems to be off \n";
+            error(
+                "Failed to receive response for getPLDMVersion command, Host seems to be off");
             return;
         }
-        std::cout << "Getting the response. PLDM RC = " << std::hex
-                  << std::showbase
-                  << static_cast<uint16_t>(response->payload[0]) << "\n";
+        error("Getting the response. PLDM RC = {RC}", "RC", lg2::hex,
+              (uint16_t)response->payload[0]);
         this->responseReceived = true;
     };
     rc = handler->registerRequest(mctp_eid, instanceId, PLDM_BASE,
@@ -1072,7 +1067,7 @@ void HostPDRHandler::setHostFirmwareCondition()
                                   std::move(getPLDMVersionHandler));
     if (rc)
     {
-        std::cerr << "Failed to discover Host state. Assuming Host as off \n";
+        error("Failed to discover Host state. Assuming Host as off");
     }
 }
 
@@ -1091,8 +1086,8 @@ void HostPDRHandler::_setHostSensorState()
 {
     if (isHostOff)
     {
-        std::cerr
-            << "set host state sensor begin : Host is off, stopped sending sensor state commands\n";
+        error(
+            "set host state sensor begin : Host is off, stopped sending sensor state commands");
         return;
     }
     if (sensorIndex != stateSensorPDRs.end())
@@ -1104,7 +1099,7 @@ void HostPDRHandler::_setHostSensorState()
 
         if (!pdr)
         {
-            std::cerr << "Failed to get State sensor PDR" << std::endl;
+            error("Failed to get State sensor PDR");
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostSensorState.GetStateSensorPDRFail",
                 pldm::PelSeverity::ERROR);
@@ -1137,9 +1132,9 @@ void HostPDRHandler::_setHostSensorState()
                 if (rc != PLDM_SUCCESS)
                 {
                     requester.markFree(mctpEid, instanceId);
-                    std::cerr << "Failed to "
-                                 "encode_get_state_sensor_readings_req, rc = "
-                              << rc << " SensorId=" << sensorId << std::endl;
+                    error(
+                        "Failed to encode_get_state_sensor_readings_req, rc = {RC}, SensorId = {SENSOR_ID}",
+                        "RC", rc, "SENSOR_ID", sensorId);
                     pldm::utils::reportError(
                         "xyz.openbmc_project.PLDM.Error.SetHostSensorState.EncodeStateSensorFail",
                         pldm::PelSeverity::ERROR);
@@ -1151,14 +1146,13 @@ void HostPDRHandler::_setHostSensorState()
                               size_t respMsgLen) {
                     if (response == nullptr || !respMsgLen)
                     {
-                        std::cerr
-                            << "Failed to receive response for "
-                               "getStateSensorReading command for sensor id="
-                            << sensorId << std::endl;
+                        error(
+                            "Failed to receive response for getStateSensorReading command for sensor id = {SENSOR_ID}",
+                            "SENSOR_ID", sensorId);
                         if (this->isHostOff)
                         {
-                            std::cerr
-                                << "set host state sensor : Host is off, stopped sending sensor state commands\n";
+                            error(
+                                "set host state sensor : Host is off, stopped sending sensor state commands");
                             return;
                         }
                         if (sensorIndex == stateSensorPDRs.end())
@@ -1179,12 +1173,10 @@ void HostPDRHandler::_setHostSensorState()
 
                     if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
                     {
-                        std::cerr
-                            << "Failed to "
-                               "decode_get_state_sensor_readings_resp, rc = "
-                            << rc
-                            << " cc=" << static_cast<unsigned>(completionCode)
-                            << " SensorId=" << sensorId << std::endl;
+                        error(
+                            "Failed to decode_get_state_sensor_readings_resp, rc = {RC} cc = {CC} SensorId = {SENSOR_ID}",
+                            "RC", rc, "CC", (unsigned)completionCode,
+                            "SENSOR_ID", sensorId);
                         if (sensorIndex == stateSensorPDRs.end())
                         {
                             return;
@@ -1231,17 +1223,16 @@ void HostPDRHandler::_setHostSensorState()
                             }
                             catch (const std::out_of_range& e)
                             {
-                                std::cerr << "No mapping for the events"
-                                          << std::endl;
+                                error("No mapping for the events");
                                 continue;
                             }
                         }
 
                         if (sensorOffset > compositeSensorStates.size())
                         {
-                            std::cerr
-                                << " Error Invalid data, Invalid sensor offset,"
-                                << " SensorId=" << sensorId << std::endl;
+                            error(
+                                "Error Invalid data, Invalid sensor offset, SensorId = {SENSOR_ID}",
+                                "SENSOR_ID", sensorId);
                             return;
                         }
 
@@ -1250,9 +1241,9 @@ void HostPDRHandler::_setHostSensorState()
                         if (possibleStates.find(eventState) ==
                             possibleStates.end())
                         {
-                            std::cerr
-                                << " Error invalid_data, Invalid event state,"
-                                << " SensorId=" << sensorId << std::endl;
+                            error(
+                                "Error invalid_data, Invalid event state, SensorId = {SENSOR_ID}",
+                                "SENSOR_ID", sensorId);
                             return;
                         }
                         const auto& [containerId, entityType,
@@ -1280,9 +1271,9 @@ void HostPDRHandler::_setHostSensorState()
 
                 if (rc != PLDM_SUCCESS)
                 {
-                    std::cerr << " Failed to send request to get State sensor "
-                                 "reading on Host,"
-                              << " SensorId=" << sensorId << std::endl;
+                    error(
+                        " Failed to send request to get State sensor reading on Host, SensorId={SENSOR_ID}",
+                        "SENSOR_ID", sensorId);
                 }
             }
         }
@@ -1302,8 +1293,8 @@ void HostPDRHandler::getFRURecordTableMetadataByHost()
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_get_fru_record_table_metadata_req, rc = "
-                  << rc << std::endl;
+        error("Failed to encode_get_fru_record_table_metadata_req, rc = {RC}",
+              "RC", rc);
         return;
     }
 
@@ -1312,8 +1303,8 @@ void HostPDRHandler::getFRURecordTableMetadataByHost()
                size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the Get FRU Record "
-                         "Table Metadata\n";
+            error(
+                "Failed to receive response for the Get FRU Record Table Metadata");
             return;
         }
 
@@ -1331,9 +1322,9 @@ void HostPDRHandler::getFRURecordTableMetadataByHost()
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Faile to decode get fru record table metadata resp, "
-                         "Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            error(
+                "Failed to decode get fru record table metadata resp, Message Error: rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", (int)cc);
             return;
         }
 
@@ -1347,8 +1338,7 @@ void HostPDRHandler::getFRURecordTableMetadataByHost()
         std::move(getFruRecordTableMetadataResponseHandler));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to send the the Set State Effecter States request\n";
+        error("Failed to send the the Set State Effecter States request");
     }
 
     return;
@@ -1375,8 +1365,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_get_fru_record_table_req, rc = " << rc
-                  << std::endl;
+        error("Failed to encode_get_fru_record_table_req, rc = {RC}", "RC", rc);
         return;
     }
 
@@ -1385,8 +1374,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
             mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the Get FRU Record "
-                         "Table\n";
+            error("Failed to receive response for the Get FRU Record Table");
             return;
         }
 
@@ -1403,9 +1391,9 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr
-                << "Failed to decode get fru record table resp, Message Error: "
-                << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            error(
+                "Failed to decode get fru record table resp, Message Error: rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", (int)cc);
             return;
         }
 
@@ -1416,7 +1404,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
         {
             fruRecordData.clear();
 
-            std::cerr << "failed to parse fru recrod data format.\n";
+            error("failed to parse fru recrod data format.");
             return;
         }
 
@@ -1428,8 +1416,7 @@ void HostPDRHandler::getFRURecordTableByHost(uint16_t& total_table_records)
         std::move(requestMsg), std::move(getFruRecordTableResponseHandler));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to send the the Set State Effecter States request\n";
+        error("Failed to send the the Set State Effecter States request");
     }
 }
 
@@ -1463,8 +1450,8 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctpEid, instanceId);
-        std::cerr << "Failed to encode_get_state_sensor_readings_req, rc = "
-                  << rc << std::endl;
+        error("Failed to encode_get_state_sensor_readings_req, rc = {RC}", "RC",
+              rc);
         return;
     }
 
@@ -1474,16 +1461,15 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
                    size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr
-                << "Failed to receive response for get_state_sensor_readings command, sensor id : "
-                << sensorId << std::endl;
+            error(
+                "Failed to receive response for get_state_sensor_readings command, sensor id : {SENSOR_ID}",
+                "SENSOR_ID", sensorId);
             // even when for some reason , if we fail to get a response
             // to one sensor, try all the dbus objects
 
             if (this->isHostOff)
             {
-                std::cerr
-                    << "Host is off, stopped sending sensor states command\n";
+                error("Host is off, stopped sending sensor states command");
                 return;
             }
 
@@ -1507,9 +1493,9 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
             responsePtr, respMsgLen, &cc, &sensorCnt, stateField.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Faile to decode get state sensor readings resp, "
-                         "Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            error(
+                "Failed to decode get state sensor readings resp, Message Error: rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", (int)cc);
             ++sensorMapIndex;
             if (sensorMapIndex == sensorMap.end())
             {
@@ -1570,7 +1556,7 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
         std::move(getStateSensorReadingsResponseHandler));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to get the State Sensor Readings request\n";
+        error("Failed to get the State Sensor Readings request");
     }
 
     return;
@@ -1636,11 +1622,12 @@ void HostPDRHandler::setLocationCode(
                     if (tlv.fruFieldType == PLDM_FRU_FIELD_TYPE_VERSION &&
                         node.entity_type == PLDM_ENTITY_SYSTEM_CHASSIS)
                     {
-                        std::cout << "Refreshing the mex firmware version : "
-                                  << std::string(reinterpret_cast<const char*>(
-                                                     tlv.fruFieldValue.data()),
-                                                 tlv.fruFieldLen)
-                                  << std::endl;
+                        auto mex_vers =
+                            std::string(reinterpret_cast<const char*>(
+                                            tlv.fruFieldValue.data()),
+                                        tlv.fruFieldLen);
+                        info("Refreshing the mex firmware version : {MEX_VERS}",
+                             "MEX_VERS", mex_vers);
                         CustomDBus::getCustomDBus().setSoftwareVersion(
                             entity.first,
                             std::string(reinterpret_cast<const char*>(
@@ -1764,7 +1751,7 @@ void HostPDRHandler::setAvailabilityState(const std::string& path)
 
 void HostPDRHandler::createDbusObjects()
 {
-    std::cerr << "Refreshing dbus hosted by pldm Started \n";
+    error("Refreshing dbus hosted by pldm Started");
 
     objMapIndex = objPathMap.begin();
 
@@ -1853,7 +1840,7 @@ void HostPDRHandler::createDbusObjects()
 
     // update xyz.openbmc_project.State.Decorator.OperationalStatus
     setOperationStatus();
-    std::cerr << "Refreshing dbus hosted by pldm Completed \n";
+    error("Refreshing dbus hosted by pldm Completed");
 }
 
 void HostPDRHandler::deleteDbusObjects(const std::vector<uint16_t> types)
@@ -1871,15 +1858,15 @@ void HostPDRHandler::deleteDbusObjects(const std::vector<uint16_t> types)
             continue;
         }
 
-        std::cerr << "Deleting the dbus objects of type : " << (unsigned)type
-                  << std::endl;
+        error("Deleting the dbus objects of type : {OBJ_TYP} ", "OBJ_TYP",
+              (unsigned)type);
         for (const auto& [path, entites] : savedObjs.at(type))
         {
             if (type !=
                 (PLDM_ENTITY_PROC | 0x8000)) // other than CPU core object
             {
-                std::cout << "Erasing Dbus Path from ObjectMap " << path
-                          << std::endl;
+                info("Erasing Dbus Path from ObjectMap {DBUS_PATH}",
+                     "DBUS_PATH", path.c_str());
                 objPathMap.erase(path);
                 // Delete the Mex Led Dbus Object paths
                 auto ledGroupPath = updateLedGroupPath(path);
@@ -1946,11 +1933,11 @@ void HostPDRHandler::setRecordPresent(uint32_t recordHandle)
                 recordEntity.entity_instance_num &&
             dbusEntity.entity_container_id == recordEntity.entity_container_id)
         {
-            std::cerr << "Removing Host FRU "
-                      << "[ " << path << " ]  with entityid [ "
-                      << recordEntity.entity_type << ","
-                      << recordEntity.entity_instance_num << ","
-                      << recordEntity.entity_container_id << "]" << std::endl;
+            error(
+                "Removing Host FRU [ {PATH} ] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ]",
+                "ENTITY_TYP", (unsigned)recordEntity.entity_type, "ENTITY_NUM",
+                (unsigned)recordEntity.entity_instance_num, "ENTITY_ID",
+                (unsigned)recordEntity.entity_container_id);
             // if the record has the same entity id, mark that dbus object as
             // not present
             CustomDBus::getCustomDBus().updateItemPresentStatus(path, false);
@@ -1965,7 +1952,8 @@ void HostPDRHandler::deletePDRFromRepo(PDRRecordHandles&& recordHandles)
 {
     for (auto& recordHandle : recordHandles)
     {
-        std::cerr << "Record handle deleted: " << recordHandle << std::endl;
+        error("Record handle deleted: {REC_HANDLE}", "REC_HANDLE",
+              recordHandle);
         this->setRecordPresent(recordHandle);
         pldm_delete_by_record_handle(repo, recordHandle, true);
     }

--- a/host-bmc/test/meson.build
+++ b/host-bmc/test/meson.build
@@ -52,6 +52,7 @@ foreach t : tests
                          libpldmutils,
                          nlohmann_json,
                          phosphor_dbus_interfaces,
+                         phosphor_logging_dep,
                          sdbusplus,
                          sdeventplus]),
        workdir: meson.current_source_dir())

--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -5,7 +5,11 @@
 #include "common/utils.hpp"
 #include "utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace fs = std::filesystem;
 namespace pldm
@@ -14,7 +18,6 @@ namespace hostbmc
 {
 namespace utils
 {
-
 Entities getParentEntites(const EntityAssociations& entityAssoc)
 {
     Entities parents{};
@@ -195,11 +198,11 @@ void updateEntityAssociation(
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "Parent entity not found in the entityMaps, type = "
-                    << parent.entity_type
-                    << ", num = " << parent.entity_instance_num
-                    << ", e = " << e.what() << std::endl;
+                error(
+                    "Parent entity not found in the entityMaps, type = {ENTITY_TYP}, num = {ENTITY_NUM}, e = {ERR_EXCEP}",
+                    "ENTITY_TYP", static_cast<int>(parent.entity_type),
+                    "ENTITY_NUM", static_cast<int>(parent.entity_instance_num),
+                    "ERR_EXCEP", e.what());
                 found = false;
                 break;
             }
@@ -272,8 +275,9 @@ void setCoreCount(const EntityAssociations& Associations)
                     }
                     catch (const std::exception& e)
                     {
-                        std::cerr << "failed to set the core count property "
-                                  << " ERROR=" << e.what() << "\n";
+                        error(
+                            "failed to set the core count property ERROR={ERR_EXCEP}",
+                            "ERR_EXCEP", e.what());
                     }
                 }
             }

--- a/libpldmresponder/base.cpp
+++ b/libpldmresponder/base.cpp
@@ -13,6 +13,7 @@
 #include <libpldm/file_io.h>
 #include <libpldm/host.h>
 #endif
+#include <phosphor-logging/lg2.hpp>
 
 #include <array>
 #include <cstring>
@@ -20,6 +21,13 @@
 #include <map>
 #include <stdexcept>
 #include <vector>
+
+#ifdef OEM_IBM
+#include "libpldm/file_io.h"
+#include "libpldm/host.h"
+#endif
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -191,8 +199,8 @@ void Handler::processSetEventReceiver(
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(eid, instanceId);
-        std::cerr << "Failed to encode_set_event_receiver_req, rc = "
-                  << std::hex << std::showbase << rc << std::endl;
+        error("Failed to encode_set_event_receiver_req, rc = {RC}", "RC",
+              lg2::hex, rc);
         return;
     }
 
@@ -200,8 +208,7 @@ void Handler::processSetEventReceiver(
         [](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for "
-                         "setEventReceiver command \n";
+            error("Failed to receive response for setEventReceiver command");
             return;
         }
 
@@ -210,9 +217,9 @@ void Handler::processSetEventReceiver(
                                                  &completionCode);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode setEventReceiver command response,"
-                      << " rc=" << rc << "cc=" << (unsigned)completionCode
-                      << "\n";
+            error(
+                "Failed to decode setEventReceiver command response, rc = {RC}, cc = {CC}",
+                "RC", rc, "CC", (unsigned)completionCode);
         }
     };
     rc = handler->registerRequest(
@@ -221,8 +228,7 @@ void Handler::processSetEventReceiver(
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to send the setEventReceiver request"
-                  << "\n";
+        error("Failed to send the setEventReceiver request");
     }
 
     if (oemPlatformHandler)

--- a/libpldmresponder/bios.cpp
+++ b/libpldmresponder/bios.cpp
@@ -4,6 +4,8 @@
 
 #include <time.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <array>
 #include <chrono>
 #include <ctime>
@@ -12,6 +14,8 @@
 #include <string>
 #include <variant>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::utils;
 
@@ -122,9 +126,9 @@ Response Handler::getDateTime(const pldm_msg* request, size_t /*payloadLength*/)
     }
     catch (const sdbusplus::exception_t& e)
     {
-        std::cerr << "Error getting time, PATH=" << bmcTimePath
-                  << " TIME INTERACE=" << timeInterface << "\n";
-
+        error(
+            "Error getting time, PATH={BMC_TIME_PATH} TIME INTERACE={TIME_INTF}",
+            "BMC_TIME_PATH", bmcTimePath, "TIME_INTF", timeInterface);
         return CmdHandler::ccOnlyResponse(request, PLDM_ERROR);
     }
 
@@ -176,10 +180,10 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error getting the time sync property, PATH="
-                  << timeSyncPath << "INTERFACE=" << timeSyncInterface
-                  << "PROPERTY=" << timeSyncProperty << "ERROR=" << e.what()
-                  << "\n";
+        error(
+            "Error getting the time sync property, PATH={TIME_SYNC_PATH} INTERFACE={SYNC_INTERFACE} PROPERTY={SYNC_PROP} ERROR={ERR_EXCEP}",
+            "TIME_SYNC_PATH", timeSyncPath, "SYNC_INTERFACE", timeSyncInterface,
+            "SYNC_PROP", timeSyncProperty, "ERR_EXCEP", e.what());
     }
 
     constexpr auto setTimeInterface = "xyz.openbmc_project.Time.EpochTime";
@@ -206,10 +210,10 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error Setting time,PATH=" << setTimePath
-                  << "TIME INTERFACE=" << setTimeInterface
-                  << "ERROR=" << e.what() << "\n";
-
+        error(
+            "Error Setting time,PATH={SET_TIME_PATH} TIME INTERFACE={TIME_INTERFACE} ERROR={ERR_EXCEP}",
+            "SET_TIME_PATH", setTimePath, "TIME_INTERFACE", setTimeInterface,
+            "ERR_EXCEP", e.what());
         return ccOnlyResponse(request, PLDM_ERROR);
     }
 

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -6,6 +6,7 @@
 #include "bios_table.hpp"
 #include "common/bios_utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/BIOSConfig/Manager/server.hpp>
 
 #include <fstream>
@@ -17,6 +18,8 @@
 
 using namespace pldm::dbus_api;
 using namespace pldm::utils;
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -486,8 +489,8 @@ void BIOSConfig::updateBaseBIOSTableProperty()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to update BaseBIOSTable property, ERROR="
-                  << e.what() << "\n";
+        error("failed to update BaseBIOSTable property, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 }
 
@@ -537,8 +540,8 @@ void BIOSConfig::buildAndStoreAttrTables(const Table& stringTable)
     // bios-settings-manager in sync
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to read BaseBIOSTable property, ERROR=" << e.what()
-                  << "\n";
+        error("Failed to read BaseBIOSTable property, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 
     Table attrTable, attrValueTable;
@@ -563,8 +566,8 @@ void BIOSConfig::buildAndStoreAttrTables(const Table& stringTable)
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Construct Table Entry Error, AttributeName = "
-                      << attr->name << std::endl;
+            error("Construct Table Entry Error, AttributeName = {ATTR_NAME}",
+                  "ATTR_NAME", attr->name);
         }
     }
 
@@ -646,16 +649,16 @@ void BIOSConfig::load(const fs::path& filePath, ParseHandler handler)
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr
-                        << "Failed to parse JSON config file(entry handler) : "
-                        << filePath.c_str() << ", " << e.what() << std::endl;
+                    error(
+                        "Failed to parse JSON config file(entry handler) : {FILE_PATH}, {ERR_EXCEP}",
+                        "FILE_PATH", filePath.c_str(), "ERR_EXCEP", e.what());
                 }
             }
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to parse JSON config file : "
-                      << filePath.c_str() << std::endl;
+            error("Failed to parse JSON config file : {FILE_PATH}", "FILE_PATH",
+                  filePath.c_str());
         }
     }
 }
@@ -730,10 +733,12 @@ void BIOSConfig::traceBIOSUpdate(
 
             for (uint8_t handle : handles)
             {
-                std::cout << "BIOS:" << attrName << ", updated to value: "
-                          << displayStringHandle(attrHandle, handle, attrTable,
-                                                 stringTable)
-                          << ", by BMC: " << std::boolalpha << isBMC << "\n";
+                info(
+                    "BIOS:{ATTR_NAME}, updated to value: {VAL}, by BMC: {CHK_BMC}",
+                    "ATTR_NAME", attrName, "VAL",
+                    displayStringHandle(attrHandle, handle, attrTable,
+                                        stringTable),
+                    "CHK_BMC", isBMC ? "true" : "false");
             }
             break;
         }
@@ -742,8 +747,10 @@ void BIOSConfig::traceBIOSUpdate(
         {
             auto value =
                 table::attribute_value::decodeIntegerEntry(attrValueEntry);
-            std::cout << "BIOS:" << attrName << ", updated to value: " << value
-                      << ", by BMC:" << std::boolalpha << isBMC << std::endl;
+            info(
+                "BIOS: {ATTR_NAME}, updated to value: {NEW_VAL}, by BMC: {BMC_CHK}",
+                "ATTR_NAME", attrName, "NEW_VAL", value, "BMC_CHK",
+                isBMC ? "true" : "false");
             break;
         }
         case PLDM_BIOS_STRING:
@@ -751,8 +758,10 @@ void BIOSConfig::traceBIOSUpdate(
         {
             auto value =
                 table::attribute_value::decodeStringEntry(attrValueEntry);
-            std::cout << "BIOS:" << attrName << " updated to value: " << value
-                      << ", by BMC:" << std::boolalpha << isBMC << std::endl;
+            info(
+                "BIOS:{ATTR_NAME} updated to value: {NEW_VAL}, by BMC:{BMC_CHK}",
+                "ATTR_NAME", attrName, "NEW_VAL", value, "BMC_CHK",
+                isBMC ? "true" : "false");
             break;
         }
         default:
@@ -783,8 +792,8 @@ int BIOSConfig::checkAttrValueToUpdate(
             }
             if (value[0] >= pvHdls.size())
             {
-                std::cerr << "Enum: Illgeal index, Index = " << (int)value[0]
-                          << std::endl;
+                error("Enum: Illgeal index, Index = {ATTR_VAL}", "ATTR_VAL",
+                      (int)value[0]);
                 return PLDM_ERROR_INVALID_DATA;
             }
             return PLDM_SUCCESS;
@@ -799,8 +808,8 @@ int BIOSConfig::checkAttrValueToUpdate(
 
             if (value < lower || value > upper)
             {
-                std::cerr << "Integer: out of bound, value = " << value
-                          << std::endl;
+                error("Integer: out of bound, value = {ATTR_VAL}", "ATTR_VAL",
+                      value);
                 return PLDM_ERROR_INVALID_DATA;
             }
             return PLDM_SUCCESS;
@@ -814,15 +823,16 @@ int BIOSConfig::checkAttrValueToUpdate(
             if (value.size() < stringConf.minLength ||
                 value.size() > stringConf.maxLength)
             {
-                std::cerr << "String: Length error, string = " << value
-                          << " length = " << value.size() << std::endl;
+                error(
+                    "String: Length error, string = {ATTR_VAL} length {ATTR_VAL_LEN}",
+                    "ATTR_VAL", value, "ATTR_VAL_LEN", value.size());
                 return PLDM_ERROR_INVALID_LENGTH;
             }
             return PLDM_SUCCESS;
         }
         default:
-            std::cerr << "ReadOnly or Unspported type, type = " << attrType
-                      << std::endl;
+            error("ReadOnly or Unspported type, type = {ATTR_TYP}", "ATTR_TYP",
+                  attrType);
             return PLDM_ERROR;
     };
 }
@@ -887,7 +897,7 @@ int BIOSConfig::setAttrValue(const void* entry, size_t size, bool isBMC,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Set attribute value error: " << e.what() << std::endl;
+        error("Set attribute value error: {ERR_EXCEP}", "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -908,7 +918,7 @@ void BIOSConfig::removeTables()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Remove the tables error: " << e.what() << std::endl;
+        error("Remove the tables error: {ERR_EXCEP}", "ERR_EXCEP", e.what());
     }
 }
 
@@ -929,7 +939,7 @@ void BIOSConfig::processBiosAttrChangeNotification(
     auto stringTable = getBIOSTable(PLDM_BIOS_STRING_TABLE);
     if (!stringTable.has_value())
     {
-        std::cerr << "BIOS string table unavailable\n";
+        error("BIOS string table unavailable");
         return;
     }
     BIOSStringTable biosStringTable(*stringTable);
@@ -940,23 +950,24 @@ void BIOSConfig::processBiosAttrChangeNotification(
     }
     catch (const std::invalid_argument& e)
     {
-        std::cerr << "Could not find handle for BIOS string, ATTRIBUTE="
-                  << attrName.c_str() << "\n";
+        error("Could not find handle for BIOS string, ATTRIBUTE={ATTR_NAME}",
+              "ATTR_NAME", attrName.c_str());
         return;
     }
 
     auto attrTable = getBIOSTable(PLDM_BIOS_ATTR_TABLE);
     if (!attrTable.has_value())
     {
-        std::cerr << "Attribute table not present\n";
+        error("Attribute table not present");
         return;
     }
     const struct pldm_bios_attr_table_entry* tableEntry =
         table::attribute::findByStringHandle(*attrTable, attrNameHdl);
     if (tableEntry == nullptr)
     {
-        std::cerr << "Attribute not found in attribute table, name= "
-                  << attrName.c_str() << "name handle=" << attrNameHdl << "\n";
+        error(
+            "Attribute not found in attribute table, name= {ATTR_NAME} name handle={ATTR_HNDL}",
+            "ATTR_NAME", attrName.c_str(), "ATTR_HNDL", attrNameHdl);
         return;
     }
 
@@ -967,7 +978,7 @@ void BIOSConfig::processBiosAttrChangeNotification(
 
     if (!attrValueSrcTable.has_value())
     {
-        std::cerr << "Attribute value table not present\n";
+        error("Attribute value table not present");
         return;
     }
 
@@ -976,9 +987,9 @@ void BIOSConfig::processBiosAttrChangeNotification(
         newValue, attrHdl, attrType, newPropVal);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Could not update the attribute value table for attribute "
-                     "handle="
-                  << attrHdl << " and type=" << (uint32_t)attrType << "\n";
+        error(
+            "Could not update the attribute value table for attribute handle={ATTR_HNDL} and type={ATTR_TYP}",
+            "ATTR_HNDL", attrHdl, "ATTR_TYP", (uint32_t)attrType);
         return;
     }
     auto destTable = table::attribute_value::updateTable(
@@ -991,8 +1002,8 @@ void BIOSConfig::processBiosAttrChangeNotification(
     rc = setAttrValue(newValue.data(), newValue.size(), true, false);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "could not setAttrValue on base bios table and dbus, rc = "
-                  << rc << "\n";
+        error("could not setAttrValue on base bios table and dbus, rc = {RC}",
+              "RC", rc);
     }
 }
 
@@ -1036,8 +1047,8 @@ void BIOSConfig::constructPendingAttribute(
 
         if (iter == biosAttributes.end())
         {
-            std::cerr << "Wrong attribute name, attributeName = "
-                      << attributeName << std::endl;
+            error("Wrong attribute name, attributeName = {ATTR_NAME}",
+                  "ATTR_NAME", attributeName);
             continue;
         }
 
@@ -1053,8 +1064,8 @@ void BIOSConfig::constructPendingAttribute(
             type != BIOSConfigManager::AttributeType::String &&
             type != BIOSConfigManager::AttributeType::Integer)
         {
-            std::cerr << "Attribute type not supported, attributeType = "
-                      << attributeType << std::endl;
+            error("Attribute type not supported, attributeType = {ATTR_TYP}",
+                  "ATTR_TYP", attributeType);
             continue;
         }
 

--- a/libpldmresponder/bios_config.hpp
+++ b/libpldmresponder/bios_config.hpp
@@ -8,6 +8,7 @@
 #include "requester/handler.hpp"
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <functional>
 #include <iostream>
@@ -16,6 +17,8 @@
 #include <set>
 #include <string>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -223,8 +226,8 @@ class BIOSConfig
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Constructs Attribute Error, " << e.what()
-                      << std::endl;
+            error("Constructs Attribute Error, {ERR_EXCEP}", "ERR_EXCEP",
+                  e.what());
         }
     }
 

--- a/libpldmresponder/bios_enum_attribute.cpp
+++ b/libpldmresponder/bios_enum_attribute.cpp
@@ -2,9 +2,13 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
 
 using namespace pldm::utils;
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -12,7 +16,6 @@ namespace responder
 {
 namespace bios
 {
-
 BIOSEnumAttribute::BIOSEnumAttribute(const Json& entry,
                                      DBusHandler* const dbusHandler) :
     BIOSAttribute(entry, dbusHandler)
@@ -112,8 +115,8 @@ void BIOSEnumAttribute::buildValMap(const Json& dbusVals)
         }
         else
         {
-            std::cerr << "Unknown D-Bus property type, TYPE="
-                      << dBusMap->propertyType << "\n";
+            error("Unknown D-Bus property type, TYPE={DBUS_PROP_TYP}",
+                  "DBUS_PROP_TYP", dBusMap->propertyType);
             throw std::invalid_argument("Unknown D-BUS property type");
         }
         valMap.emplace(value, possibleValues[pos]);
@@ -220,9 +223,10 @@ void BIOSEnumAttribute::constructEntry(
             }
             catch (const std::invalid_argument& ex)
             {
-                std::cerr << "Enum Value " << currValue
-                          << " is not one of the possible values. Error: "
-                          << ex.what() << " for Attribute " << name << '\n';
+                error(
+                    "Enum Value {ENUM_VAL} is not one of the possible values. Error:{ERR_EXCEP} for Attribute {ATTR_NAME}",
+                    "ENUM_VAL", currValue, "ERR_EXCEP", ex.what(), "ATTR_NAME",
+                    name);
                 currValueIndices[0] = getValueIndex(defaultValue,
                                                     possibleValues);
             }
@@ -248,8 +252,8 @@ int BIOSEnumAttribute::updateAttrVal(Table& newValue, uint16_t attrHdl,
     auto iter = valMap.find(newPropVal);
     if (iter == valMap.end())
     {
-        std::cerr << "Could not find index for new BIOS enum, value="
-                  << std::get<std::string>(newPropVal) << "\n";
+        error("Could not find index for new BIOS enum, value={ENUM_VAL}",
+              "ENUM_VAL", std::get<std::string>(newPropVal));
         return PLDM_ERROR;
     }
     auto currentValue = iter->second;

--- a/libpldmresponder/bios_integer_attribute.cpp
+++ b/libpldmresponder/bios_integer_attribute.cpp
@@ -2,6 +2,10 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 using namespace pldm::utils;
 
 namespace pldm
@@ -10,7 +14,6 @@ namespace responder
 {
 namespace bios
 {
-
 BIOSIntegerAttribute::BIOSIntegerAttribute(const Json& entry,
                                            DBusHandler* const dbusHandler) :
     BIOSAttribute(entry, dbusHandler)
@@ -33,13 +36,12 @@ BIOSIntegerAttribute::BIOSIntegerAttribute(const Json& entry,
     auto rc = pldm_bios_table_attr_entry_integer_info_check(&info, &errmsg);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Wrong filed for integer attribute, ATTRIBUTE_NAME="
-                  << attr.c_str() << " ERRMSG=" << errmsg
-                  << " LOWER_BOUND=" << integerInfo.lowerBound
-                  << " UPPER_BOUND=" << integerInfo.upperBound
-                  << " DEFAULT_VALUE=" << integerInfo.defaultValue
-                  << " SCALAR_INCREMENT=" << integerInfo.scalarIncrement
-                  << "\n";
+        error(
+            "Wrong field for integer attribute, ATTRIBUTE_NAME={ATTR_NAME} ERRMSG= {ERR_MSG} LOWER_BOUND={LOW_BOUND} UPPER_BOUND={UPPER_BOUND} DEFAULT_VALUE={DEF_VAL} SCALAR_INCREMENT={SCALAR_INCREMENT}",
+            "ATTR_NAME", attr.c_str(), "ERR_MSG", errmsg, "LOW_BOUND",
+            integerInfo.lowerBound, "UPPER_BOUND", integerInfo.upperBound,
+            "DEF_VAL", integerInfo.defaultValue, "SCALAR_INCREMENT",
+            integerInfo.scalarIncrement);
         throw std::invalid_argument("Wrong field for integer attribute");
     }
 }
@@ -95,8 +97,8 @@ void BIOSIntegerAttribute::setAttrValueOnDbus(
                                             static_cast<double>(currentValue));
     }
 
-    std::cerr << "Unsupported property type on dbus: " << dBusMap->propertyType
-              << std::endl;
+    error("Unsupported property type on dbus: {DBUS_PROP_TYP}", "DBUS_PROP_TYP",
+          dBusMap->propertyType);
     throw std::invalid_argument("dbus type error");
 }
 
@@ -137,9 +139,10 @@ void BIOSIntegerAttribute::constructEntry(
     if (currentValue < (int64_t)integerInfo.lowerBound ||
         currentValue > (int64_t)integerInfo.upperBound)
     {
-        std::cerr << "Setting to default value " << integerInfo.defaultValue
-                  << " For Attribute " << name
-                  << " Received value: " << currentValue << std::endl;
+        error(
+            "Setting to default value {DEF_VAL} For Attribute {ATTR_NAME} Received value: {CURR_VAL}",
+            "DEF_VAL", integerInfo.defaultValue, "ATTR_NAME", name, "CURR_VAL",
+            currentValue);
         currentValue = integerInfo.defaultValue;
     }
 
@@ -184,8 +187,8 @@ uint64_t BIOSIntegerAttribute::getAttrValue(const PropertyValue& propertyValue)
     }
     else
     {
-        std::cerr << "Unsupported property type for getAttrValue: "
-                  << dBusMap->propertyType << std::endl;
+        error("Unsupported property type for getAttrValue: {DBUS_PROP_TYP}",
+              "DBUS_PROP_TYP", dBusMap->propertyType);
         throw std::invalid_argument("dbus type error");
     }
     return value;
@@ -208,8 +211,8 @@ uint64_t BIOSIntegerAttribute::getAttrValue()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Get Integer Attribute Value Error: AttributeName = "
-                  << name << std::endl;
+        error("Get Integer Attribute Value Error: AttributeName = {ATTR_NAME}",
+              "ATTR_NAME", name);
         return integerInfo.defaultValue;
     }
 }

--- a/libpldmresponder/bios_string_attribute.cpp
+++ b/libpldmresponder/bios_string_attribute.cpp
@@ -2,11 +2,15 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
 #include <tuple>
 #include <variant>
 
 using namespace pldm::utils;
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -14,7 +18,6 @@ namespace responder
 {
 namespace bios
 {
-
 BIOSStringAttribute::BIOSStringAttribute(const Json& entry,
                                          DBusHandler* const dbusHandler) :
     BIOSAttribute(entry, dbusHandler)
@@ -23,8 +26,9 @@ BIOSStringAttribute::BIOSStringAttribute(const Json& entry,
     auto iter = strTypeMap.find(strTypeTmp);
     if (iter == strTypeMap.end())
     {
-        std::cerr << "Wrong string type, STRING_TYPE=" << strTypeTmp
-                  << " ATTRIBUTE_NAME=" << name << "\n";
+        error(
+            "Wrong string type, STRING_TYPE={STRING_TYPE} ATTRIBUTE_NAME={ATTR_NAME}",
+            "STRING_TYPE", strTypeTmp, "ATTR_NAME", name);
         throw std::invalid_argument("Wrong string type");
     }
     stringInfo.stringType = static_cast<uint8_t>(iter->second);
@@ -48,12 +52,11 @@ BIOSStringAttribute::BIOSStringAttribute(const Json& entry,
     auto rc = pldm_bios_table_attr_entry_string_info_check(&info, &errmsg);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Wrong field for string attribute, ATTRIBUTE_NAME=" << name
-                  << " ERRMSG=" << errmsg
-                  << " MINIMUM_STRING_LENGTH=" << stringInfo.minLength
-                  << " MAXIMUM_STRING_LENGTH=" << stringInfo.maxLength
-                  << " DEFAULT_STRING_LENGTH=" << stringInfo.defLength
-                  << " DEFAULT_STRING=" << stringInfo.defString << "\n";
+        error(
+            "Wrong field for string attribute, ATTRIBUTE_NAME={ATTR_NAME} ERRMSG={ERR_MSG} MINIMUM_STRING_LENGTH={MIN_LEN} MAXIMUM_STRING_LENGTH={MAX_LEN} DEFAULT_STRING_LENGTH={DEF_LEN} DEFAULT_STRING={DEF_STR}",
+            "ATTR_NAME", name, "ERR_MSG", errmsg, "MIN_LEN",
+            stringInfo.minLength, "MAX_LEN", stringInfo.maxLength, "DEF_LEN",
+            stringInfo.defLength, "DEF_STR", stringInfo.defString);
         throw std::invalid_argument("Wrong field for string attribute");
     }
 }
@@ -86,8 +89,8 @@ std::string BIOSStringAttribute::getAttrValue()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Get String Attribute Value Error: AttributeName = "
-                  << name << std::endl;
+        error("Get String Attribute Value Error: AttributeName = {ATTR_NAME}",
+              "ATTR_NAME", name);
         return stringInfo.defString;
     }
 }
@@ -129,8 +132,9 @@ void BIOSStringAttribute::constructEntry(
     if (currStr.size() < stringInfo.minLength ||
         currStr.size() > stringInfo.maxLength)
     {
-        std::cerr << "Setting to default. Received string size "
-                  << currStr.size() << " For Attribute " << name << std::endl;
+        error(
+            "Setting to default. Received string size {STR_SIZE} For Attribute {ATTR_NAME}",
+            "STR_SIZE", currStr.size(), "ATTR_NAME", name);
         currStr = stringInfo.defString;
     }
 
@@ -150,8 +154,8 @@ int BIOSStringAttribute::updateAttrVal(Table& newValue, uint16_t attrHdl,
     }
     catch (const std::bad_variant_access& e)
     {
-        std::cerr << "invalid value passed for the property, error: "
-                  << e.what() << "\n";
+        error("invalid value passed for the property, error: {ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -13,10 +13,13 @@
 #include <libpldm/utils.h>
 #include <systemd/sd-journal.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
 
 #include <iostream>
 #include <set>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -162,8 +165,8 @@ void FruImpl::buildFRUTable()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Look up of inventory objects failed and PLDM FRU table "
-                     "creation failed\n";
+        info(
+            "Look up of inventory objects failed and PLDM FRU table creation failed");
         return;
     }
 
@@ -209,9 +212,9 @@ void FruImpl::buildFRUTable()
                 }
                 catch (const std::exception& e)
                 {
-                    std::cout << "Config JSONs missing for the item "
-                                 "interface type, interface = "
-                              << interface.first << "\n";
+                    info(
+                        "Config JSONs missing for the item interface type, interface = {INTF}",
+                        "INTF", interface.first);
                     break;
                 }
             }
@@ -250,9 +253,8 @@ std::string FruImpl::populatefwVersion()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call "
-                     "Asociation, ERROR= "
-                  << e.what() << "\n";
+        error("failed to make a d-bus call Asociation, ERROR= {ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return {};
     }
     return currentBmcVersion;
@@ -402,11 +404,12 @@ void FruImpl::removeIndividualFRU(const std::string& fruObjPath)
 
     objectPathToRSIMap.erase(fruObjPath);
     objToEntityNode.erase(fruObjPath); // sm00
-    std::cerr << "Removing Individual FRU "
-              << "[ " << fruObjPath << " ] "
-              << "with entityid [ " << removeEntity.entity_type << ","
-              << removeEntity.entity_instance_num << ","
-              << removeEntity.entity_container_id << " ]\n";
+    error(
+        "Removing Individual FRU [ {FRU_OBJ_PATH} ] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ]",
+        "FRU_OBJ_PATH", fruObjPath, "ENTITY_TYP",
+        static_cast<unsigned>(removeEntity.entity_type), "ENTITY_NUM",
+        static_cast<unsigned>(removeEntity.entity_instance_num), "ENTITY_ID",
+        static_cast<unsigned>(removeEntity.entity_container_id));
     associatedEntityMap.erase(fruObjPath); // sm00
 
     deleteFruRecord(rsi);
@@ -557,14 +560,15 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
             PLDM_ENTITY_ASSOCIAION_PHYSICAL, false, true, last_container_id);
         pldm_entity node_entity = pldm_entity_extract(node);
         objToEntityNode[fruObjectPath] = node_entity;
-        std::cerr << " Building Individual FRU "
-                  << "[ " << fruObjectPath << " ] "
-                  << "with entityid [ " << node_entity.entity_type << ","
-                  << node_entity.entity_instance_num << ","
-                  << node_entity.entity_container_id << " ] "
-                  << "Parent :[ " << parent.entity_type << ","
-                  << parent.entity_instance_num << ","
-                  << parent.entity_container_id << " ]\n";
+        error(
+            "Building Individual FRU [FRU_OBJ_PATH] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ] Parent :[ {P_ENTITY_TYP}, {P_ENTITY_NUM}, {P_ENTITY_ID} ]",
+            "FRU_OBJ_PATH", fruObjectPath, "ENTITY_TYP",
+            static_cast<unsigned>(node_entity.entity_type), "ENTITY_NUM",
+            static_cast<unsigned>(node_entity.entity_instance_num), "ENTITY_ID",
+            static_cast<unsigned>(node_entity.entity_container_id),
+            "P_ENTITY_TYP", static_cast<unsigned>(parent.entity_type),
+            "P_ENTITY_NUM", static_cast<unsigned>(parent.entity_instance_num),
+            "P_ENTITY_ID", static_cast<unsigned>(parent.entity_container_id));
         auto recordInfos = parser.getRecordInfo(fruInterface);
 
         // sm00
@@ -598,9 +602,9 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
     }
     catch (const std::exception& e)
     {
-        std::cout << "Config JSONs missing for the item "
-                  << " in concurrent add path "
-                  << "interface type, interface = " << fruInterface << "\n";
+        info(
+            "Config JSONs missing for the item in concurrent add path interface type, interface = {FRU_INTF}",
+            "FRU_INTF", fruInterface);
     }
 #ifdef OEM_IBM
     auto lastLocalRecord = pldm_pdr_find_last_local_record(pdrRepo);
@@ -713,22 +717,24 @@ void FruImpl::reGenerateStatePDR(const std::string& fruObjectPath,
             }
             catch (const InternalFailure& e)
             {
-                std::cerr
-                    << "PDR config directory does not exist or empty, TYPE= "
-                    << (unsigned)pdrType << "PATH= " << dirEntry
-                    << " ERROR=" << e.what() << "\n";
+                error(
+                    "PDR config directory does not exist or empty, TYPE= {PDR_TYP} PATH= {DIR_PATH} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", (unsigned)pdrType, "DIR_PATH",
+                    dirEntry.path().string(), "ERR_EXCEP", e.what());
                 // log an error here
             }
             catch (const Json::exception& e)
             {
-                std::cerr << "Failed parsing PDR JSON file, TYPE= "
-                          << (unsigned)pdrType << " ERROR=" << e.what() << "\n";
+                error(
+                    "Failed parsing PDR JSON file, TYPE= {PDR_TYP} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", (unsigned)pdrType, "ERR_EXCEP", e.what());
                 // log error
             }
             catch (const std::exception& e)
             {
-                std::cerr << "Failed parsing PDR JSON file, TYPE= "
-                          << (unsigned)pdrType << " ERROR=" << e.what() << "\n";
+                error(
+                    "Failed parsing PDR JSON file, TYPE= {PDR_TYP} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", (unsigned)pdrType, "ERR_EXCEP", e.what());
                 // log appropriate error
             }
         }
@@ -867,8 +873,9 @@ void FruImpl::subscribeFruPresence(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "could not subscribe for concurrent maintenance of fru: "
-                  << fruInterface << " error " << e.what() << "\n";
+        error(
+            "could not subscribe for concurrent maintenance of fru: {FRU_INTF} error {ERR_EXCEP}",
+            "FRU_INTF", fruInterface, "ERR_EXCEP", e.what());
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.CMsubscribeFailure",
             pldm::PelSeverity::ERROR);
@@ -968,9 +975,8 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to encode_pldm_pdr_repository_chg_event_data, rc = "
-            << rc << std::endl;
+        error("Failed to encode_pldm_pdr_repository_chg_event_data, rc = {RC}",
+              "RC", static_cast<int>(rc));
         return;
     }
     auto instanceId = requester.getInstanceId(mctp_eid);
@@ -985,17 +991,16 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_platform_event_message_req, rc = " << rc
-                  << std::endl;
+        error("Failed to encode_platform_event_message_req, rc = {RC}", "RC",
+              static_cast<unsigned>(rc));
         return;
     }
     auto platformEventMessageResponseHandler =
         [](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the PDR repository "
-                         "changed event"
-                      << "\n";
+            error(
+                "Failed to receive response for the PDR repository changed event");
             return;
         }
         uint8_t completionCode{};
@@ -1005,10 +1010,10 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: rc={RC}, cc={CC}",
+                "RC", static_cast<int>(rc), "CC",
+                static_cast<unsigned>(completionCode));
         }
     };
     rc = handler->registerRequest(
@@ -1016,9 +1021,8 @@ void FruImpl::sendPDRRepositoryChgEventbyPDRHandles(
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send the PDR repository changed event request "
-                     "after CM"
-                  << "\n";
+        error(
+            "Failed to send the PDR repository changed event request after CM");
     }
 }
 
@@ -1057,10 +1061,10 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 auto statesSize = set.value("size", 0);
                 if (!statesSize)
                 {
-                    std::cerr << "Malformed PDR JSON return "
-                                 "pdrEntry;- no state set "
-                                 "info, TYPE="
-                              << PLDM_STATE_EFFECTER_PDR << "\n";
+                    error(
+                        "Malformed PDR JSON return pdrEntry;- no state set info, TYPE={INFO_TYP}",
+                        "INFO_TYP",
+                        static_cast<unsigned>(PLDM_STATE_EFFECTER_PDR));
                     throw InternalFailure();
                 }
                 pdrSize += sizeof(state_effecter_possible_states) -
@@ -1076,7 +1080,7 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
             if (!pdr)
             {
-                std::cerr << "Failed to get state effecter PDR.\n";
+                error("Failed to get state effecter PDR.");
                 continue;
             }
             pdr->hdr.record_handle = 0;
@@ -1184,9 +1188,9 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr
-                        << "D-Bus object path does not exist, effecter ID: "
-                        << pdr->effecter_id << "\n";
+                    error(
+                        "D-Bus object path does not exist, effecter ID: {EFFECTER_ID}",
+                        "EFFECTER_ID", static_cast<uint16_t>(pdr->effecter_id));
                 }
                 dbusMappings.emplace_back(std::move(dbusMapping));
                 dbusValMaps.emplace_back(std::move(dbusIdToValMap));
@@ -1224,10 +1228,10 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 auto statesSize = set.value("size", 0);
                 if (!statesSize)
                 {
-                    std::cerr << "Malformed PDR JSON return "
-                                 "pdrEntry;- no state set "
-                                 "info, TYPE="
-                              << PLDM_STATE_SENSOR_PDR << "\n";
+                    error(
+                        "Malformed PDR JSON return pdrEntry;- no state set info, TYPE={INFO_TYP}",
+                        "INFO_TYP",
+                        static_cast<unsigned>(PLDM_STATE_SENSOR_PDR));
                     throw InternalFailure();
                 }
                 pdrSize += sizeof(state_sensor_possible_states) -
@@ -1243,7 +1247,7 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
             if (!pdr)
             {
-                std::cerr << "Failed to get state sensor PDR.\n";
+                error("Failed to get state sensor PDR.");
                 continue;
             }
             pdr->hdr.record_handle = 0;
@@ -1363,8 +1367,9 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr << "D-Bus object path does not exist, sensor ID: "
-                              << pdr->sensor_id << "\n";
+                    error(
+                        "D-Bus object path does not exist, sensor ID: {SENSOR_ID}",
+                        "SENSOR_ID", static_cast<uint16_t>(pdr->sensor_id));
                 }
                 dbusMappings.emplace_back(std::move(dbusMapping));
                 dbusValMaps.emplace_back(std::move(dbusIdToValMap));

--- a/libpldmresponder/fru_parser.cpp
+++ b/libpldmresponder/fru_parser.cpp
@@ -1,23 +1,23 @@
 #include "fru_parser.hpp"
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 
+PHOSPHOR_LOG2_USING;
+
 using namespace pldm::responder::dbus;
 
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace fru_parser
 {
-
 using Json = nlohmann::json;
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
@@ -50,8 +50,9 @@ void FruParser::setupDefaultDBusLookup(const fs::path& masterJsonPath)
     auto data = Json::parse(jsonFile, nullptr, false);
     if (data.is_discarded())
     {
-        std::cerr << "Parsing FRU Dbus Lookup Map config file failed, FILE="
-                  << masterJsonPath;
+        error(
+            "Parsing FRU Dbus Lookup Map config file failed, FILE={JSON_PATH}",
+            "JSON_PATH", masterJsonPath.c_str());
         std::abort();
     }
     std::map<Interface, EntityType> defIntfToEntityType;
@@ -66,7 +67,7 @@ void FruParser::setupDefaultDBusLookup(const fs::path& masterJsonPath)
         }
         catch (const std::exception& e)
         {
-            std::cerr << "FRU DBus lookup map format error\n";
+            error("FRU DBus lookup map format error");
             throw InternalFailure();
         }
     }
@@ -118,7 +119,8 @@ void FruParser::setupFruRecordMap(const std::string& dirPath)
         auto data = Json::parse(jsonFile, nullptr, false);
         if (data.is_discarded())
         {
-            std::cerr << "Parsing FRU config file failed, FILE=" << file.path();
+            error("Parsing FRU config file failed, FILE={FILE}", "FILE",
+                  file.path().c_str());
             throw InternalFailure();
         }
 

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -1,5 +1,6 @@
 libpldmresponder_deps = [
   phosphor_dbus_interfaces,
+  phosphor_logging_dep,
   nlohmann_json,
   sdbusplus,
   sdeventplus,

--- a/libpldmresponder/pdr_numeric_effecter.hpp
+++ b/libpldmresponder/pdr_numeric_effecter.hpp
@@ -4,15 +4,16 @@
 
 #include "libpldmresponder/pdr_utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace pdr_numeric_effecter
 {
-
 using Json = nlohmann::json;
 
 static const Json empty{};
@@ -41,7 +42,7 @@ void generateNumericEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
             reinterpret_cast<pldm_numeric_effecter_value_pdr*>(entry.data());
         if (!pdr)
         {
-            std::cerr << "Failed to get numeric effecter PDR.\n";
+            error("Failed to get numeric effecter PDR.");
             continue;
         }
         pdr->hdr.record_handle = 0;
@@ -218,9 +219,10 @@ void generateNumericEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "D-Bus object path " << objectPath
-                      << " does not exist, numeric effecter ID: "
-                      << pdr->effecter_id << " error : " << e.what() << "\n";
+            error(
+                "D-Bus object path {OBJ_PATH} does not exist, numeric effecter ID: {EFFECTER_ID} error : {ERR_EXCEP}",
+                "OBJ_PATH", objectPath.c_str(), "EFFECTER_ID",
+                static_cast<unsigned>(pdr->effecter_id), "ERR_EXCEP", e.what());
         }
         dbusMappings.emplace_back(std::move(dbusMapping));
 

--- a/libpldmresponder/pdr_state_effecter.hpp
+++ b/libpldmresponder/pdr_state_effecter.hpp
@@ -5,15 +5,16 @@
 
 #include <libpldm/platform.h>
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace pdr_state_effecter
 {
-
 using Json = nlohmann::json;
 
 static const Json empty{};
@@ -42,10 +43,9 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
             auto statesSize = set.value("size", 0);
             if (!statesSize)
             {
-                std::cerr << "Malformed PDR JSON return "
-                             "pdrEntry;- no state set "
-                             "info, TYPE="
-                          << PLDM_STATE_EFFECTER_PDR << "\n";
+                error(
+                    "Malformed PDR JSON return pdrEntry;- no state set info, TYPE={PDR_TYP}",
+                    "PDR_TYP", static_cast<unsigned>(PLDM_STATE_EFFECTER_PDR));
                 throw InternalFailure();
             }
             pdrSize += sizeof(state_effecter_possible_states) -
@@ -60,7 +60,7 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
             reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
         if (!pdr)
         {
-            std::cerr << "Failed to get state effecter PDR.\n";
+            error("Failed to get state effecter PDR.");
             continue;
         }
         pdr->hdr.record_handle = 0;
@@ -159,10 +159,11 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
             }
             catch (const std::exception& e)
             {
-                std::cerr << "D-Bus object " << objectPath
-                          << " does not exist, state effecter ID: "
-                          << pdr->effecter_id << " error : " << e.what()
-                          << "\n";
+                error(
+                    "D-Bus object path {OBJ_PATH} does not exist, numeric effecter ID: {EFFECTER_ID} error : {ERR_EXCEP}",
+                    "OBJ_PATH", objectPath.c_str(), "EFFECTER_ID",
+                    static_cast<unsigned>(pdr->effecter_id), "ERR_EXCEP",
+                    e.what());
             }
 
             dbusMappings.emplace_back(std::move(dbusMapping));

--- a/libpldmresponder/pdr_utils.cpp
+++ b/libpldmresponder/pdr_utils.cpp
@@ -5,20 +5,21 @@
 
 #include <libpldm/platform.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <bitset>
 #include <climits>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::pdr;
 
 namespace pldm
 {
-
 namespace responder
 {
-
 namespace pdr_utils
 {
-
 pldm_pdr* Repo::getPdr() const
 {
     return repo;
@@ -83,10 +84,9 @@ StatestoDbusVal populateMapping(const std::string& type, const Json& dBusValues,
     StatestoDbusVal valueMap;
     if (dBusValues.size() != pv.size())
     {
-        std::cerr
-            << "dBusValues size is not equal to pv size, dBusValues Size: "
-            << dBusValues.size() << ", pv Size: " << pv.size() << "\n";
-
+        error(
+            "dBusValues size is not equal to pv size, dBusValues Size: {DBUS_VAL_SIZE}, pv Size: {PV_SIZE}",
+            "DBUS_VAL_SIZE", dBusValues.size(), "PV_SIZE", pv.size());
         return {};
     }
 
@@ -134,8 +134,8 @@ StatestoDbusVal populateMapping(const std::string& type, const Json& dBusValues,
         }
         else
         {
-            std::cerr << "Unknown D-Bus property type, TYPE=" << type.c_str()
-                      << "\n";
+            error("Unknown D-Bus property type, TYPE={TYP}", "TYP",
+                  type.c_str());
             return {};
         }
 
@@ -277,8 +277,8 @@ std::vector<uint8_t> fetchBitMap(const std::vector<std::vector<uint8_t>>& pdrs)
                 tempStream << std::setfill('0') << std::setw(2) << std::hex
                            << byte << " ";
             }
-            std::cout << "Panel:BitMap received: " << tempStream.str()
-                      << std::endl;
+            error("Panel:BitMap received: {RECV_STREAM}", "RECV_STREAM",
+                  tempStream.str());
             if (compEffCount)
             {
                 statesPtr += sizeof(state_effecter_possible_states) +

--- a/libpldmresponder/pdr_utils.hpp
+++ b/libpldmresponder/pdr_utils.hpp
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <filesystem>
@@ -15,6 +16,8 @@
 #include <functional>
 #include <iostream>
 #include <string>
+
+PHOSPHOR_LOG2_USING;
 
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
@@ -98,7 +101,7 @@ inline Json readJson(const std::string& path)
     std::ifstream jsonFile(path);
     if (!jsonFile.is_open())
     {
-        std::cerr << "Error opening PDR JSON file, PATH=" << path << "\n";
+        error("Error opening PDR JSON file, PATH={PDR_JSON}", "PDR_JSON", path);
         return {};
     }
 

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -20,9 +20,13 @@
 #include <libpldm/entity.h>
 #include <libpldm/state_set.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 using namespace pldm::utils;
 using namespace pldm::responder::pdr;
 using namespace pldm::responder::pdr_utils;
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -69,7 +73,7 @@ void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
 {
     for (const auto& directory : dir)
     {
-        std::cerr << "checking if : " << directory << "exists" << std::endl;
+        error("checking if : {DIR} exists", "DIR", directory.c_str());
         if (!fs::exists(directory))
         {
             return;
@@ -140,23 +144,25 @@ void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
             }
             catch (const InternalFailure& e)
             {
-                std::cerr
-                    << "PDR config directory does not exist or empty, TYPE= "
-                    << pdrType << "PATH= " << dirEntry << " ERROR=" << e.what()
-                    << "\n";
+                error(
+                    "PDR config directory does not exist or empty, TYPE= {PDR_TYP} PATH= {DIR_PATH} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", pdrType, "DIR_PATH", dirEntry.path().string(),
+                    "ERR_EXCEP", e.what());
             }
             catch (const Json::exception& e)
             {
-                std::cerr << "Failed parsing PDR JSON file, TYPE= " << pdrType
-                          << " ERROR=" << e.what() << "\n";
+                error(
+                    "Failed parsing PDR JSON file, TYPE= {PDR_TYP} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", pdrType, "ERR_EXCEP", e.what());
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.Generate.PDRJsonFileParseFail",
                     pldm::PelSeverity::ERROR);
             }
             catch (const std::exception& e)
             {
-                std::cerr << "Failed parsing PDR JSON file, TYPE= " << pdrType
-                          << " ERROR=" << e.what() << "\n";
+                error(
+                    "Failed parsing PDR JSON file, TYPE= {PDR_TYP} ERROR={ERR_EXCEP}",
+                    "PDR_TYP", pdrType, "ERR_EXCEP", e.what());
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.Generate.PDRJsonFileParseFail",
                     pldm::PelSeverity::ERROR);
@@ -317,8 +323,8 @@ Response Handler::getPDR(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error accessing PDR, HANDLE=" << recordHandle
-                  << " ERROR=" << e.what() << "\n";
+        error("Error accessing PDR, HANDLE={REC_HNDL} ERROR={ERR_EXCEP}",
+              "REC_HNDL", recordHandle, "ERR_EXCEP", e.what());
         return CmdHandler::ccOnlyResponse(request, PLDM_ERROR);
     }
     return response;
@@ -560,8 +566,7 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                                        uint8_t /*formatVersion*/, uint8_t tid,
                                        size_t eventDataOffset)
 {
-    std::cerr << "Got a repo change event from TID: " << (unsigned)tid
-              << std::endl;
+    error("Got a repo change event from TID: {TID}", "TID", (unsigned)tid);
     uint8_t eventDataFormat{};
     uint8_t eventDataOperation{};
     uint8_t numberOfChangeRecords{};
@@ -604,8 +609,8 @@ int Handler::pldmPDRRepositoryChgEvent(const pldm_msg* request,
                 return rc;
             }
 
-            std::cout << "pldmPDRRepositoryChgEvent eventDataOperation : "
-                      << (unsigned)eventDataOperation << std::endl;
+            error("pldmPDRRepositoryChgEvent eventDataOperation : {EVENT_OP}",
+                  "EVENT_OP", (unsigned)eventDataOperation);
 
             if (eventDataOperation == PLDM_RECORDS_ADDED ||
                 eventDataOperation == PLDM_RECORDS_DELETED)
@@ -692,7 +697,8 @@ int Handler::getPDRRecordHandles(const ChangeEntry* changeEntryData,
     }
     for (const auto& i : pdrRecordHandles)
     {
-        std::cerr << "Record handles sent down to BMC: " << i << std::endl;
+        error("Record handles sent down to BMC: {PDR_REC_HNDL}", "PDR_REC_HNDL",
+              static_cast<unsigned>(i));
     }
     return PLDM_SUCCESS;
 }
@@ -871,7 +877,7 @@ bool isOemNumericEffecter(Handler& handler, uint16_t effecterId,
 
     if (numericEffecterPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return false;
     }
 
@@ -929,7 +935,7 @@ bool isOemStateSensor(Handler& handler, uint16_t sensorId,
     getRepoByType(handler.getRepo(), stateSensorPDRs, PLDM_STATE_SENSOR_PDR);
     if (stateSensorPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return false;
     }
 
@@ -956,10 +962,10 @@ bool isOemStateSensor(Handler& handler, uint16_t sensorId,
 
         if (sensorRearmCount > tmpCompSensorCnt)
         {
-            std::cerr << "The requester sent wrong sensorRearm"
-                      << " count for the sensor, SENSOR_ID=" << sensorId
-                      << "SENSOR_REARM_COUNT=" << (uint16_t)sensorRearmCount
-                      << "\n";
+            error(
+                "The requester sent wrong sensorRearm count for the sensor, SENSOR_ID={SENSOR_ID} SENSOR_REARM_COUNT={SENSOR_REARM_COUNT}",
+                "SENSOR_ID", sensorId, "SENSOR_REARM_COUNT",
+                (uint16_t)sensorRearmCount);
             break;
         }
 
@@ -996,7 +1002,7 @@ bool isOemStateEffecter(Handler& handler, uint16_t effecterId,
                   PLDM_STATE_EFFECTER_PDR);
     if (stateEffecterPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return false;
     }
 
@@ -1022,9 +1028,10 @@ bool isOemStateEffecter(Handler& handler, uint16_t effecterId,
 
         if (compEffecterCnt > pdr->composite_effecter_count)
         {
-            std::cerr << "The requester sent wrong composite effecter"
-                      << " count for the effecter, EFFECTER_ID=" << effecterId
-                      << "COMP_EFF_CNT=" << (uint16_t)compEffecterCnt << "\n";
+            error(
+                "The requester sent wrong composite effecter count for the effecter, EFFECTER_ID={EFFECTER_ID} COMP_EFF_CNT={COMP_EFF_CNT}",
+                "EFFECTER_ID", effecterId, "COMP_EFF_CNT",
+                (uint16_t)compEffecterCnt);
             return false;
         }
 

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -15,7 +15,11 @@
 #include <libpldm/states.h>
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <map>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -23,7 +27,6 @@ namespace responder
 {
 namespace platform
 {
-
 using generatePDR = std::function<void(
     const pldm::utils::DBusHandler& dBusIntf, const pldm::utils::Json& json,
     pdr_utils::RepoInterface& repo,
@@ -331,7 +334,7 @@ class Handler : public CmdHandler
         getRepoByType(pdrRepo, stateEffecterPDRs, PLDM_STATE_EFFECTER_PDR);
         if (stateEffecterPDRs.empty())
         {
-            std::cerr << "Failed to get record by PDR type\n";
+            error("Failed to get record by PDR type");
             return PLDM_PLATFORM_INVALID_EFFECTER_ID;
         }
 
@@ -352,11 +355,10 @@ class Handler : public CmdHandler
                 pdr->possible_states);
             if (compEffecterCnt > pdr->composite_effecter_count)
             {
-                std::cerr << "The requester sent wrong composite effecter"
-                          << " count for the effecter, EFFECTER_ID="
-                          << (unsigned)effecterId
-                          << "COMP_EFF_CNT=" << (unsigned)compEffecterCnt
-                          << "\n";
+                error(
+                    "The requester sent wrong composite effecter count for the effecter, EFFECTER_ID={EFFECTER_ID} COMP_EFF_CNT={COMP_EFF_CNT}",
+                    "EFFECTER_ID", (unsigned)effecterId, "COMP_EFF_CNT",
+                    (unsigned)compEffecterCnt);
                 return PLDM_ERROR_INVALID_DATA;
             }
             break;
@@ -384,13 +386,12 @@ class Handler : public CmdHandler
                 if (states->possible_states_size < bitfieldIndex ||
                     !(states->states[bitfieldIndex].byte & (1 << bit)))
                 {
-                    std::cerr
-                        << "Invalid state set value, EFFECTER_ID="
-                        << (unsigned)effecterId << " VALUE="
-                        << (unsigned)stateField[currState].effecter_state
-                        << " COMPOSITE_EFFECTER_ID=" << (unsigned)currState
-                        << " DBUS_PATH=" << dbusMappings[currState].objectPath
-                        << "\n";
+                    error(
+                        "Invalid state set value, EFFECTER_ID={EFFECTER_ID} VALUE={VAL} COMPOSITE_EFFECTER_ID={COMP_EFF_ID} DBUS_PATH={DBUS_OBJ_PATH}",
+                        "EFFECTER_ID", (unsigned)effecterId, "VAL",
+                        (unsigned)stateField[currState].effecter_state,
+                        "COMP_EFF_ID", (unsigned)currState, "DBUS_OBJ_PATH",
+                        dbusMappings[currState].objectPath.c_str());
                     rc = PLDM_PLATFORM_SET_EFFECTER_UNSUPPORTED_SENSORSTATE;
                     break;
                 }
@@ -409,12 +410,12 @@ class Handler : public CmdHandler
                     }
                     catch (const std::exception& e)
                     {
-                        std::cerr
-                            << "Error setting property, ERROR=" << e.what()
-                            << " PROPERTY=" << dbusMapping.propertyName
-                            << " INTERFACE="
-                            << dbusMapping.interface << " PATH="
-                            << dbusMapping.objectPath << "\n";
+                        error(
+                            "Error setting property, ERROR={ERR_EXCEP} PROPERTY={DBUS_PROP_NAME} INTERFACE={INTF} PATH={DBUS_OBJ_PATH}",
+                            "ERR_EXCEP", e.what(), "DBUS_PROP_NAME",
+                            dbusMapping.propertyName, "INTF",
+                            dbusMapping.interface, "DBUS_OBJ_PATH",
+                            dbusMapping.objectPath.c_str());
                         return PLDM_ERROR;
                     }
                 }
@@ -429,8 +430,9 @@ class Handler : public CmdHandler
         }
         catch (const std::out_of_range& e)
         {
-            std::cerr << "the effecterId does not exist. effecter id: "
-                      << (unsigned)effecterId << e.what() << '\n';
+            error(
+                "the effecterId does not exist. effecter id: {EFFECTER_ID}, {ERR_EXCEP}",
+                "EFFECTER_ID", (unsigned)effecterId, "ERR_EXCEP", e.what());
         }
 
         return rc;

--- a/libpldmresponder/platform_numeric_effecter.hpp
+++ b/libpldmresponder/platform_numeric_effecter.hpp
@@ -10,8 +10,12 @@
 #include <math.h>
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <map>
 #include <optional>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -19,7 +23,6 @@ namespace responder
 {
 namespace platform_numeric_effecter
 {
-
 /** @brief Function to get the effecter value by PDR factor coefficient, etc.
  *  @param[in] pdr - The structure of pldm_numeric_effecter_value_pdr.
  *  @param[in] effecterValue - effecter value.
@@ -220,7 +223,7 @@ std::pair<int, std::optional<pldm::utils::PropertyValue>>
     }
     else
     {
-        std::cerr << "Wrong field effecterDataSize...\n";
+        error("Wrong field effecterDataSize...");
         return {PLDM_ERROR, {}};
     }
 }
@@ -259,7 +262,7 @@ int setNumericEffecterValueHandler(const DBusInterface& dBusIntf,
                                         PLDM_NUMERIC_EFFECTER_PDR);
     if (numericEffecterPDRs.empty())
     {
-        std::cerr << "The Numeric Effecter PDR repo is empty." << std::endl;
+        error("The Numeric Effecter PDR repo is empty.");
         return PLDM_ERROR;
     }
 
@@ -287,7 +290,7 @@ int setNumericEffecterValueHandler(const DBusInterface& dBusIntf,
 
     if (effecterValueLength != effecterValueArrayLength)
     {
-        std::cerr << "effecter data size is incorrect.\n";
+        error("effecter data size is incorrect.");
         return PLDM_ERROR_INVALID_DATA;
     }
 
@@ -312,16 +315,18 @@ int setNumericEffecterValueHandler(const DBusInterface& dBusIntf,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Error setting property, ERROR=" << e.what()
-                      << " PROPERTY=" << dbusMapping.propertyName
-                      << " INTERFACE=" << dbusMapping.interface << " PATH="
-                      << dbusMapping.objectPath << "\n";
+            error(
+                "Error setting property, ERROR={ERR_EXCEP} PROPERTY={DBUS_PROP} INTERFACE={DBUS_INTF}, PATH={DBUS_OBJ_PATH}",
+                "ERR_EXCEP", e.what(), "DBUS_PROP", dbusMapping.propertyName,
+                "DBUS_INTF", dbusMapping.interface, "DBUS_OBJ_PATH",
+                dbusMapping.objectPath);
             return PLDM_ERROR;
         }
     }
     catch (const std::out_of_range& e)
     {
-        std::cerr << "Unknown effecter ID : " << effecterId << e.what() << '\n';
+        error("Unknown effecter ID : {EFFECTER_ID} , {ERR_EXCEP}",
+              "EFFECTER_ID", effecterId, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 

--- a/libpldmresponder/platform_state_effecter.hpp
+++ b/libpldmresponder/platform_state_effecter.hpp
@@ -8,8 +8,12 @@
 #include <libpldm/platform.h>
 #include <libpldm/states.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cstdint>
 #include <map>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -51,7 +55,7 @@ int setStateEffecterStatesHandler(
                   PLDM_STATE_EFFECTER_PDR);
     if (stateEffecterPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return PLDM_PLATFORM_INVALID_EFFECTER_ID;
     }
 
@@ -71,9 +75,9 @@ int setStateEffecterStatesHandler(
             pdr->possible_states);
         if (compEffecterCnt > pdr->composite_effecter_count)
         {
-            std::cerr << "The requester sent wrong composite effecter"
-                      << " count for the effecter, EFFECTER_ID=" << effecterId
-                      << "COMP_EFF_CNT=" << compEffecterCnt << "\n";
+            error(
+                "The requester sent wrong composite effecter count for the effecter, EFFECTER_ID={EFFECTER_ID} COMP_EFF_CNT={COMP_EFF_CNT}",
+                "EFFECTER_ID", effecterId, "COMP_EFF_CNT", compEffecterCnt);
             return PLDM_ERROR_INVALID_DATA;
         }
         break;
@@ -99,12 +103,11 @@ int setStateEffecterStatesHandler(
             if (states->possible_states_size < bitfieldIndex ||
                 !(states->states[bitfieldIndex].byte & (1 << bit)))
             {
-                std::cerr << "Invalid state set value, EFFECTER_ID="
-                          << effecterId
-                          << " VALUE=" << stateField[currState].effecter_state
-                          << " COMPOSITE_EFFECTER_ID=" << currState
-                          << " DBUS_PATH=" << dbusMappings[currState].objectPath
-                          << "\n";
+                error(
+                    "Invalid state set value, EFFECTER_ID={EFFECTER_ID} VALUE={VALUE} COMPOSITE_EFFECTER_ID={COMP_EFFECTER_ID} DBUS_PATH={DBUS_PATH}",
+                    "EFFECTER_ID", effecterId, "VALUE",
+                    stateField[currState].effecter_state, "COMP_EFFECTER_ID",
+                    currState, "DBUS_PATH", dbusMappings[currState].objectPath);
                 rc = PLDM_PLATFORM_SET_EFFECTER_UNSUPPORTED_SENSORSTATE;
                 break;
             }
@@ -122,11 +125,12 @@ int setStateEffecterStatesHandler(
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr
-                        << "Error setting property, ERROR=" << e.what()
-                        << " PROPERTY=" << dbusMapping.propertyName
-                        << " INTERFACE=" << dbusMapping.interface << " PATH="
-                        << dbusMapping.objectPath << "\n";
+                    error(
+                        "Error setting property, ERROR={ERR_EXCEP} PROPERTY={DBUS_PROP} INTERFACE={INTF} PATH={DBUS_OBJ_PATH}",
+                        "ERR_EXCEP", e.what(), "DBUS_PROP",
+                        dbusMapping.propertyName, "DBUS_INTF",
+                        dbusMapping.interface, "DBUS_OBJ_PATH",
+                        dbusMapping.objectPath);
                     return PLDM_ERROR;
                 }
             }
@@ -141,7 +145,8 @@ int setStateEffecterStatesHandler(
     }
     catch (const std::out_of_range& e)
     {
-        std::cerr << "Unknown effecter ID : " << effecterId << e.what() << '\n';
+        error("Unknown effecter ID : {EFFECTER_ID}, {ERR_EXCEP}", "EFFECTER_ID",
+              effecterId, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 

--- a/libpldmresponder/platform_state_sensor.hpp
+++ b/libpldmresponder/platform_state_sensor.hpp
@@ -7,8 +7,12 @@
 #include <libpldm/platform.h>
 #include <libpldm/states.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cstdint>
 #include <map>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -63,9 +67,9 @@ uint8_t getStateSensorEventState(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Get StateSensor EventState from dbus Error, interface : "
-                  << dbusMapping.objectPath.c_str()
-                  << " ,exception : " << e.what() << '\n';
+        error(
+            "Get StateSensor EventState from dbus Error, interface : {INTF} ,exception : {ERR_EXCEP}",
+            "INTF", dbusMapping.objectPath.c_str(), "ERR_EXCEP", e.what());
     }
 
     return PLDM_SENSOR_UNKNOWN;
@@ -105,7 +109,7 @@ int getStateSensorReadingsHandler(
     getRepoByType(handler.getRepo(), stateSensorPDRs, PLDM_STATE_SENSOR_PDR);
     if (stateSensorPDRs.empty())
     {
-        std::cerr << "Failed to get record by PDR type\n";
+        error("Failed to get record by PDR type");
         return PLDM_PLATFORM_INVALID_SENSOR_ID;
     }
 
@@ -125,9 +129,9 @@ int getStateSensorReadingsHandler(
         compSensorCnt = pdr->composite_sensor_count;
         if (sensorRearmCnt > compSensorCnt)
         {
-            std::cerr << "The requester sent wrong sensorRearm"
-                      << " count for the sensor, SENSOR_ID=" << sensorId
-                      << "SENSOR_REARM_COUNT=" << sensorRearmCnt << "\n";
+            error(
+                "The requester sent wrong sensorRearm count for the sensor, SENSOR_ID={SENSOR_ID} SENSOR_REARM_COUNT={SENSOR_REARM_CNT}",
+                "SENSOR_ID", sensorId, "SENSOR_REARM_CNT", sensorRearmCnt);
             return PLDM_PLATFORM_REARM_UNAVAILABLE_IN_PRESENT_STATE;
         }
 
@@ -195,8 +199,9 @@ int getStateSensorReadingsHandler(
     }
     catch (const std::out_of_range& e)
     {
-        std::cerr << "the sensorId does not exist. sensor id: " << sensorId
-                  << e.what() << '\n';
+        error(
+            "the sensorId does not exist. sensor id: {SENSOR_ID}, {ERR_EXCEP}",
+            "SENSOR_ID", sensorId, "ERR_EXCEP", e.what());
         rc = PLDM_ERROR;
     }
 

--- a/libpldmresponder/test/meson.build
+++ b/libpldmresponder/test/meson.build
@@ -37,6 +37,7 @@ foreach t : tests
                          libpldm_dep,
                          libpldmresponder_dep,
                          libpldmutils,
+			 phosphor_logging_dep,
                          gtest,
                          gmock,
                          nlohmann_json,

--- a/meson.build
+++ b/meson.build
@@ -73,6 +73,7 @@ phosphor_dbus_interfaces = dependency('phosphor-dbus-interfaces')
 sdbusplus = dependency('sdbusplus')
 sdeventplus = dependency('sdeventplus')
 stdplus = dependency('stdplus')
+phosphor_logging_dep = dependency('phosphor-logging')
 
 if cpp.has_header('nlohmann/json.hpp')
   nlohmann_json = declare_dependency()
@@ -145,6 +146,7 @@ libpldmutils = library(
   dependencies: [
       libpldm_dep,
       phosphor_dbus_interfaces,
+      phosphor_logging_dep,
       nlohmann_json,
       sdbusplus,
   ],
@@ -179,6 +181,7 @@ deps = [
   libpldmutils,
   nlohmann_json,
   phosphor_dbus_interfaces,
+  phosphor_logging_dep,
   sdbusplus,
   sdeventplus,
   stdplus,

--- a/oem/ibm/host-bmc/host_lamp_test.cpp
+++ b/oem/ibm/host-bmc/host_lamp_test.cpp
@@ -9,13 +9,16 @@
 #include "common/types.hpp"
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
 namespace led
 {
-
 bool HostLampTest::asserted() const
 {
     return sdbusplus::xyz::openbmc_project::Led::server::Group::asserted();
@@ -91,9 +94,9 @@ uint16_t HostLampTest::getEffecterID()
 
     if (stateEffecterPDRs.empty())
     {
-        std::cerr
-            << "Lamp Test: The state set PDR can not be found, entityType = "
-            << entityType << std::endl;
+        error(
+            "Lamp Test: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+            "ENTITY_TYP", entityType);
         return effecterID;
     }
 
@@ -123,8 +126,8 @@ void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
     if (rc != PLDM_SUCCESS)
     {
         requester.markFree(mctp_eid, instanceId);
-        std::cerr << "Failed to encode_set_state_effecter_states_req, rc = "
-                  << rc << std::endl;
+        error("Failed to encode_set_state_effecter_states_req, rc = {RC}", "RC",
+              static_cast<int>(rc));
         return;
     }
 
@@ -132,8 +135,8 @@ void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
         [&rc](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr << "Failed to receive response for the Set State "
-                         "Effecter States\n";
+            error(
+                "Failed to receive response for the Set State Effecter States");
             return;
         }
 
@@ -144,10 +147,9 @@ void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Failed to decode_set_state_effecter_states_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_set_state_effecter_states_resp: rc={RC}, cc={CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
 
@@ -157,8 +159,7 @@ void HostLampTest::setHostStateEffecter(uint16_t effecterID, uint8_t& rc)
         std::move(setStateEffecterStatesResponseHandler));
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr
-            << "Failed to send the the Set State Effecter States request\n";
+        error("Failed to send the the Set State Effecter States request");
     }
 
     return;

--- a/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
+++ b/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
@@ -3,20 +3,26 @@
 #include "oem_ibm_handler.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace responder
 {
 using namespace oem_ibm_platform;
 void SlotHandler::timeOutHandler()
 {
-    std::cerr
-        << "Timer expired waiting for Event from Inventory on following pldm_entity: [ "
-        << current_on_going_slot_entity.entity_type << ","
-        << current_on_going_slot_entity.entity_instance_num << ","
-        << current_on_going_slot_entity.entity_container_id << "]" << std::endl;
-
+    error(
+        "Timer expired waiting for Event from Inventory on following pldm_entity: [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ]",
+        "ENTITY_TYP",
+        static_cast<unsigned>(current_on_going_slot_entity.entity_type),
+        "ENTITY_NUM",
+        static_cast<unsigned>(current_on_going_slot_entity.entity_instance_num),
+        "ENTITY_ID",
+        static_cast<unsigned>(
+            current_on_going_slot_entity.entity_container_id));
     // Disable the timer
     timer.setEnabled(false);
 
@@ -37,7 +43,8 @@ void SlotHandler::enableSlot(uint16_t effecterId,
                              uint8_t stateFileValue)
 
 {
-    std::cerr << "CM: slot enable effecter id: " << effecterId << std::endl;
+    error("CM: slot enable effecter id: {EFFECTER_ID}", "EFFECTER_ID",
+          effecterId);
     const pldm_entity entity = getEntityIDfromEffecterID(effecterId);
 
     for (const auto& [key, value] : fruAssociationMap)
@@ -60,8 +67,8 @@ void SlotHandler::processSlotOperations(const std::string& slotObjectPath,
                                         const pldm_entity& entity,
                                         uint8_t stateFiledValue)
 {
-    std::cerr << "CM: processing the slot operations, SlotObject: "
-              << slotObjectPath << std::endl;
+    error("CM: processing the slot operations, SlotObject: {SLOT_OBJ}",
+          "SLOT_OBJ", slotObjectPath);
 
     std::string adapterObjPath;
     try
@@ -74,8 +81,9 @@ void SlotHandler::processSlotOperations(const std::string& slotObjectPath,
         return;
     }
 
-    std::cerr << "CM: Found an adapter under the slot, adapter object:"
-              << adapterObjPath << std::endl;
+    error(
+        "CM: Found an adapter under the slot, adapter object:{ADAPTER_OBJ_PATH}",
+        "ADAPTER_OBJ_PATH", adapterObjPath);
     // create a presence match for the adpter present property
     createPresenceMatch(adapterObjPath, entity, stateFiledValue);
 
@@ -116,9 +124,10 @@ void SlotHandler::callVPDManager(const std::string& adapterObjPath,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to VPD Manager , Operation ="
-                  << (unsigned)stateFiledValue << ", ERROR=" << e.what()
-                  << "\n";
+        error(
+            "failed to make a d-bus call to VPD Manager , Operation = {STATE_FILED_VAL}, ERROR={ERR_EXCEP}",
+            "STATE_FILED_VAL", (unsigned)stateFiledValue, "ERR_EXCEP",
+            e.what());
     }
 }
 
@@ -201,9 +210,9 @@ void SlotHandler::processPropertyChangeFromVPD(
             sensorOpState = uint8_t(SLOT_STATE_DISABLED);
         }
     }
-    std::cerr
-        << "CM: processing the property change from VPD Present value and sensor opState:"
-        << presentValue << "and" << (unsigned)sensorOpState << std::endl;
+    error(
+        "CM: processing the property change from VPD Present value and sensor opState: {CURR_VAL} and {SENSOR_OP_STATE}",
+        "CURR_VAL", presentValue, "SENSOR_OP_STATE", (unsigned)sensorOpState);
     // set the sensor state based on the stateFieldValue
     this->sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
                                sensorOpState, uint8_t(SLOT_STATE_UNKOWN));
@@ -261,9 +270,9 @@ uint8_t SlotHandler::fetchSlotSensorState(const std::string& slotObjectPath)
     }
     catch (const std::bad_optional_access& e)
     {
-        std::cerr
-            << "Failed to get the adapterObjectPath from slotObjectPath : "
-            << slotObjectPath << e.what() << '\n';
+        error(
+            "Failed to get the adapterObjectPath from slotObjectPath : {SLOT_OBJ_PATH}, {ERR_EXCEP}",
+            "SLOT_OBJ_PATH", slotObjectPath, "ERR_EXCEP", e.what());
         return uint8_t(SLOT_STATE_UNKOWN);
     }
 
@@ -316,8 +325,9 @@ bool SlotHandler::fetchSensorStateFromDbus(const std::string& adapterObjectPath)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to Inventory manager, ERROR="
-                  << e.what() << "\n";
+        error(
+            "failed to make a d-bus call to Inventory manager, ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
 
     return false;

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -13,11 +13,15 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <thread>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -30,7 +34,6 @@ extern SocketWriteStatus socketWriteStatus;
 namespace fs = std::filesystem;
 namespace dma
 {
-
 /** @struct AspeedXdmaOp
  *
  * Structure representing XDMA operation
@@ -64,9 +67,9 @@ int DMA::transferHostDataToSocket(int fd, uint32_t length, uint64_t address)
     if (dmaFd < 0)
     {
         rc = -errno;
-        std::cerr
-            << "transferHostDataToSocket : Failed to open the XDMA device, RC="
-            << rc << "\n";
+        error(
+            "transferHostDataToSocket : Failed to open the XDMA device, RC={RC}",
+            "RC", rc);
         return rc;
     }
 
@@ -77,9 +80,9 @@ int DMA::transferHostDataToSocket(int fd, uint32_t length, uint64_t address)
     if (MAP_FAILED == vgaMemDump)
     {
         rc = -errno;
-        std::cerr
-            << "transferHostDataToSocket : Failed to mmap the XDMA device, RC="
-            << rc << "\n";
+        error(
+            "transferHostDataToSocket : Failed to mmap the XDMA device, RC={RC}",
+            "RC", rc);
         return rc;
     }
 
@@ -92,18 +95,17 @@ int DMA::transferHostDataToSocket(int fd, uint32_t length, uint64_t address)
     if (rc < 0)
     {
         rc = -errno;
-        std::cerr
-            << "transferHostDataToSocket : Failed to execute the DMA operation, RC="
-            << rc << " ADDRESS=" << address << " LENGTH=" << length << "\n";
+        error(
+            "transferHostDataToSocket : Failed to execute the DMA operation, RC={RC} ADDRESS={ADDR} LENGTH={LEN}",
+            "RC", rc, "ADDR", address, "LEN", length);
         if (rc != -EINTR)
         {
             munmap(vgaMemDump, pageAlignedLength);
         }
         else
         {
-            std::cerr
-                << "transferHostDataToSocket : Received interrupt during dump DMA transfer. Skipping Unmap"
-                << std::endl;
+            error(
+                "transferHostDataToSocket : Received interrupt during dump DMA transfer. Skipping Unmap");
         }
         return rc;
     }
@@ -134,9 +136,7 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
         }
         else
         {
-            std::cerr
-                << "Received interrupt during DMA transfer. Skipping Unmap"
-                << std::endl;
+            error("Received interrupt during DMA transfer. Skipping Unmap");
         }
     };
 
@@ -145,8 +145,8 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
     if (dmaFd < 0)
     {
         rc = -errno;
-        std::cerr << "transferDataHost : Failed to open the XDMA device, RC="
-                  << rc << "\n";
+        error("transferDataHost : Failed to open the XDMA device, RC={RC}",
+              "RC", rc);
         return rc;
     }
 
@@ -158,8 +158,8 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
     if (MAP_FAILED == vgaMem)
     {
         rc = -errno;
-        std::cerr << "transferDataHost : Failed to mmap the XDMA device, RC="
-                  << rc << "\n";
+        error("transferDataHost : Failed to mmap the XDMA device, RC={RC}",
+              "RC", rc);
         return rc;
     }
 
@@ -170,9 +170,9 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
         rc = lseek(fd, offset, SEEK_SET);
         if (rc == -1)
         {
-            std::cerr << "transferDataHost upstream : lseek failed, ERROR="
-                      << errno << ", UPSTREAM=" << upstream
-                      << ", OFFSET=" << offset << "\n";
+            error(
+                "transferDataHost upstream : lseek failed, ERROR={ERR}, UPSTREAM={UP_STRM}, OFFSET={KEY2}",
+                "ERR", errno, "UP_STRM", upstream, "OFFSET", offset);
             return rc;
         }
 
@@ -184,17 +184,17 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
         rc = read(fd, buffer.data(), length);
         if (rc == -1)
         {
-            std::cerr << "transferDataHost upstream : file read failed, ERROR="
-                      << errno << ", UPSTREAM=" << upstream
-                      << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
+            error(
+                "transferDataHost upstream : file read failed, ERROR={ERR}, UPSTREAM={UP_STRM}, LENGTH={LEN}, OFFSET={OFFSET}",
+                "ERR", errno, "UP_STRM", upstream, "LEN", length, "OFFSET",
+                offset);
             return rc;
         }
         if (rc != static_cast<int>(length))
         {
-            std::cerr
-                << "transferDataHost upstream : mismatch between number of characters to read and "
-                << "the length read, LENGTH=" << length << " COUNT=" << rc
-                << "\n";
+            error(
+                "transferDataHost upstream : mismatch between number of characters to read and the length read, LENGTH={LEN} COUNT={RC}",
+                "LEN", length, "RC", rc);
             return -1;
         }
         memcpy(static_cast<char*>(vgaMemPtr.get()), buffer.data(),
@@ -210,10 +210,9 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
     if (rc < 0)
     {
         rc = -errno;
-        std::cerr
-            << "transferDataHost : Failed to execute the DMA operation, RC="
-            << rc << " UPSTREAM=" << upstream << " ADDRESS=" << address
-            << " LENGTH=" << length << "\n";
+        error(
+            "transferDataHost : Failed to execute the DMA operation, RC={RC} UPSTREAM={UP_STRM} ADDRESS={ADDR} LENGTH={LEN}",
+            "RC", rc, "UP_STRM", upstream, "ADDR", address, "LEN", length);
         return rc;
     }
 
@@ -222,18 +221,18 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
         rc = lseek(fd, offset, SEEK_SET);
         if (rc == -1)
         {
-            std::cerr << "transferDataHost downstream : lseek failed, ERROR="
-                      << errno << ", UPSTREAM=" << upstream
-                      << ", OFFSET=" << offset << "\n";
+            error(
+                "transferDataHost downstream : lseek failed, ERROR={ERR}, UPSTREAM={UP_STRM}, OFFSET={OFFSET}",
+                "ERR", errno, "UP_STRM", upstream, "OFFSET", offset);
             return rc;
         }
         rc = write(fd, static_cast<const char*>(vgaMemPtr.get()), length);
         if (rc == -1)
         {
-            std::cerr
-                << "transferDataHost downstream : file write failed, ERROR="
-                << errno << ", UPSTREAM=" << upstream << ", LENGTH=" << length
-                << ", OFFSET=" << offset << "\n";
+            error(
+                "transferDataHost downstream : file write failed, ERROR={ERR}, UPSTREAM={UP_STRM}, LENGTH={LEN}, OFFSET={OFFSET}",
+                "ERR", errno, "UP_STRM", upstream, "LEN", length, "OFFSET",
+                offset);
             return rc;
         }
     }
@@ -245,7 +244,6 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
 
 namespace oem_ibm
 {
-
 Response Handler::readFileIntoMemory(const pldm_msg* request,
                                      size_t payloadLength)
 {
@@ -278,8 +276,9 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "File handle does not exist in the file table, HANDLE="
-                  << fileHandle << "\n";
+        error(
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
+            "FILE_HNDL", fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -288,7 +287,8 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
 
     if (!fs::exists(value.fsPath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle << "\n";
+        error("File does not exist, HANDLE={FILE_HNDL}", "FILE_HNDL",
+              fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -298,10 +298,9 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
     auto fileSize = fs::file_size(value.fsPath);
     if (offset >= fileSize)
     {
-        std::cerr
-            << "fileIO:Handler::readFileIntoMemory:Offset exceeds file size, OFFSET="
-            << offset << " FILE_SIZE=" << fileSize << " FILE_HANDLE"
-            << fileHandle << "\n";
+        error(
+            "fileIO:Handler::readFileIntoMemory:Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE} FILE_HANDLE={FILE_HANDLE}",
+            "OFFSET", offset, "FILE_SIZE", fileSize, "FILE_HANDLE", fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_DATA_OUT_OF_RANGE, 0, responsePtr);
@@ -315,8 +314,8 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
 
     if ((length == 0) && (length % dma::minSize))
     {
-        std::cerr << "Read length is not a multiple of DMA minSize, LENGTH="
-                  << length << "\n";
+        error("Read length is not a multiple of DMA minSize, LENGTH={LEN}",
+              "LEN", length);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_ERROR_INVALID_LENGTH, 0, responsePtr);
@@ -354,8 +353,8 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
 
     if ((length == 0) || (length % dma::minSize))
     {
-        std::cerr << "Write length is not a multiple of DMA minSize, LENGTH="
-                  << length << "\n";
+        error("Write length is not a multiple of DMA minSize, LENGTH={LEN}",
+              "LEN", length);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_ERROR_INVALID_LENGTH, 0, responsePtr);
@@ -372,8 +371,9 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "File handle does not exist in the file table, HANDLE="
-                  << fileHandle << "\n";
+        error(
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
+            "FILE_HNDL", fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -382,7 +382,8 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
 
     if (!fs::exists(value.fsPath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle << "\n";
+        error("File does not exist, HANDLE={FILE_HNDL}", "FILE_HNDL",
+              fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -392,10 +393,9 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
     auto fileSize = fs::file_size(value.fsPath);
     if (offset >= fileSize)
     {
-        std::cerr
-            << "FileIO:Handler::writeFileFromMemory:Offset exceeds file size, OFFSET="
-            << offset << " FILE_SIZE=" << fileSize
-            << " FILE_HANDLE=" << fileHandle << "\n";
+        error(
+            "fileIO:Handler::readFileFromMemory:Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE} FILE_HANDLE={FILE_HANDLE}",
+            "OFFSET", offset, "FILE_SIZE", fileSize, "FILE_HANDLE", fileHandle);
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_DATA_OUT_OF_RANGE, 0, responsePtr);
@@ -499,8 +499,10 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "File handle does not exist in the file table, HANDLE="
-                  << fileHandle << "\n";
+        error(
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
+            "FILE_HNDL", fileHandle);
+
         encode_read_file_resp(request->hdr.instance_id,
                               PLDM_INVALID_FILE_HANDLE, length, responsePtr);
         return response;
@@ -508,7 +510,8 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
 
     if (!fs::exists(value.fsPath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle << "\n";
+        error("File does not exist, HANDLE={FILE_HNDL}", "FILE_HNDL",
+              fileHandle);
         encode_read_file_resp(request->hdr.instance_id,
                               PLDM_INVALID_FILE_HANDLE, length, responsePtr);
         return response;
@@ -517,8 +520,8 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
     auto fileSize = fs::file_size(value.fsPath);
     if (offset >= fileSize)
     {
-        std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                  << " FILE_SIZE=" << fileSize << "\n";
+        error("Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+              "OFFSET", offset, "FILE_SIZE", fileSize);
         encode_read_file_resp(request->hdr.instance_id, PLDM_DATA_OUT_OF_RANGE,
                               length, responsePtr);
         return response;
@@ -580,8 +583,9 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "File handle does not exist in the file table, HANDLE="
-                  << fileHandle << "\n";
+        error(
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
+            "FILE_HNDL", fileHandle);
         encode_write_file_resp(request->hdr.instance_id,
                                PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
         return response;
@@ -589,7 +593,8 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
 
     if (!fs::exists(value.fsPath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle << "\n";
+        error("File does not exist, HANDLE={FILE_HNDL}", "FILE_HNDL",
+              fileHandle);
         encode_write_file_resp(request->hdr.instance_id,
                                PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
         return response;
@@ -598,8 +603,8 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
     auto fileSize = fs::file_size(value.fsPath);
     if (offset >= fileSize)
     {
-        std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                  << " FILE_SIZE=" << fileSize << "\n";
+        error("Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+              "OFFSET", offset, "FILE_SIZE", fileSize);
         encode_write_file_resp(request->hdr.instance_id, PLDM_DATA_OUT_OF_RANGE,
                                0, responsePtr);
         return response;
@@ -651,8 +656,8 @@ Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
     }
     if ((length == 0) || (length % dma::minSize))
     {
-        std::cerr << "Length is not a multiple of DMA minSize, LENGTH="
-                  << length << "\n";
+        error("Length is not a multiple of DMA minSize, LENGTH={LEN}", "LEN",
+              length);
         encode_rw_file_by_type_memory_resp(request->hdr.instance_id, cmd,
                                            PLDM_ERROR_INVALID_LENGTH, 0,
                                            responsePtr);
@@ -666,7 +671,7 @@ Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={LEN}", "LEN", fileType);
         encode_rw_file_by_type_memory_resp(request->hdr.instance_id, cmd,
                                            PLDM_INVALID_FILE_TYPE, 0,
                                            responsePtr);
@@ -731,7 +736,7 @@ Response Handler::writeFileByType(const pldm_msg* request, size_t payloadLength)
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         encode_rw_file_by_type_resp(request->hdr.instance_id,
                                     PLDM_WRITE_FILE_BY_TYPE,
                                     PLDM_INVALID_FILE_TYPE, 0, responsePtr);
@@ -780,7 +785,7 @@ Response Handler::readFileByType(const pldm_msg* request, size_t payloadLength)
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         encode_rw_file_by_type_resp(request->hdr.instance_id,
                                     PLDM_READ_FILE_BY_TYPE,
                                     PLDM_INVALID_FILE_TYPE, 0, responsePtr);
@@ -900,7 +905,7 @@ Response Handler::newFileAvailable(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 
@@ -944,7 +949,7 @@ Response Handler::fileAckWithMetaData(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 
@@ -990,7 +995,7 @@ Response Handler::newFileAvailableWithMetaData(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        std::cerr << "unknown file type, TYPE=" << fileType << "\n";
+        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -15,9 +15,13 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <filesystem>
 #include <iostream>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -25,7 +29,6 @@ namespace responder
 {
 namespace dma
 {
-
 // The minimum data size of dma transfer in bytes
 constexpr uint32_t minSize = 16;
 
@@ -114,7 +117,8 @@ Response transferAll(DMAInterface* intf, uint8_t command, fs::path& path,
     int file = open(path.string().c_str(), flags);
     if (file == -1)
     {
-        std::cerr << "File does not exist, path = " << path.string() << "\n";
+        error("File does not exist, path = {FILE_PATH}", "FILE_PATH",
+              path.string());
         encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
                                    responsePtr);
         return response;

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
 
 #include <exception>
@@ -24,6 +25,8 @@
 #include <fstream>
 #include <iostream>
 #include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -81,17 +84,17 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
         fileExists = fs::exists(path);
         if (!fileExists)
         {
-            std::cerr << "File does not exist. PATH=" << path.c_str() << "\n";
+            error("File does not exist. PATH={PATH}", "PATH", path.c_str());
             return PLDM_INVALID_FILE_HANDLE;
         }
 
         size_t fileSize = fs::file_size(path);
         if (offset >= fileSize)
         {
-            std::cerr
-                << "FileHandler::transferFileData: Offset exceeds file size, OFFSET="
-                << offset << " FILE_SIZE=" << fileSize
-                << " FILE_HANDLE=" << fileHandle << "\n";
+            error(
+                "FileHandler::transferFileData: Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE} FILE_HANDLE={FILE_HANDLE}",
+                "OFFSET", offset, "FILE_SIZE", fileSize, "FILE_HANDLE",
+                fileHandle);
             return PLDM_DATA_OUT_OF_RANGE;
         }
         if (offset + length > fileSize)
@@ -116,8 +119,7 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
     int file = open(path.string().c_str(), flags);
     if (file == -1)
     {
-        std::cerr << "File does not exist, PATH = " << path.string() << "\n";
-        ;
+        error("File does not exist, PATH = {PATH}", "PATH", path.string());
         return PLDM_ERROR;
     }
     pldm::utils::CustomFD fd(file);
@@ -200,17 +202,17 @@ int FileHandler::readFile(const std::string& filePath, uint32_t offset,
 {
     if (!fs::exists(filePath))
     {
-        std::cerr << "File does not exist, HANDLE=" << fileHandle
-                  << " PATH=" << filePath.c_str() << "\n";
+        error("File does not exist, HANDLE={FILE_HNDLE} PATH={PATH}",
+              "FILE_HNDLE", fileHandle, "PATH", filePath.c_str());
         return PLDM_INVALID_FILE_HANDLE;
     }
 
     size_t fileSize = fs::file_size(filePath);
     if (offset >= fileSize)
     {
-        std::cerr << "FileHandler::readFile:Offset exceeds file size, OFFSET="
-                  << offset << " FILE_SIZE=" << fileSize << " FILE_HANDLE"
-                  << fileHandle << "\n";
+        error(
+            "FileHandler::readFileData: Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE} FILE_HANDLE={FILE_HANDLE}",
+            "OFFSET", offset, "FILE_SIZE", fileSize, "FILE_HANDLE", fileHandle);
         return PLDM_DATA_OUT_OF_RANGE;
     }
 
@@ -230,7 +232,8 @@ int FileHandler::readFile(const std::string& filePath, uint32_t offset,
         stream.read(filePos, length);
         return PLDM_SUCCESS;
     }
-    std::cerr << "Unable to read file, FILE=" << filePath.c_str() << "\n";
+    error("Unable to read file, FILE={FILE_PATH}", "FILE_PATH",
+          filePath.c_str());
     return PLDM_ERROR;
 }
 

--- a/oem/ibm/libpldmresponder/file_io_type_cert.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.cpp
@@ -7,7 +7,11 @@
 
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -15,7 +19,6 @@ using namespace utils;
 
 namespace responder
 {
-
 constexpr auto certObjPath = "/xyz/openbmc_project/certs/ca/entry/";
 constexpr auto certEntryIntf = "xyz.openbmc_project.Certs.Entry";
 static constexpr auto certFilePath = "/var/lib/ibm/bmcweb/";
@@ -29,8 +32,9 @@ int CertHandler::writeFromMemory(uint32_t offset, uint32_t length,
     auto it = certMap.find(certType);
     if (it == certMap.end())
     {
-        std::cerr << "CertHandler::writeFromMemory:file for type " << certType
-                  << " doesn't exist\n";
+        error(
+            "CertHandler::writeFromMemory:file for type {CERT_TYP} doesn't exist",
+            "CERT_TYP", certType);
         return PLDM_ERROR;
     }
 
@@ -71,9 +75,9 @@ int CertHandler::readIntoMemory(uint32_t offset, uint32_t& length,
 int CertHandler::read(uint32_t offset, uint32_t& length, Response& response,
                       oem_platform::Handler* /*oemPlatformHandler*/)
 {
-    std::cout
-        << "CertHandler::read:Read file response for Sign CSR, file handle: "
-        << fileHandle << std::endl;
+    info(
+        "CertHandler::read:Read file response for Sign CSR, file handle: {FILE_HNDL}",
+        "FILE_HNDL", fileHandle);
     std::string filePath = certFilePath;
     filePath += "CSR_" + std::to_string(fileHandle);
     if (certType != PLDM_FILE_TYPE_CERT_SIGNING_REQUEST)
@@ -95,8 +99,8 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
     auto it = certMap.find(certType);
     if (it == certMap.end())
     {
-        std::cerr << "CertHandler::write:file for type " << certType
-                  << " doesn't exist\n";
+        error("CertHandler::write:file for type {CERT_TYP} doesn't exist",
+              "CERT_TYP", certType);
         return PLDM_ERROR;
     }
 
@@ -104,15 +108,17 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
     int rc = lseek(fd, offset, SEEK_SET);
     if (rc == -1)
     {
-        std::cerr << "CertHandler::write:lseek failed, ERROR=" << errno
-                  << ", OFFSET=" << offset << "\n";
+        error(
+            "CertHandler::write:lseek failed, ERROR={ERR_EXCEP}, OFFSET={OFFSET}",
+            "ERR_EXCEP", errno, "OFFSET", offset);
         return PLDM_ERROR;
     }
     rc = ::write(fd, buffer, length);
     if (rc == -1)
     {
-        std::cerr << "CertHandler::write:file write failed, ERROR=" << errno
-                  << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
+        error(
+            "CertHandler::write:file write failed, ERROR={ERR_EXCEP}, LENGTH={LEN}, OFFSET={OFFSET}",
+            "ERR_EXCEP", errno, "LEN", length, "OFFSET", offset);
         return PLDM_ERROR;
     }
     length = rc;
@@ -152,10 +158,9 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "CertHandler::write:failed to set Client certificate, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "CertHandler::write:failed to set Client certificate, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
             PropertyValue valueStatus{
@@ -165,18 +170,17 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
                                           certEntryIntf, "Status", "string"};
             try
             {
-                std::cout
-                    << "CertHandler::write:Client cert write, status: complete. File handle: "
-                    << fileHandle << std::endl;
+                info(
+                    "CertHandler::write:Client cert write, status: complete. File handle: {FILE_HNDL}",
+                    "FILE_HNDL", fileHandle);
                 pldm::utils::DBusHandler().setDbusProperty(dbusMappingStatus,
                                                            valueStatus);
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "CertHandler::write:failed to set status property of certicate entry, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "CertHandler::write:failed to set status property of certicate entry, ERROR={ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
             fs::remove(filePath);
@@ -188,17 +192,16 @@ int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
                                     certEntryIntf, "Status", "string"};
             try
             {
-                std::cout
-                    << "CertHandler::write:Client cert write, status: Bad CSR. File handle: "
-                    << fileHandle << std::endl;
+                info(
+                    "CertHandler::write:Client cert write, status: Bad CSR. File handle: {FILE_HNDLE}",
+                    "FILE_HNDLE", fileHandle);
                 pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "CertHandler::write:failed to set status property of certicate entry, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "CertHandler::write:failed to set status property of certicate entry, {ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
         }
@@ -221,9 +224,9 @@ int CertHandler::newFileAvailable(uint64_t length)
     }
     if (certType == PLDM_FILE_TYPE_SIGNED_CERT)
     {
-        std::cout
-            << "CertHandler::newFileAvailable:new file available client cert file, file handle: "
-            << fileHandle << std::endl;
+        info(
+            "CertHandler::newFileAvailable:new file available client cert file, file handle: {FILE_HNDLE}",
+            "FILE_HNDLE", fileHandle);
         fileFd = open(
             (filePath + "ClientCert_" + std::to_string(fileHandle)).c_str(),
             flags, S_IRUSR | S_IWUSR);
@@ -235,9 +238,9 @@ int CertHandler::newFileAvailable(uint64_t length)
     }
     if (fileFd == -1)
     {
-        std::cerr
-            << "CertHandler::newFileAvailable:failed to open file for type "
-            << certType << " ERROR=" << errno << "\n";
+        error(
+            "CertHandler::newFileAvailable:failed to open file for type {CERT_TYP} ERROR={ERR_EXCEP}",
+            "CERT_TYP", certType, "ERR_EXCEP", errno);
         return PLDM_ERROR;
     }
     certMap.emplace(certType, std::tuple(fileFd, length));
@@ -266,18 +269,18 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
     {
         if (certSigningStatus == PLDM_SUCCESS)
         {
-            std::cerr
-                << "CertHandler::newFileAvailableWithMetaData:new file available client cert file, file handle: "
-                << fileHandle << std::endl;
+            error(
+                "CertHandler::newFileAvailableWithMetaData:new file available client cert file, file handle: {FILE_HNDL}",
+                "FILE_HNDL", fileHandle);
             fileFd = open(
                 (filePath + "ClientCert_" + std::to_string(fileHandle)).c_str(),
                 flags, S_IRUSR | S_IWUSR);
         }
         else if (certSigningStatus == PLDM_INVALID_CERT_DATA)
         {
-            std::cerr
-                << "newFileAvailableWithMetaData:client cert file Invalid data, file handle: "
-                << fileHandle << std::endl;
+            error(
+                "newFileAvailableWithMetaData:client cert file Invalid data, file handle: {FILE_HNDL}",
+                "FILE_HNDL", fileHandle);
             DBusMapping dbusMapping{certObjPath + std::to_string(fileHandle),
                                     certEntryIntf, "Status", "string"};
             std::string status = "xyz.openbmc_project.Certs.Entry.State.BadCSR";
@@ -288,10 +291,9 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
             }
             catch (const std::exception& e)
             {
-                std::cerr
-                    << "newFileAvailableWithMetaData:Failed to set status property of certicate entry, "
-                       "ERROR="
-                    << e.what() << "\n";
+                error(
+                    "newFileAvailableWithMetaData:Failed to set status property of certicate entry, ERROR= {ERR_EXCEP}",
+                    "ERR_EXCEP", e.what());
                 return PLDM_ERROR;
             }
         }
@@ -303,9 +305,9 @@ int CertHandler::newFileAvailableWithMetaData(uint64_t length,
     }
     if (fileFd == -1)
     {
-        std::cerr
-            << "newFileAvailableWithMetaData:failed to open file for type "
-            << certType << " ERROR=" << errno << "\n";
+        error(
+            "newFileAvailableWithMetaData:failed to open file for type {CERT_TYP} ERROR={ERR_EXCEP}",
+            "CERT_TYP", certType, "ERR_EXCEP", errno);
         return PLDM_ERROR;
     }
     certMap.emplace(certType, std::tuple(fileFd, length));
@@ -340,10 +342,9 @@ int CertHandler::fileAckWithMetaData(uint8_t fileStatus,
         }
         catch (const std::exception& e)
         {
-            std::cerr
-                << "CertHandler::fileAckWithMetaData:Failed to set status property of certicate entry, "
-                   "ERROR="
-                << e.what() << "\n";
+            error(
+                "CertHandler::fileAckWithMetaData:Failed to set status property of certicate entry, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }

--- a/oem/ibm/libpldmresponder/file_io_type_lic.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.cpp
@@ -7,7 +7,11 @@
 
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -19,7 +23,6 @@ const std::vector<Json> emptyJsonList{};
 
 namespace responder
 {
-
 static constexpr auto codFilePath = "/var/lib/ibm/cod/";
 static constexpr auto licFilePath = "/var/lib/pldm/license/";
 constexpr auto newLicenseFile = "new_license.bin";
@@ -34,8 +37,8 @@ int LicenseHandler::updateBinFileAndLicObjs(const fs::path& newLicJsonFilePath)
     auto dataNew = Json::parse(jsonFileNew, nullptr, false);
     if (dataNew.is_discarded())
     {
-        std::cerr << "Parsing the new license json file failed, FILE="
-                  << newLicJsonFilePath << "\n";
+        error("Parsing the new license json file failed, FILE={NEW_LIC_JSON}",
+              "NEW_LIC_JSON", newLicJsonFilePath.c_str());
         throw InternalFailure();
     }
 
@@ -46,8 +49,7 @@ int LicenseHandler::updateBinFileAndLicObjs(const fs::path& newLicJsonFilePath)
     rc = createOrUpdateLicenseObjs();
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "createOrUpdateLicenseObjs failed with rc= " << rc
-                  << " \n";
+        error("createOrUpdateLicenseObjs failed with rc= {RC}", "RC", rc);
         return rc;
     }
     return PLDM_SUCCESS;
@@ -69,8 +71,8 @@ int LicenseHandler::writeFromMemory(
                               std::ios::out | std::ios::binary);
     if (!licJsonFile)
     {
-        std::cerr << "license json file create error: " << newLicJsonFilePath
-                  << std::endl;
+        error("license json file create error: {NEW_LIC_JSON}", "NEW_LIC_JSON",
+              newLicJsonFilePath.c_str());
         return -1;
     }
 
@@ -78,7 +80,7 @@ int LicenseHandler::writeFromMemory(
                                address);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "transferFileData failed with rc= " << rc << " \n";
+        error("transferFileData failed with rc= {RC}", "RC", rc);
         return rc;
     }
 
@@ -87,8 +89,7 @@ int LicenseHandler::writeFromMemory(
         rc = updateBinFileAndLicObjs(newLicJsonFilePath);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "updateBinFileAndLicObjs failed with rc= " << rc
-                      << " \n";
+            error("updateBinFileAndLicObjs failed with rc= {RC}", "RC", rc);
             return rc;
         }
     }
@@ -107,8 +108,8 @@ int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,
                               std::ios::out | std::ios::binary | std::ios::app);
     if (!licJsonFile)
     {
-        std::cerr << "license json file create error: " << newLicJsonFilePath
-                  << std::endl;
+        error("license json file create error: {NEW_LIC_JSON}", "NEW_LIC_JSON",
+              newLicJsonFilePath.c_str());
         return -1;
     }
 
@@ -121,7 +122,7 @@ int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,
     updateBinFileAndLicObjs(newLicJsonFilePath);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "updateBinFileAndLicObjs failed with rc= " << rc << " \n";
+        error("updateBinFileAndLicObjs failed with rc= {RC}", "RC", rc);
         return rc;
     }
 
@@ -178,9 +179,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -195,9 +196,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -212,9 +213,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -229,9 +230,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -246,9 +247,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -263,9 +264,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }
@@ -280,9 +281,9 @@ int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         }
         catch (const std::exception& e)
         {
-            std::cerr << "failed to set status property of license manager, "
-                         "ERROR="
-                      << e.what() << "\n";
+            error(
+                "failed to set status property of license manager, ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
     }

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -2,11 +2,14 @@
 
 #include "file_io_by_type.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Software/Version/error.hpp>
 
 #include <filesystem>
 #include <sstream>
 #include <string>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -209,8 +212,8 @@ class LidHandler : public FileHandler
         auto fd = open(lidPath.c_str(), flags, S_IRUSR);
         if (fd == -1)
         {
-            std::cerr << "Could not open file for writing  " << lidPath.c_str()
-                      << "\n";
+            error("Could not open file for writing {LID_PATH}", "LID_PATH",
+                  lidPath.c_str());
             return PLDM_ERROR;
         }
         close(fd);
@@ -218,7 +221,7 @@ class LidHandler : public FileHandler
         rc = transferFileData(lidPath, false, offset, length, address);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "writeFileFromMemory failed with rc= " << rc << " \n";
+            error("writeFileFromMemory failed with rc= {RC}", "RC", rc);
             return rc;
         }
         if (lidType == PLDM_FILE_TYPE_LID_MARKER)
@@ -276,10 +279,10 @@ class LidHandler : public FileHandler
             size_t fileSize = fs::file_size(lidPath);
             if (offset > fileSize)
             {
-                std::cerr
-                    << "LidHandler::write:Offset exceeds file size, OFFSET="
-                    << offset << " FILE_SIZE=" << fileSize
-                    << " FILE_HANDLE=" << fileHandle << "\n";
+                error(
+                    "LidHandler::write: Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE} FILE_HANDLE={FILE_HANDLE}",
+                    "OFFSET", offset, "FILE_SIZE", fileSize, "FILE_HANDLE",
+                    fileHandle);
                 return PLDM_DATA_OUT_OF_RANGE;
             }
         }
@@ -288,28 +291,30 @@ class LidHandler : public FileHandler
             flags = O_WRONLY | O_CREAT | O_TRUNC | O_SYNC;
             if (offset > 0)
             {
-                std::cerr << "Offset is non zero in a new file \n";
+                error("Offset is non zero in a new file");
                 return PLDM_DATA_OUT_OF_RANGE;
             }
         }
         auto fd = open(lidPath.c_str(), flags, S_IRUSR);
         if (fd == -1)
         {
-            std::cerr << "could not open file " << lidPath.c_str() << "\n";
+            error("could not open file {LID_PATH}", "LID_PATH",
+                  lidPath.c_str());
             return PLDM_ERROR;
         }
         rc = lseek(fd, offset, SEEK_SET);
         if (rc == -1)
         {
-            std::cerr << "lseek failed, ERROR=" << errno
-                      << ", OFFSET=" << offset << "\n";
+            error("lseek failed, ERROR={ERR}, OFFSET={OFFSET}", "ERR", errno,
+                  "OFFSET", offset);
             return PLDM_ERROR;
         }
         rc = ::write(fd, buffer, length);
         if (rc == -1)
         {
-            std::cerr << "file write failed, ERROR=" << errno
-                      << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
+            error(
+                "file write failed, ERROR={ERR}, LENGTH={LEN}, OFFSET={OFFSET}",
+                "ERR", errno, "LEN", length, "OFFSET", offset);
             return PLDM_ERROR;
         }
         else if (rc == static_cast<int>(length))

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -9,14 +9,17 @@
 
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
 #include <ranges>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
 namespace responder
 {
-
 static constexpr auto pciePath = "/var/lib/pldm/pcie-topology/";
 constexpr auto topologyFile = "topology";
 constexpr auto cableInfoFile = "cableinfo";
@@ -85,14 +88,14 @@ int PCIeInfoHandler::writeFromMemory(
     std::ofstream pcieData(infoFile, std::ios::out | std::ios::binary);
     if (!pcieData)
     {
-        std::cerr << "PCIe Info file creation error " << std::endl;
+        error("PCIe Info file creation error ");
         return PLDM_ERROR;
     }
 
     auto rc = transferFileData(infoFile, false, offset, length, address);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "transferFileData failed with rc= " << rc << " \n";
+        error("transferFileData failed with rc= {RC}", "RC", rc);
         return rc;
     }
 
@@ -112,7 +115,8 @@ int PCIeInfoHandler::write(const char* buffer, uint32_t, uint32_t& length,
                            std::ios::out | std::ios::binary | std::ios::app);
     if (!pcieData)
     {
-        std::cerr << "PCIe Info file creation error: " << infoFile << std::endl;
+        error("PCIe Info file creation error: {INFO_FILE}", "INFO_FILE",
+              infoFile.c_str());
         return PLDM_ERROR;
     }
 
@@ -129,8 +133,7 @@ int PCIeInfoHandler::fileAck(uint8_t /*fileStatus*/)
 {
     if (receivedFiles.find(infoType) == receivedFiles.end())
     {
-        std::cerr << "Received FileAck for the file which is not received"
-                  << std::endl;
+        error("Received FileAck for the file which is not received");
     }
     receivedFiles[infoType] = true;
 
@@ -152,7 +155,7 @@ int PCIeInfoHandler::fileAck(uint8_t /*fileStatus*/)
 
             for (const auto& cable : cables)
             {
-                std::cerr << "Removing cable object [ " << cable << " ]\n";
+                error("Removing cable object [ {CABLE} ]", "CABLE", cable);
                 pldm::dbus::CustomDBus::getCustomDBus().deleteObject(cable);
             }
             cables.clear();
@@ -191,9 +194,10 @@ void PCIeInfoHandler::setProperty(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To set " << propertyName << "property"
-                  << "and path :" << objPath << "ERROR=" << e.what()
-                  << std::endl;
+        error(
+            "Failed To set {PROP_NAME} property and path :{OBJ_PATH}, ERROR={ERR_EXCEP}",
+            "PROP_NAME", propertyName, "OBJ_PATH", objPath.c_str(), "ERR_EXCEP",
+            e.what());
     }
 }
 
@@ -326,10 +330,10 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
 
             std::filesystem::path slot(slotAndAdapter.first);
 
-            std::cerr << "Primary Link, "
-                      << " BusId - [" << std::hex << std::showbase << linkId
-                      << "] LinkStatus - [" << linkStatus << "] on [ "
-                      << slot.filename() << "] \n";
+            error(
+                "Primary Link, BusId - [{BUS_ID}] LinkStatus - [{LINK_STATUS}] on [{FILE_NAME}]",
+                "BUS_ID", lg2::hex, linkId, "LINK_STATUS", linkStatus,
+                "FILE_NAME", slot.filename());
         }
         else
         {
@@ -356,10 +360,10 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
             std::filesystem::path printSlot = slot.parent_path().filename();
             printSlot /= slot.filename();
 
-            std::cerr << "Secondary Link, "
-                      << " BusId - [ " << std::hex << std::showbase << linkId
-                      << " ] LinkStatus - [" << linkStatus << "] on [ "
-                      << printSlot << "] \n";
+            error(
+                "Secondary Link, BusId - [{BUS_ID}] LinkStatus - [{LINK_STATUS}] on [{PRINT_SLOT}]",
+                "BUS_ID", lg2::hex, linkId, "LINK_STATUS", linkStatus,
+                "PRINT_SLOT", printSlot);
         }
     }
     if (!slotAndAdapter.second.empty())
@@ -375,16 +379,16 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                         itemPCIeDevice, "int64_t");
             std::filesystem::path adapter(slotAndAdapter.second);
 
-            std::cerr << "Primary Link, "
-                      << " GenerationInUse - [" << link_speed[linkSpeed]
-                      << "] LanesInUse - [" << linkWidth << "] on [ "
-                      << adapter.filename() << "]\n";
+            error(
+                "Primary Link, GenerationInUse - [{LINK_SPEED}] LanesInUse - [{LINK_WIDTH}] on [{ADAPTER_FILE}]",
+                "LINK_SPEED", link_speed[linkSpeed], "LINK_WIDTH", linkWidth,
+                "ADAPTER_FILE", adapter.filename());
         }
         else
         {
             if (isHostedByPLDM)
             {
-                // std::cerr << "secondary link not empty adapter \n";
+                // error("secondary link not empty adapter \n";
                 //  its a secondary link so update the link speed on mex adapter
                 if (linkStatus ==
                         "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Open" ||
@@ -427,9 +431,10 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
             printAdapter /= adapter.parent_path().filename();
             printAdapter /= adapter.filename();
 
-            std::cerr << "Secondary Link, GenerationInUse - ["
-                      << link_speed[linkSpeed] << "] LanesInUse - ["
-                      << linkWidth << "] on [ " << printAdapter << "]\n";
+            error(
+                "Secondary Link, GenerationInUse - [{LINK_SPEED}] LanesInUse - [{LINK_WIDTH}] on [{PRNT_ADAPTER}]",
+                "LINK_SPEED", link_speed[linkSpeed], "LINK_WIDTH", linkWidth,
+                "PRNT_ADAPTER", printAdapter);
         }
     }
 }
@@ -653,8 +658,8 @@ void PCIeInfoHandler::parseSpeciallink(linkId_t linkId,
                 // out the slot
                 auto slotAndAdapter = pldm::responder::utils::getSlotAndAdapter(
                     localPortLocCode.first);
-                std::cerr << "Special processing for link - [ " << linkId
-                          << " ] \n";
+                error("Special processing for link - [{LINK_ID}]", "LINK_ID",
+                      linkId);
                 setTopologyOnSlotAndAdapter(
                     std::get<1>(linkInfo), slotAndAdapter, linkId,
                     std::get<0>(linkInfo), std::get<2>(linkInfo),
@@ -687,8 +692,7 @@ void PCIeInfoHandler::setTopologyAttrsOnDbus()
                     std::get<0>(info), std::get<2>(info), std::get<3>(info));
                 break;
             case Unknown:
-                std::cerr << "link type is unkown : " << (unsigned)link
-                          << std::endl;
+                error("link type is unkown : {LINK}", "LINK", (unsigned)link);
                 switch (linkTypeInfo[link])
                 {
                     case Primary:
@@ -763,16 +767,15 @@ void PCIeInfoHandler::setTopologyAttrsOnDbus()
 
         pldm::dbus::CustomDBus::getCustomDBus().setAssociations(
             cableObjectPath.string(), associations);
-
-        std::cerr << "Hosted Cable [ " << cable_no << " ] Length - [ "
-                  << std::get<4>(info) << " ] Type - [ " << std::get<5>(info)
-                  << " ] Status - [ " << std::get<6>(info) << " ] PN - [ "
-                  << std::get<3>(info) << " ]\n";
-        std::cerr << "Hosted Cable [ " << cable_no << " ] UPConnector - [ "
-                  << upstreamInformation << " ] DNConnector - [ "
-                  << downstreamInformation << " ] DChassis - [ "
-                  << downstreamChassis << " ]\n";
-
+        error(
+            "Hosted Cable [ {CABLE_NO} ] Length - [ {LEN} ] Type - [ {CABLE_TYP} ] Status - [ {CABLE_STATUS} ] PN - [ {PN} ]",
+            "CABLE_NO", cable_no, "LEN", std::get<4>(info), "CABLE_TYP",
+            std::get<5>(info), "CABLE_STATUS", std::get<6>(info), "PN",
+            std::get<3>(info));
+        error(
+            "Hosted Cable [ {CABLE_NO} ] UPConnector - [ {UP_CONN} ] DNConnector - [ {DN_CONN} ] DChassis - [ {D_CHASSIS} ]",
+            "CABLE_NO", cable_no, "UP_CONN", upstreamInformation, "DN_CONN",
+            downstreamInformation, "D_CHASSIS", downstreamChassis);
         cables.push_back(cableObjectPath.string());
     }
 }
@@ -815,7 +818,7 @@ void PCIeInfoHandler::parseTopologyData()
     if (MAP_FAILED == file_in_memory)
     {
         int rc = -errno;
-        std::cerr << "mmap on topology file failed, RC=" << rc << std::endl;
+        error("mmap on topology file failed, RC={RC}", "RC", rc);
         return;
     }
 
@@ -831,8 +834,7 @@ void PCIeInfoHandler::parseTopologyData()
     }
     else
     {
-        std::cerr
-            << "Parsing of topology file failed : pcie_link_list is null\n";
+        error("Parsing of topology file failed : pcie_link_list is null");
         return;
     }
 
@@ -841,7 +843,7 @@ void PCIeInfoHandler::parseTopologyData()
 
     if (single_entry_data == nullptr)
     {
-        std::cerr << "Parsing of topology file failed : single_link is null \n";
+        error("Parsing of topology file failed : single_link is null");
         return;
     }
 
@@ -939,8 +941,7 @@ void PCIeInfoHandler::parseTopologyData()
                                                 ->slot_loc_codes_offset));
         if (slot_data == nullptr)
         {
-            std::cerr
-                << "Parsing the topology file failed : slot_data is null \n";
+            error("Parsing the topology file failed : slot_data is null");
             return;
         }
         // get the Slot location code common part
@@ -957,7 +958,7 @@ void PCIeInfoHandler::parseTopologyData()
                                slot_data->slotLocCodesCmnPrtSize;
         if (suffix_data == nullptr)
         {
-            std::cerr << "slot location suffix data is nullptr \n";
+            error("slot location suffix data is nullptr");
             return;
         }
 
@@ -1046,7 +1047,7 @@ void PCIeInfoHandler::parseCableInfo()
     if (MAP_FAILED == file_in_memory)
     {
         int rc = -errno;
-        std::cerr << "mmap on cable ifno file failed, RC=" << rc << std::endl;
+        error("mmap on cable ifno file failed, RC={RC}", "RC", rc);
         return;
     }
 
@@ -1064,7 +1065,7 @@ void PCIeInfoHandler::parseCableInfo()
 
     if (cable_data == nullptr)
     {
-        std::cerr << "Cable info parsing failed , cable_data = nullptr \n";
+        error("Cable info parsing failed , cable_data = nullptr");
         return;
     }
 
@@ -1152,8 +1153,8 @@ void PCIeInfoHandler::deleteTopologyFiles()
         }
         catch (const fs::filesystem_error& err)
         {
-            std::cerr << "Topology file deletion failed " << pciePath << " : "
-                      << err.what() << "\n";
+            error("Topology file deletion failed {PCIE_PATH} : {ERR_EXCEP}",
+                  "PCIE_PATH", pciePath, "ERR_EXCEP", err.what());
         }
     }
 }

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -10,6 +10,7 @@
 #include <systemd/sd-bus.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
 
@@ -19,16 +20,16 @@
 #include <iostream>
 #include <vector>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace responder
 {
-
 using namespace sdbusplus::xyz::openbmc_project::Logging::server;
 
 namespace detail
 {
-
 /**
  * @brief Finds the Entry::Level value for the severity of the PEL
  *        passed in.
@@ -81,7 +82,8 @@ Entry::Level getEntryLevelFromPEL(const std::string& pelFileName)
         }
         else
         {
-            std::cerr << "Unable to open PEL file " << pelFileName << "\n";
+            error("Unable to open PEL file {PEL_FILE_NAME}", "PEL_FILE_NAME",
+                  pelFileName);
         }
     }
 
@@ -115,8 +117,9 @@ int PelHandler::readIntoMemory(uint32_t offset, uint32_t& length,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "GetPEL D-Bus call failed, PEL id = 0x" << std::hex
-                  << fileHandle << ", error = " << e.what() << "\n";
+        error(
+            "GetPEL D-Bus call failed, PEL id = 0x{FILE_HNDL}, error ={ERR_EXCEP}",
+            "FILE_HNDL", lg2::hex, fileHandle, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -146,14 +149,15 @@ int PelHandler::read(uint32_t offset, uint32_t& length, Response& response,
         off_t fileSize = lseek(fd, 0, SEEK_END);
         if (fileSize == -1)
         {
-            std::cerr << "file seek failed";
+            error("file seek failed");
             return PLDM_ERROR;
         }
         if (offset >= fileSize)
         {
-            std::cerr << "PelHandler::read:Offset exceeds file size, OFFSET="
-                      << offset << " FILE_SIZE=" << fileSize
-                      << " FILE_HANDLE=" << fileHandle << std::endl;
+            error(
+                "PelHandler::read: Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE} FILE_HANDLE={FILE_HANDLE}",
+                "OFFSET", offset, "FILE_SIZE", fileSize, "FILE_HANDLE",
+                fileHandle);
             return PLDM_DATA_OUT_OF_RANGE;
         }
         if (offset + length > fileSize)
@@ -163,7 +167,7 @@ int PelHandler::read(uint32_t offset, uint32_t& length, Response& response,
         auto rc = lseek(fd, offset, SEEK_SET);
         if (rc == -1)
         {
-            std::cerr << "file seek failed";
+            error("file seek failed");
             return PLDM_ERROR;
         }
         size_t currSize = response.size();
@@ -173,21 +177,22 @@ int PelHandler::read(uint32_t offset, uint32_t& length, Response& response,
         rc = ::read(fd, filePos, length);
         if (rc == -1)
         {
-            std::cerr << "file read failed";
+            error("file read failed");
             return PLDM_ERROR;
         }
         if (rc != length)
         {
-            std::cerr << "mismatch between number of characters to read and "
-                      << "the length read, LENGTH=" << length << " COUNT=" << rc
-                      << std::endl;
+            error(
+                "mismatch between number of characters to read and the length read, LENGTH={LEN} COUNT={COUNT}",
+                "LEN", length, "COUNT", rc);
             return PLDM_ERROR;
         }
     }
     catch (const std::exception& e)
     {
-        std::cerr << "GetPEL D-Bus call failed on PEL ID 0x" << std::hex
-                  << fileHandle << ", error = " << e.what() << "\n";
+        error(
+            "GetPEL D-Bus call failed on PEL ID 0x{FILE_HNDL}, error ={ERR_EXCEP}",
+            "FILE_HNDL", lg2::hex, fileHandle, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;
@@ -201,8 +206,8 @@ int PelHandler::writeFromMemory(uint32_t offset, uint32_t length,
     int fd = mkstemp(tmpFile);
     if (fd == -1)
     {
-        std::cerr << "failed to create a temporary pel, ERROR=" << errno
-                  << "\n";
+        error("failed to create a temporary pel, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", errno);
         return PLDM_ERROR;
     }
     close(fd);
@@ -233,8 +238,9 @@ int PelHandler::fileAck(uint8_t /*fileStatus*/)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "HostAck D-Bus call failed on PEL ID 0x" << std::hex
-                  << fileHandle << ", error = " << e.what() << "\n";
+        error(
+            "HostAck D-Bus call failed on PEL ID 0x{FILE_HNDL}, error ={ERR_EXCEP}",
+            "FILE_HNDL", lg2::hex, fileHandle, "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -267,8 +273,8 @@ int PelHandler::storePel(std::string&& pelFileName)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to PEL daemon, ERROR="
-                  << e.what() << "\n";
+        error("failed to make a d-bus call to PEL daemon, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 
@@ -282,7 +288,7 @@ int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
 
     if (offset > 0)
     {
-        std::cerr << "Offset is non zero \n";
+        error("Offset is non zero");
         return PLDM_ERROR;
     }
 
@@ -290,8 +296,8 @@ int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
     auto fd = mkstemp(tmpFile);
     if (fd == -1)
     {
-        std::cerr << "failed to create a temporary pel, ERROR=" << errno
-                  << "\n";
+        error("failed to create a temporary pel, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", errno);
         return PLDM_ERROR;
     }
 
@@ -309,8 +315,9 @@ int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
 
     if (rc == -1)
     {
-        std::cerr << "file write failed, ERROR=" << errno
-                  << ", LENGTH=" << length << ", OFFSET=" << offset << "\n";
+        error(
+            "file write failed, ERROR={ERR_EXCEP}, LENGTH={LEN}, OFFSET={OFFSET}",
+            "ERR_EXCEP", errno, "LEN", length, "ERR_EXCEP", offset);
         fs::remove(tmpFile);
         return PLDM_ERROR;
     }
@@ -321,8 +328,8 @@ int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
         rc = storePel(path.string());
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "save PEL failed, ERROR = " << rc
-                      << "tmpFile = " << tmpFile << "\n";
+            error("save PEL failed, ERROR = {RC} tmpFile = {TMP_FILE}", "KEY0",
+                  rc, "TMP_FILE", tmpFile);
         }
     }
 

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
@@ -2,12 +2,14 @@
 
 #include "common/utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace responder
 {
-
 int ProgressCodeHandler::setRawBootProperty(
     const std::tuple<uint64_t, std::vector<uint8_t>>& progressCodeBuffer)
 {
@@ -35,8 +37,9 @@ int ProgressCodeHandler::setRawBootProperty(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a d-bus call to host-postd daemon, ERROR="
-                  << e.what() << "\n";
+        error(
+            "failed to make a d-bus call to host-postd daemon, ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
 

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
@@ -7,7 +7,11 @@
 
 #include <stdint.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 typedef uint8_t byte;
 
@@ -41,8 +45,9 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Get keyword error from dbus interface : "
-                  << keywrdInterface << " ERROR= " << e.what() << std::endl;
+        error(
+            "Get keyword error from dbus interface : {INTF} ERROR= {ERR_EXCEP}",
+            "INTF", keywrdInterface, "ERR_EXCEP", e.what());
     }
 
     auto keywrdSize = std::get<std::vector<byte>>(keywrd).size();
@@ -69,8 +74,8 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
     auto fd = open(keywrdFilePath, std::ios::out | std::ofstream::binary);
     if (!keywrdFile)
     {
-        std::cerr << "VPD keyword file open error: " << keywrdFilePath
-                  << " errno: " << errno << std::endl;
+        error("VPD keyword file open error: {KEYWRD_PATH} errno: {ERR}",
+              "KEYWRD_PATH", keywrdFilePath, "ERR", errno);
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.readKeywordHandler.keywordFileOpenError",
             pldm::PelSeverity::ERROR);
@@ -98,8 +103,8 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
                      keywrdSize);
     if (keywrdFile.bad())
     {
-        std::cerr << "Error while writing to file: " << keywrdFilePath
-                  << std::endl;
+        error("Error while writing to file: {KEYWRD_PATH}", "KEYWRD_PATH",
+              keywrdFilePath);
     }
     keywrdFile.close();
 
@@ -107,8 +112,8 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
     fs::remove(keywrdFilePath);
     if (rc)
     {
-        std::cerr << "Read error for keyword file with size: " << keywrdSize
-                  << std::endl;
+        error("Read error for keyword file with size: {KEYWRD_SIZE}",
+              "KEYWRD_SIZE", keywrdSize);
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.readKeywordHandler.keywordFileReadError",
             pldm::PelSeverity::ERROR);

--- a/oem/ibm/libpldmresponder/file_table.cpp
+++ b/oem/ibm/libpldmresponder/file_table.cpp
@@ -2,30 +2,31 @@
 
 #include "libpldm/utils.h"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <fstream>
 #include <iostream>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace filetable
 {
-
 FileTable::FileTable(const std::string& fileTableConfigPath)
 {
     std::ifstream jsonFile(fileTableConfigPath);
     if (!jsonFile.is_open())
     {
-        std::cerr << "File table config file does not exist, FILE="
-                  << fileTableConfigPath.c_str() << "\n";
+        error("File table config file does not exist, FILE={FILE_TABLE_CONF}",
+              "FILE_TABLE_CONF", fileTableConfigPath.c_str());
         return;
     }
 
     auto data = Json::parse(jsonFile, nullptr, false);
     if (data.is_discarded())
     {
-        std::cerr << "Parsing config file failed"
-                  << "\n";
+        error("Parsing config file failed");
         return;
     }
 

--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -1,12 +1,15 @@
 #include "fru_oem_ibm.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 namespace responder
 {
 namespace oem_ibm_fru
 {
-
 void pldm::responder::oem_ibm_fru::Handler::setFruHandler(
     pldm::responder::fru::Handler* handler)
 {
@@ -151,8 +154,8 @@ void Handler::dbus_map_update(const std::string& adapterObjPath,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To set " << propertyName << "property"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed To set {PROP_NAME} property ERROR={ERR_EXCEP}",
+              "PROP_NAME", propertyName, "ERR_EXCEP", e.what());
     }
 }
 
@@ -170,15 +173,14 @@ void Handler::setFruPresence(const std::string& adapterObjPath)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to set the present property"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed to set the present property ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 }
 
 void Handler::setFirmwareUAK(std::vector<uint8_t> data)
 {
-    std::cout << "Got a SetFRURecordTable cmd from host to set the firmware UAK"
-              << std::endl;
+    info("Got a SetFRURecordTable cmd from host to set the firmware UAK");
     static constexpr auto uakObjPath = "/com/ibm/VPD/Manager";
     static constexpr auto uakInterface = "com.ibm.VPD.Manager";
 
@@ -200,8 +202,8 @@ void Handler::setFirmwareUAK(std::vector<uint8_t> data)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed to make a DBus call to VPD manager, ERROR="
-                  << e.what() << "\n";
+        error("failed to make a DBus call to VPD manager, ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return;
     }
 }

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -8,7 +8,11 @@
 #include "libpldmresponder/file_io.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <regex>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace pldm::pdr;
 using namespace pldm::utils;
@@ -139,7 +143,7 @@ int pldm::responder::oem_ibm_platform::Handler::
                 if (stateField[currState].effecter_state ==
                     uint8_t(CodeUpdateState::START))
                 {
-                    std::cout << "Received Start Update Request From PHYP\n";
+                    info("Received Start Update Request From PHYP");
                     codeUpdate->setCodeUpdateProgress(true);
                     startUpdateEvent =
                         std::make_unique<sdeventplus::source::Defer>(
@@ -151,7 +155,7 @@ int pldm::responder::oem_ibm_platform::Handler::
                 else if (stateField[currState].effecter_state ==
                          uint8_t(CodeUpdateState::END))
                 {
-                    std::cout << "Received End Update Request From PHYP\n";
+                    info("Received End Update Request From PHYP");
                     rc = PLDM_SUCCESS;
                     assembleImageEvent = std::make_unique<
                         sdeventplus::source::Defer>(
@@ -166,7 +170,7 @@ int pldm::responder::oem_ibm_platform::Handler::
                 else if (stateField[currState].effecter_state ==
                          uint8_t(CodeUpdateState::ABORT))
                 {
-                    std::cout << "Received Abort Update Request From PHYP\n";
+                    info("Received Abort Update Request From PHYP");
                     codeUpdate->setCodeUpdateProgress(false);
                     codeUpdate->clearDirPath(LID_STAGING_DIR);
                     auto sensorId = codeUpdate->getFirmwareUpdateSensor();
@@ -201,7 +205,7 @@ int pldm::responder::oem_ibm_platform::Handler::
             {
                 if (stateField[currState].effecter_state == POWER_CYCLE_HARD)
                 {
-                    std::cout << "Got a Deep IPL request" << std::endl;
+                    info("Got a Deep IPL request");
                     systemRebootEvent =
                         std::make_unique<sdeventplus::source::Defer>(
                             event,
@@ -274,8 +278,8 @@ void buildAllCodeUpdateEffecterPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
     pdr->hdr.record_handle = 0;
@@ -325,8 +329,8 @@ void buildAllSlotEnabeEffecterPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
 
@@ -391,8 +395,8 @@ void buildAllCodeUpdateSensorPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_SENSOR_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_SENSOR_ID));
         return;
     }
     pdr->hdr.record_handle = 0;
@@ -440,8 +444,8 @@ void buildAllSlotEnableSensorPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_SENSOR_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_SENSOR_ID));
         return;
     }
     auto& associatedEntityMap = platformHandler->getAssociateEntityMap();
@@ -502,8 +506,8 @@ void buildAllNumericEffecterPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_numeric_effecter_value_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
 
@@ -582,8 +586,8 @@ void buildAllSystemPowerStateEffecterPDR(
         reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
     pdr->hdr.record_handle = 0;
@@ -647,8 +651,9 @@ void attachOemEntityToEntityAssociationPDR(
         {
             // parent node not found in the entity association tree,
             // this should not be possible
-            std::cerr << "Parent Entity of type " << parent_entity.entity_type
-                      << " not found in the BMC Entity Association tree\n";
+            error(
+                "Parent Entity of type {ENTITY_TYP} not found in the BMC Entity Association tree ",
+                "ENTITY_TYP", static_cast<unsigned>(parent_entity.entity_type));
             return;
         }
         uint32_t bmc_record_handle = 0;
@@ -706,8 +711,10 @@ std::filesystem::path pldm::responder::oem_ibm_platform::Handler::getConfigDir()
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Error getting Names property , PATH=" << objectPath
-                      << " Compatible interface =" << ibmCompatible[0] << "\n";
+            error(
+                "Error getting Names property , PATH={OBJ_PATH} Compatible interface = {INTF}",
+                "OBJ_PATH", objectPath.c_str(), "INTF",
+                ibmCompatible[0].c_str());
         }
     }
     return fs::path();
@@ -727,8 +734,8 @@ void buildAllRealSAIEffecterPDR(oem_ibm_platform::Handler* platformHandler,
         reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
     if (!pdr)
     {
-        std::cerr << "Failed to get record by PDR type, ERROR:"
-                  << PLDM_PLATFORM_INVALID_EFFECTER_ID << std::endl;
+        error("Failed to get record by PDR type, ERROR:{ERR}", "ERR", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
         return;
     }
     pdr->hdr.record_handle = 0;
@@ -846,10 +853,9 @@ int pldm::responder::oem_ibm_platform::Handler::sendEventToHost(
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << " for code update event rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: for code update event rc={RC}, cc={CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
     auto rc = handler->registerRequest(
@@ -858,7 +864,7 @@ int pldm::responder::oem_ibm_platform::Handler::sendEventToHost(
         std::move(oemPlatformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send BIOS attribute change event message \n";
+        error("Failed to send BIOS attribute change event message");
     }
 
     return rc;
@@ -917,9 +923,9 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
             request);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr
-                << " Set state effecter state command failure. PLDM error code ="
-                << rc << std::endl;
+            error(
+                " Set state effecter state command failure. PLDM error code ={RC}",
+                "RC", rc);
             requester.markFree(mctp_eid, instanceId);
             return;
         }
@@ -928,8 +934,8 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
                       size_t respMsgLen) {
             if (response == nullptr || !respMsgLen)
             {
-                std::cerr << "Failed to receive response for "
-                          << "setstateEffecterSates command\n";
+                error(
+                    "Failed to receive response for setstateEffecterSates command");
                 return;
             }
             uint8_t completionCode{};
@@ -937,17 +943,17 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
                 response, respMsgLen, &completionCode);
             if (rc)
             {
-                std::cerr << "Failed to decode setStateEffecterStates response,"
-                          << " rc " << rc << "\n";
+                error(
+                    "Failed to decode setStateEffecterStates response,rc= {RC}",
+                    "RC", static_cast<unsigned>(rc));
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
                     pldm::PelSeverity::ERROR);
             }
             if (completionCode)
             {
-                std::cerr << "Failed to set a Host effecter "
-                          << ", cc=" << static_cast<unsigned>(completionCode)
-                          << "\n";
+                error("Failed to set a Host effecter, cc={CC}", "CC",
+                      static_cast<unsigned>(completionCode));
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
                     pldm::PelSeverity::ERROR);
@@ -959,7 +965,7 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
             std::move(setStateEffecterStatesRespHandler));
         if (rc)
         {
-            std::cerr << "Failed to send request to set an effecter on Host \n";
+            error("Failed to send request to set an effecter on Host");
         }
     }
 }
@@ -1034,9 +1040,9 @@ int pldm::responder::oem_ibm_platform::Handler::setNumericEffecter(
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Failed to make a DBus call as the dump policy is disabled,ERROR= "
-            << e.what() << "\n";
+        error(
+            "Failed to make a DBus call as the dump policy is disabled,ERROR= {ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         // case when the dump policy is disabled but we set the host effecter as
         // true and the host moves on
         setHostEffecterState(true);
@@ -1086,16 +1092,14 @@ void pldm::responder::oem_ibm_platform::Handler::sendStateSensorEvent(
                              instanceId);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to encode state sensor event, rc = " << rc
-                  << std::endl;
+        error("Failed to encode state sensor event, rc = {RC}", "RC", rc);
         requester.markFree(mctp_eid, instanceId);
         return;
     }
     rc = sendEventToHost(requestMsg, instanceId);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to send event to host: "
-                  << "rc=" << rc << std::endl;
+        error("Failed to send event to host: rc={RC}", "RC", rc);
     }
     return;
 }
@@ -1104,7 +1108,7 @@ void pldm::responder::oem_ibm_platform::Handler::_processEndUpdate(
     sdeventplus::source::EventBase& /*source */)
 {
     assembleImageEvent.reset();
-    std::cout << "Starting assembleCodeUpdateImage \n";
+    info("Starting assembleCodeUpdateImage");
     int retc = codeUpdate->assembleCodeUpdateImage();
     if (retc != PLDM_SUCCESS)
     {
@@ -1124,11 +1128,11 @@ void pldm::responder::oem_ibm_platform::Handler::_processStartUpdate(
     auto rc = codeUpdate->setRequestedApplyTime();
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "setRequestedApplyTime failed \n";
+        error("setRequestedApplyTime failed");
         state = CodeUpdateState::FAIL;
     }
     auto sensorId = codeUpdate->getFirmwareUpdateSensor();
-    std::cout << "Sending Start Update sensor event to PHYP\n";
+    info("Sending Start Update sensor event to PHYP");
     sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0, uint8_t(state),
                          uint8_t(CodeUpdateState::END));
 }
@@ -1168,14 +1172,14 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                                          "RequestedPowerTransition", "string"};
     try
     {
-        std::cout << "InbandCodeUpdate: ChassifOff the host\n";
+        info("InbandCodeUpdate: ChassifOff the host");
         dBusIntf->setDbusProperty(dbusMapping, value);
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Chassis State transition to Off failed,"
-                  << "unable to set property RequestedPowerTransition"
-                  << "ERROR=" << e.what() << "\n";
+        error(
+            "Chassis State transition to Off failed, unable to set property RequestedPowerTransition ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
 
     using namespace sdbusplus::bus::match::rules;
@@ -1203,15 +1207,14 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                         "Policy.AlwaysOn";
                 try
                 {
-                    std::cout
-                        << "InbandCodeUpdate: Setting the one time APR policy\n";
+                    info("InbandCodeUpdate: Setting the one time APR policy");
                     dBusIntf->setDbusProperty(dbusMapping, value);
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr << "Setting one-time restore policy failed,"
-                              << "unable to set property PowerRestorePolicy"
-                              << "ERROR=" << e.what() << "\n";
+                    error(
+                        "Setting one-time restore policy failed, unable to set property PowerRestorePolicy ERROR={ERR_EXCEP}",
+                        "ERR_EXCEP", e.what());
                 }
                 dbusMapping = pldm::utils::DBusMapping{
                     "/xyz/openbmc_project/state/bmc0",
@@ -1220,15 +1223,14 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                 value = "xyz.openbmc_project.State.BMC.Transition.Reboot";
                 try
                 {
-                    std::cout << "InbandCodeUpdate: Rebooting the BMC\n";
+                    info("InbandCodeUpdate: Rebooting the BMC");
                     dBusIntf->setDbusProperty(dbusMapping, value);
                 }
                 catch (const std::exception& e)
                 {
-                    std::cerr << "BMC state transition to reboot failed,"
-                              << "unable to set property "
-                                 "RequestedBMCTransition"
-                              << "ERROR=" << e.what() << "\n";
+                    error(
+                        "BMC state transition to reboot failed, unable to set property RequestedBMCTransition ERROR={ERR_EXCEP}",
+                        "ERR_EXCEP", e.what());
                 }
             }
         }
@@ -1290,8 +1292,9 @@ void pldm::responder::oem_ibm_platform::Handler::resetWatchDogTimer()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To reset watchdog timer"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed To reset watchdog timer ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
+
         return;
     }
 }
@@ -1314,8 +1317,8 @@ void pldm::responder::oem_ibm_platform::Handler::disableWatchDogTimer()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed To disable watchdog timer"
-                  << "ERROR=" << e.what() << "\n";
+        error("Failed To disable watchdog timer ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
     }
 }
 int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
@@ -1330,14 +1333,14 @@ int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
         if (std::get<std::string>(propertyValue) !=
             "xyz.openbmc_project.State.BMC.BMCState.Ready")
         {
-            std::cerr << "GetPDR : PLDM stack is not ready for PDR exchange"
-                      << std::endl;
+            error("GetPDR : PLDM stack is not ready for PDR exchange");
+
             return PLDM_ERROR_NOT_READY;
         }
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Error getting the current BMC state" << std::endl;
+        error("Error getting the current BMC state");
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;
@@ -1358,8 +1361,9 @@ void pldm::responder::oem_ibm_platform::Handler::setBitmapMethodCall(
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to call the D-Bus Method"
-                  << "ERROR=" << e.what() << std::endl;
+        error("Failed to call the D-Bus Method ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
+
         return;
     }
 }
@@ -1452,8 +1456,8 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtChassisOff()
     auto bootType = getBiosAttrValue("pvm_boot_type");
     if (bootInitiator.empty() || bootType.empty())
     {
-        std::cerr
-            << "ERROR in fetching the pvm_boot_initiator and pvm_boot_type BIOS attribute values\n";
+        error(
+            "ERROR in fetching the pvm_boot_initiator and pvm_boot_type BIOS attribute values");
         return;
     }
     else if (bootInitiator != "Host")
@@ -1475,8 +1479,8 @@ void pldm::responder::oem_ibm_platform::Handler::turnOffRealSAIEffecter()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to turn off partition SAI effecter"
-                  << "ERROR=" << e.what() << "\n";
+        error("Failed to turn off partition SAI effecter ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
     try
     {
@@ -1487,8 +1491,8 @@ void pldm::responder::oem_ibm_platform::Handler::turnOffRealSAIEffecter()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to turn off platform SAI effecter"
-                  << "ERROR=" << e.what() << "\n";
+        error("Failed to turn off platform SAI effecter ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
 }
 
@@ -1517,8 +1521,8 @@ uint8_t pldm::responder::oem_ibm_platform::Handler::fetchRealSAIStatus()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed to fetch Real SAI sensor status"
-                  << "ERROR=" << e.what() << "\n";
+        error("Failed to fetch Real SAI sensor status ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
     }
     return PLDM_SENSOR_NORMAL;
 }
@@ -1526,7 +1530,7 @@ uint8_t pldm::responder::oem_ibm_platform::Handler::fetchRealSAIStatus()
 void pldm::responder::oem_ibm_platform::Handler::
     processPowerCycleOffSoftGraceful()
 {
-    std::cerr << "Received soft graceful power cycle request" << std::endl;
+    error("Received soft graceful power cycle request");
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot";
     pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/host0",
@@ -1538,15 +1542,15 @@ void pldm::responder::oem_ibm_platform::Handler::
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Error to do a ForceWarmReboot, chassis power remains on, and boot the host back up. Unable to set property RequestedHostTransition. ERROR="
-            << e.what() << "\n";
+        error(
+            "Error to do a ForceWarmReboot, chassis power remains on, and boot the host back up. Unable to set property RequestedHostTransition. ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
 }
 
 void pldm::responder::oem_ibm_platform::Handler::processPowerOffSoftGraceful()
 {
-    std::cerr << "Received soft power off graceful request" << std::endl;
+    error("Received soft power off graceful request");
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.State.Chassis.Transition.Off";
     pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/chassis0",
@@ -1558,15 +1562,15 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffSoftGraceful()
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Error in powering down the host. Unable to set property RequestedPowerTransition. ERROR="
-            << e.what() << "\n";
+        error(
+            "Error in powering down the host. Unable to set property RequestedPowerTransition. ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
 }
 
 void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
 {
-    std::cerr << "Received hard power off graceful request" << std::endl;
+    error("Received hard power off graceful request");
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn";
     pldm::utils::DBusMapping dbusMapping{
@@ -1588,9 +1592,9 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
     }
     catch (const std::exception& e)
     {
-        std::cerr
-            << "Setting one-time restore policy failed, Unable to set property PowerRestorePolicy. ERROR="
-            << e.what() << "\n";
+        error(
+            "Setting one-time restore policy failed, Unable to set property PowerRestorePolicy. ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
     }
     processPowerOffSoftGraceful();
 }
@@ -1626,9 +1630,10 @@ void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
     }
     else if (!value && timer.isEnabled())
     {
-        std::cout << "setSurvTimer:LogginPel:hostOff=" << (bool)hostOff
-                  << " hostTransitioningToOff=" << (bool)hostTransitioningToOff
-                  << " tid=" << (uint16_t)tid << std::endl;
+        info(
+            "setSurvTimer:LogginPel:hostOff={HOST_OFF} hostTransitioningToOff={HOST_TRANST_OFF} tid={TID}",
+            "HOST_OFF", (bool)hostOff, "HOST_TRANST_OFF",
+            (bool)hostTransitioningToOff, "TID", (uint16_t)tid);
         startStopTimer(false);
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.setSurvTimer.RecvSurveillancePingFail",
@@ -1639,7 +1644,8 @@ void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
 void pldm::responder::oem_ibm_platform::Handler::propertyChanged(
     const DbusChangedProps& chProperties, std::string objPath)
 {
-    std::cerr << "Got a link reset set for CEC path: " << objPath << std::endl;
+    error("Got a link reset set for CEC path: {OBJ_PATH}", "OBJ_PATH",
+          objPath.c_str());
     static constexpr auto propName = "linkReset";
     const auto it = chProperties.find(propName);
     if (it == chProperties.end())
@@ -1698,9 +1704,9 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
 
         if (stateEffecterPDRs.empty())
         {
-            std::cerr
-                << "PCIe CEC LinkReset: The state set PDR can not be found, entityType = "
-                << entityType << std::endl;
+            error(
+                "PCIe CEC LinkReset: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+                "ENTITY_TYP", entityType);
             return;
         }
 
@@ -1716,8 +1722,9 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to fetch the BusID of the slot. ERROR= "
-                      << e.what() << std::endl;
+            error("Failed to fetch the BusID of the slot. ERROR= {ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
+
             return;
         }
 
@@ -1731,13 +1738,14 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
             }
         }
 
-        std::cerr << "Sending effecter call to host with effecter ID : "
-                  << effecterID << "and BusID : " << instanceId << std::endl;
+        error(
+            "Sending effecter call to host with effecter ID : {EFFECTER_ID} and BusID : {BUS_ID}",
+            "EFFECTER_ID", effecterID, "BUS_ID", instanceId);
         hostEffecterParser->sendSetStateEffecterStates(
             mctp_eid, effecterID, 1, stateField, nullptr, value);
-
-        std::cerr << "Setting link reset on link: " << path
-                  << " is successful setting it back to false" << std::endl;
+        error(
+            "Setting link reset on link: {LINK_PATH} is successful setting it back to false",
+            "LINK_PATH", path.c_str());
         pldm::utils::DBusMapping dbusMapping;
         dbusMapping.objectPath = path;
         dbusMapping.interface = "com.ibm.Control.Host.PCIeLink";
@@ -1750,8 +1758,8 @@ void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Failed to set the link reset property. ERROR = "
-                      << e.what() << std::endl;
+            error("Failed to set the link reset property. ERROR = {ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
             return;
         }
     }

--- a/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
@@ -6,9 +6,12 @@
 #include "common/utils.hpp"
 #include "libpldmresponder/pdr.hpp"
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
@@ -16,7 +19,6 @@ namespace responder
 {
 namespace platform
 {
-
 int sendBiosAttributeUpdateEvent(
     uint8_t eid, dbus_api::Requester* requester,
     const std::vector<uint16_t>& handles,
@@ -66,8 +68,8 @@ int sendBiosAttributeUpdateEvent(
         requestMsg.size() - sizeof(pldm_msg_hdr), request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message encode failure 1. PLDM error code = " << std::hex
-                  << std::showbase << rc << "\n";
+        error("Message encode failure 1. PLDM error code = {RC}", "RC",
+              lg2::hex, rc);
         requester->markFree(eid, instanceId);
         return rc;
     }
@@ -87,8 +89,7 @@ int sendBiosAttributeUpdateEvent(
         [](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)
         {
-            std::cerr
-                << "Failed to receive response for platform event message \n";
+            error("Failed to receive response for platform event message");
             return;
         }
         uint8_t completionCode{};
@@ -97,10 +98,9 @@ int sendBiosAttributeUpdateEvent(
                                                      &completionCode, &status);
         if (rc || completionCode)
         {
-            std::cerr << "Failed to decode_platform_event_message_resp: "
-                      << "rc=" << rc
-                      << ", cc=" << static_cast<unsigned>(completionCode)
-                      << std::endl;
+            error(
+                "Failed to decode_platform_event_message_resp: RC = {RC}, cc = {CC}",
+                "RC", rc, "CC", static_cast<unsigned>(completionCode));
         }
     };
     rc = handler->registerRequest(
@@ -108,7 +108,7 @@ int sendBiosAttributeUpdateEvent(
         std::move(requestMsg), std::move(platformEventMessageResponseHandler));
     if (rc)
     {
-        std::cerr << "Failed to send the platform event message \n";
+        error("Failed to send the platform event message");
     }
 
     return rc;

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -11,6 +11,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <exception>
@@ -18,12 +19,13 @@
 #include <iostream>
 #include <mutex>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
 using namespace pldm::dbus;
 namespace responder
 {
-
 std::atomic<SocketWriteStatus> socketWriteStatus = Free;
 std::mutex lockMutex;
 
@@ -59,7 +61,7 @@ int setupUnixSocket(const std::string& socketInterface)
     if (strnlen(socketInterface.c_str(), sizeof(addr.sun_path)) ==
         sizeof(addr.sun_path))
     {
-        std::cerr << "setupUnixSocket: UNIX socket path too long" << std::endl;
+        error("setupUnixSocket: UNIX socket path too long");
         return -1;
     }
 
@@ -67,21 +69,21 @@ int setupUnixSocket(const std::string& socketInterface)
 
     if ((sock = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0)) == -1)
     {
-        std::cerr << "setupUnixSocket: socket() call failed" << std::endl;
+        error("setupUnixSocket: socket() call failed");
         return -1;
     }
 
     if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) == -1)
     {
-        std::cerr << "setupUnixSocket: bind() call failed  with errno " << errno
-                  << std::endl;
+        error("setupUnixSocket: bind() call failed  with errno {ERR}", "ERR",
+              errno);
         close(sock);
         return -1;
     }
 
     if (listen(sock, 1) == -1)
     {
-        std::cerr << "setupUnixSocket: listen() call failed" << std::endl;
+        error("setupUnixSocket: listen() call failed");
         close(sock);
         return -1;
     }
@@ -99,8 +101,7 @@ int setupUnixSocket(const std::string& socketInterface)
     int retval = select(nfd, &rfd, NULL, NULL, &tv);
     if (retval < 0)
     {
-        std::cerr << "setupUnixSocket: select call failed " << errno
-                  << std::endl;
+        error("setupUnixSocket: select call failed {ERR}", "ERR", errno);
         close(sock);
         return -1;
     }
@@ -110,8 +111,7 @@ int setupUnixSocket(const std::string& socketInterface)
         fd = accept(sock, NULL, NULL);
         if (fd < 0)
         {
-            std::cerr << "setupUnixSocket: accept() call failed " << errno
-                      << std::endl;
+            error("setupUnixSocket: accept() call failed {ERR}", "ERR", errno);
             close(sock);
             return -1;
         }
@@ -147,8 +147,7 @@ void writeToUnixSocket(const int sock, const char* buf,
         int retval = select(nfd, NULL, &wfd, NULL, &tv);
         if (retval < 0)
         {
-            std::cerr << "writeToUnixSocket: select call failed " << errno
-                      << std::endl;
+            error("writeToUnixSocket: select call failed {ERR}", "ERR", errno);
             close(sock);
             socketWriteStatus = Error;
             munmap((void*)buf, blockSize);
@@ -167,14 +166,12 @@ void writeToUnixSocket(const int sock, const char* buf,
             {
                 if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
                 {
-                    std::cerr << "writeToUnixSocket: Write call failed with "
-                                 "EAGAIN or EWOULDBLOCK or EINTR"
-                              << std::endl;
+                    error(
+                        "writeToUnixSocket: Write call failed with EAGAIN or EWOULDBLOCK or EINTR");
                     nwrite = 0;
                     continue;
                 }
-                std::cerr << "writeToUnixSocket: Failed to write " << errno
-                          << std::endl;
+                error("writeToUnixSocket: Failed to write {ERR}", "ERR", errno);
                 close(sock);
                 socketWriteStatus = Error;
                 munmap((void*)buf, blockSize);
@@ -460,7 +457,8 @@ void findPortObjects(const std::string& cardObjPath,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "no ports under card " << cardObjPath << "\n";
+        error("no ports under card {CARD_OBJ_PATH}", "CARD_OBJ_PATH",
+              cardObjPath.c_str());
     }
 }
 
@@ -534,8 +532,8 @@ std::string getObjectPathByLocationCode(const std::string& locationCode,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Look up of inventory objects failed for location "
-                  << locationCode << std::endl;
+        error("Look up of inventory objects failed for location {LOC_CODE}",
+              "LOC_CODE", locationCode);
         return path;
     }
 
@@ -557,8 +555,8 @@ std::string getObjectPathByLocationCode(const std::string& locationCode,
             }
         }
     }
-    std::cerr << "Location not found " << locationCode << " for Item type "
-              << inventoryItemType << std::endl;
+    error("Location not found {LOC_CODE} for Item type {INVEN_ITEM_TYP}",
+          "LOC_CODE", locationCode, "INVEN_ITEM_TYP", inventoryItemType);
     return path;
 }
 
@@ -592,7 +590,8 @@ void findSlotObjects(const std::string& boardObjPath,
     }
     catch (const std::exception& e)
     {
-        std::cerr << "no cec slots under motherboard" << boardObjPath << "\n";
+        error("no cec slots under motherboard {BOARD_OBJ_PATH}",
+              "BOARD_OBJ_PATH", boardObjPath.c_str());
     }
 }
 

--- a/pldmd/instance_id.cpp
+++ b/pldmd/instance_id.cpp
@@ -1,10 +1,13 @@
 #include "instance_id.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <stdexcept>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
-
 uint8_t InstanceId::next()
 {
     uint8_t idx = 0;
@@ -17,7 +20,7 @@ uint8_t InstanceId::next()
     {
         // check all the instance ids and free up the one
         // that is acquired oldest
-        std::cerr << "all the Instance ids are exhausted \n";
+        error("lg2 all the Instance ids are exhausted");
 
         auto instance = returnOldestId();
         if (instance.has_value())
@@ -61,8 +64,8 @@ std::optional<uint8_t> InstanceId::returnOldestId()
     }
     if (skipInstance)
     {
-        std::cerr
-            << "None of the instance id's are older then the pldm instance id expiration time\n";
+        error(
+            "lg2 None of the instance id's are older then the pldm instance id expiration time");
         return std::nullopt;
     }
     const std::time_t t_c =

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -22,6 +22,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/source/io.hpp>
 #include <sdeventplus/source/signal.hpp>
@@ -73,11 +74,12 @@ using namespace pldm::responder;
 using namespace pldm::utils;
 using sdeventplus::source::Signal;
 using namespace pldm::flightrecorder;
+PHOSPHOR_LOG2_USING;
 
 void interruptFlightRecorderCallBack(Signal& /*signal*/,
                                      const struct signalfd_siginfo*)
 {
-    std::cerr << "\nReceived SIGUR1(10) Signal interrupt\n";
+    info("Received SIGUR1(10) Signal interrupt");
 
     // obtain the flight recorder instance and dump the recorder
     FlightRecorder::GetInstance().playRecorder();
@@ -96,7 +98,7 @@ static std::optional<Response>
         requestMsg.data() + sizeof(eid) + sizeof(type));
     if (PLDM_SUCCESS != unpack_pldm_header(hdr, &hdrFields))
     {
-        std::cerr << "Empty PLDM request header \n";
+        info("Empty PLDM request header");
         return std::nullopt;
     }
 
@@ -132,7 +134,7 @@ static std::optional<Response>
             header.command = hdrFields.command;
             if (PLDM_SUCCESS != pack_pldm_header(&header, responseHdr))
             {
-                std::cerr << "Failed adding response header \n";
+                error("Failed adding response header");
                 return std::nullopt;
             }
             response.insert(response.end(), completion_code);
@@ -152,9 +154,9 @@ static std::optional<Response>
 
 void optionUsage(void)
 {
-    std::cerr << "Usage: pldmd [options]\n";
-    std::cerr << "Options:\n";
-    std::cerr << "  [--verbose] - would enable verbosity\n";
+    error("Usage: pldmd [options]");
+    error("Options:");
+    error(" [--verbose] - would enable verbosity");
 }
 
 int main(int argc, char** argv)
@@ -181,7 +183,7 @@ int main(int argc, char** argv)
     if (-1 == sockfd)
     {
         returnCode = -errno;
-        std::cerr << "Failed to create the socket, RC= " << returnCode << "\n";
+        error("Failed to create the socket, RC={RC}", "RC", returnCode);
         exit(EXIT_FAILURE);
     }
     socklen_t optlen;
@@ -194,8 +196,8 @@ int main(int argc, char** argv)
                          &optlen);
     if (res == -1)
     {
-        std::cerr << "Error calling setsockopt. RC = " << res
-                  << ", errno = " << errno << std::endl;
+        error("Error calling setsockopt. RC = {RC}, errno = {ERR}", "RC", res,
+              "ERR", errno);
     }
     auto event = Event::get_default();
     auto& bus = pldm::utils::DBusHandler::getBus();
@@ -338,8 +340,7 @@ int main(int argc, char** argv)
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Failed to connect to the socket, RC= " << returnCode
-                  << "\n";
+        error("Failed to connect to the socket, RC= {RC}", "RC", returnCode);
         exit(EXIT_FAILURE);
     }
 
@@ -347,8 +348,9 @@ int main(int argc, char** argv)
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Failed to send message type as pldm to mctp, RC= "
-                  << returnCode << "\n";
+        error("Failed to send message type as pldm to mctp, RC= {RC}", "RC",
+              returnCode);
+
         exit(EXIT_FAILURE);
     }
 
@@ -386,7 +388,7 @@ int main(int argc, char** argv)
         else if (peekedLength <= -1)
         {
             returnCode = -errno;
-            std::cerr << "recv system call failed, RC= " << returnCode << "\n";
+            error("recv system call failed, RC= {RC}", "RC", returnCode);
         }
         else
         {
@@ -404,8 +406,7 @@ int main(int argc, char** argv)
                 if (MCTP_MSG_TYPE_PLDM != requestMsg[1])
                 {
                     // Skip this message and continue.
-                    std::cerr << "Encountered Non-PLDM type message"
-                              << "\n";
+                    error("Encountered Non-PLDM type message");
                 }
                 else
                 {
@@ -439,13 +440,11 @@ int main(int argc, char** argv)
                                                  sizeof(currentSendbuffSize));
                             if (res == -1)
                             {
-                                std::cerr
-                                    << "Responder : Failed to set the new send buffer size [bytes] : "
-                                    << currentSendbuffSize
-                                    << " from current size [bytes] : "
-                                    << oldBuffSize
-                                    << ", Error : " << strerror(errno)
-                                    << std::endl;
+                                error(
+                                    "Responder : Failed to set the new send buffer size [bytes] : {CUR_BUFF_SIZE} from current size [bytes] : {OLD_BUFF_SIZE}, Error : {ERR}",
+                                    "CUR_BUFF_SIZE", currentSendbuffSize,
+                                    "OLD_BUFF_SIZE", oldBuffSize, "ERR",
+                                    strerror(errno));
                                 return;
                             }
                         }
@@ -454,18 +453,17 @@ int main(int argc, char** argv)
                         if (-1 == result)
                         {
                             returnCode = -errno;
-                            std::cerr << "sendto system call failed, RC= "
-                                      << returnCode << "\n";
+                            error("sendto system call failed, RC= {RC}", "RC",
+                                  returnCode);
                         }
                     }
                 }
             }
             else
             {
-                std::cerr
-                    << "Failure to read peeked length packet. peekedLength= "
-                    << peekedLength << " recvDataLength=" << recvDataLength
-                    << "\n";
+                error(
+                    "Failure to read peeked length packet. peekedLength = {PEEK_LEN}, recvDataLength= {RECV_DATA}",
+                    "PEEK_LEN", peekedLength, "RECV_DATA", recvDataLength);
             }
         }
     };
@@ -486,7 +484,7 @@ int main(int argc, char** argv)
 
     if (shutdown(sockfd, SHUT_RDWR))
     {
-        std::perror("Failed to shutdown the socket");
+        error("Failed to shutdown the socket");
     }
     if (returnCode)
     {

--- a/pldmtool/meson.build
+++ b/pldmtool/meson.build
@@ -27,6 +27,7 @@ executable(
     libpldmutils,
     nlohmann_json,
     phosphor_dbus_interfaces,
+    phosphor_logging_dep,
     sdbusplus,
   ],
   install: true,

--- a/pldmtool/pldm_base_cmd.cpp
+++ b/pldmtool/pldm_base_cmd.cpp
@@ -4,6 +4,8 @@
 
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #ifdef OEM_IBM
 #include "libpldm/file_io.h"
 #include "libpldm/host.h"
@@ -109,8 +111,8 @@ class GetPLDMTypes : public CommandInterface
                                         types.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 
@@ -181,8 +183,8 @@ class GetPLDMVersion : public CommandInterface
                                           &version);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         char buffer[16] = {0};
@@ -232,8 +234,8 @@ class GetTID : public CommandInterface
         auto rc = decode_get_tid_resp(responsePtr, payloadLength, &cc, &tid);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << "\n";
+            lg2::error("Response Message Error:rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         ordered_json data;
@@ -280,8 +282,8 @@ class GetPLDMCommands : public CommandInterface
                                            cmdTypes.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         printPldmCommands(cmdTypes, pldmType);

--- a/pldmtool/pldm_cmd_helper.cpp
+++ b/pldmtool/pldm_cmd_helper.cpp
@@ -5,6 +5,7 @@
 #include <libpldm/pldm.h>
 #include <systemd/sd-bus.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
 
@@ -31,7 +32,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == sockFd)
     {
         returnCode = -errno;
-        std::cerr << "Failed to create the socket : RC = " << sockFd << "\n";
+        lg2::error("Failed to create the socket : RC = {KEY0}", "KEY0", sockFd);
         return returnCode;
     }
     Logger(pldmVerbose, "Success in creating the socket : RC = ", sockFd);
@@ -48,8 +49,9 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Failed to connect to socket : RC = " << returnCode
-                  << "\n";
+        lg2::error("Failed to connect to socket : RC = {KEY0}", "KEY0",
+                   returnCode);
+
         return returnCode;
     }
     Logger(pldmVerbose, "Success in connecting to socket : RC = ", returnCode);
@@ -59,8 +61,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Failed to send message type as pldm to mctp : RC = "
-                  << returnCode << "\n";
+        lg2::error("Failed to send message type as pldm to mctp : RC = {KEY0}",
+                   "KEY0", returnCode);
         return returnCode;
     }
     Logger(
@@ -71,7 +73,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        std::cerr << "Write to socket failure : RC = " << returnCode << "\n";
+        lg2::error("Write to socket failure : RC = {KEY0}", "KEY0", returnCode);
         return returnCode;
     }
     Logger(pldmVerbose, "Write to socket successful : RC = ", result);
@@ -80,14 +82,16 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     ssize_t peekedLength = recv(socketFd(), nullptr, 0, MSG_TRUNC | MSG_PEEK);
     if (0 == peekedLength)
     {
-        std::cerr << "Socket is closed : peekedLength = " << peekedLength
-                  << "\n";
+        lg2::error("Socket is closed : peekedLength = {KEY0}", "KEY0",
+                   peekedLength);
+
         return returnCode;
     }
     else if (peekedLength <= -1)
     {
         returnCode = -errno;
-        std::cerr << "recv() system call failed : RC = " << returnCode << "\n";
+        lg2::error("recv() system call failed : RC = {KEY0}", "KEY0",
+                   returnCode);
         return returnCode;
     }
     else
@@ -112,8 +116,9 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
             }
             else if (recvDataLength != peekedLength)
             {
-                std::cerr << "Failure to read response length packet: length = "
-                          << recvDataLength << "\n";
+                lg2::error(
+                    "Failure to read response length packet: length = {KEY0}",
+                    "KEY0", recvDataLength);
                 return returnCode;
             }
         } while (1);
@@ -123,8 +128,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == returnCode)
     {
         returnCode = -errno;
-        std::cerr << "Failed to shutdown the socket : RC = " << returnCode
-                  << "\n";
+        lg2::error("Failed to shutdown the socket : RC ={KEY0}", "KEY0",
+                   returnCode);
         return returnCode;
     }
 
@@ -151,15 +156,17 @@ void CommandInterface::exec()
     }
     catch (const std::exception& e)
     {
-        std::cerr << "GetInstanceId D-Bus call failed, MCTP id = "
-                  << (unsigned)mctp_eid << ", error = " << e.what() << "\n";
+        lg2::error(
+            "GetInstanceId D-Bus call failed, MCTP id = {KEY0}, error = {KEY1}",
+            "KEY0", (unsigned)mctp_eid, "KEY1", e.what());
         return;
     }
     auto [rc, requestMsg] = createRequestMsg();
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Failed to encode request message for " << pldmType << ":"
-                  << commandName << " rc = " << rc << "\n";
+        lg2::error(
+            "Failed to encode request message for {KEY0} : {KEY1}, rc = {KEY1}",
+            "KEY0", pldmType, "KEY1", commandName, "KEY1", rc);
         return;
     }
 
@@ -168,7 +175,7 @@ void CommandInterface::exec()
 
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "pldmSendRecv: Failed to receive RC = " << rc << "\n";
+        lg2::error("pldmSendRecv: Failed to receive RC = {KEY0}", "KEY0", rc);
         return;
     }
 
@@ -203,8 +210,8 @@ int CommandInterface::pldmSendRecv(std::vector<uint8_t>& requestMsg,
         int fd = pldm_open();
         if (-1 == fd)
         {
-            std::cerr << "failed to init mctp "
-                      << "\n";
+            lg2::error("failed to init mctp ");
+
             return -1;
         }
         uint8_t* responseMessage = nullptr;

--- a/pldmtool/pldm_fru_cmd.cpp
+++ b/pldmtool/pldm_fru_cmd.cpp
@@ -2,6 +2,8 @@
 
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #ifdef OEM_IBM
 #include "libpldm/fru_oem_ibm.h"
 #endif
@@ -63,8 +65,9 @@ class GetFruRecordTableMetadata : public CommandInterface
             &total_record_set_identifiers, &total_table_records, &checksum);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
+
             return;
         }
         ordered_json output;
@@ -382,8 +385,8 @@ class GetFRURecordByOption : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 
@@ -434,8 +437,9 @@ class GetFruRecordTable : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)cc << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
+
             return;
         }
 

--- a/pldmtool/pldm_fw_update_cmd.cpp
+++ b/pldmtool/pldm_fw_update_cmd.cpp
@@ -5,6 +5,8 @@
 #include "common/utils.hpp"
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 namespace pldmtool
 {
 
@@ -92,8 +94,8 @@ class GetStatus : public CommandInterface
             &reasonCode, &updateOptionFlagsEnabled);
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
             return;
         }
 
@@ -177,9 +179,9 @@ class GetFwParams : public CommandInterface
             &pendingCompImageSetVersion, &compParameterTable);
         if (rc != PLDM_SUCCESS || fwParams.completion_code != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)fwParams.completion_code
-                      << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)fwParams.completion_code);
+
             return;
         }
 
@@ -267,9 +269,9 @@ class GetFwParams : public CommandInterface
                 &pendingCompVerStr);
             if (rc)
             {
-                std::cerr
-                    << "Decoding component parameter table entry failed, RC="
-                    << rc << "\n";
+                lg2::error(
+                    "Decoding component parameter table entry failed, RC={KEY0}",
+                    "KEY0", rc);
                 return;
             }
 

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -4,6 +4,8 @@
 #include "common/types.hpp"
 #include "pldm_cmd_helper.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <cstddef>
 #include <map>
 
@@ -119,10 +121,10 @@ class GetPDR : public CommandInterface
                                                   prevRecordHandle);
                 if (!result.second)
                 {
-                    std::cerr
-                        << "Record handle " << recordHandle
-                        << " has multiple references: " << result.first->second
-                        << ", " << prevRecordHandle << "\n";
+                    lg2::error(
+                        "Record handle {KEY0} has multiple references: {KEY1}, {KEY2}",
+                        "KEY0", recordHandle, "KEY1", result.first->second,
+                        "KEY2", prevRecordHandle);
                     return;
                 }
                 prevRecordHandle = recordHandle;
@@ -172,9 +174,8 @@ class GetPDR : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode
-                      << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
             return;
         }
 
@@ -731,7 +732,7 @@ class GetPDR : public CommandInterface
             reinterpret_cast<pldm_pdr_fru_record_set*>(data);
         if (!pdr)
         {
-            std::cerr << "Failed to get the FRU record set PDR" << std::endl;
+            lg2::error("Failed to get the FRU record set PDR");
             return;
         }
 
@@ -759,8 +760,7 @@ class GetPDR : public CommandInterface
             reinterpret_cast<pldm_pdr_entity_association*>(data);
         if (!pdr)
         {
-            std::cerr << "Failed to get the PDR eneity association"
-                      << std::endl;
+            lg2::error("Failed to get the PDR eneity association");
             return;
         }
 
@@ -772,7 +772,7 @@ class GetPDR : public CommandInterface
         }
         else
         {
-            std::cout << "Get associationType failed.\n";
+            lg2::info("Get associationType failed.");
         }
         output["containerEntityType"] =
             getEntityName(pdr->container.entity_type);
@@ -805,7 +805,7 @@ class GetPDR : public CommandInterface
             (struct pldm_numeric_effecter_value_pdr*)data;
         if (!pdr)
         {
-            std::cerr << "Failed to get numeric effecter PDR" << std::endl;
+            lg2::error("Failed to get numeric effecter PDR");
             return;
         }
 
@@ -1000,7 +1000,7 @@ class GetPDR : public CommandInterface
     {
         if (data == NULL)
         {
-            std::cerr << "Failed to get PDR message" << std::endl;
+            lg2::error("Failed to get PDR message");
             return;
         }
 
@@ -1020,8 +1020,9 @@ class GetPDR : public CommandInterface
             // is not supported
             if (!strToPdrType.contains(pdrRecType))
             {
-                std::cerr << "PDR type '" << pdrRecType
-                          << "' is not supported or invalid\n";
+                lg2::error("PDR type {KEY0} is not supported or invalid",
+                           "KEY0", pdrRecType);
+
                 // PDR type not supported, setting next record handle to 0
                 // to avoid looping through all PDR records
                 nextRecordHndl = 0;
@@ -1113,16 +1114,18 @@ class SetStateEffecter : public CommandInterface
         if (effecterCount > maxEffecterCount ||
             effecterCount < minEffecterCount)
         {
-            std::cerr << "Request Message Error: effecterCount size "
-                      << effecterCount << "is invalid\n";
+            lg2::error(
+                "Request Message Error: effecterCount size {KEY0} is invalid",
+                "KEY0", effecterCount);
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
 
         if (effecterData.size() > maxEffecterDataSize)
         {
-            std::cerr << "Request Message Error: effecterData size "
-                      << effecterData.size() << "is invalid\n";
+            lg2::error(
+                "Request Message Error: effecterData size {KEY0} is invalid",
+                "KEY0", effecterData.size());
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
@@ -1130,8 +1133,9 @@ class SetStateEffecter : public CommandInterface
         auto stateField = parseEffecterData(effecterData, effecterCount);
         if (!stateField)
         {
-            std::cerr << "Failed to parse effecter data, effecterCount size "
-                      << effecterCount << "\n";
+            lg2::error(
+                "Failed to parse effecter data, effecterCount size {KEY0}",
+                "KEY0", effecterCount);
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
@@ -1149,8 +1153,9 @@ class SetStateEffecter : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode << "\n";
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
+
             return;
         }
 
@@ -1230,9 +1235,9 @@ class SetNumericEffecterValue : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode
-                      << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
+
             return;
         }
 
@@ -1297,9 +1302,9 @@ class GetStateSensorReadings : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode
-                      << std::endl;
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
+
             return;
         }
         ordered_json output;

--- a/requester/handler.hpp
+++ b/requester/handler.hpp
@@ -9,6 +9,7 @@
 #include <sys/socket.h>
 
 #include <function2/function2.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/timer.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/source/event.hpp>
@@ -19,12 +20,12 @@
 #include <tuple>
 #include <unordered_map>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace requester
 {
-
 /** @struct RequestKey
  *
  *  RequestKey uniquely identifies the PLDM request message to match it with the
@@ -130,21 +131,20 @@ class Handler
         auto instanceIdExpiryCallBack = [key, this](void) {
             if (this->handlers.contains(key))
             {
-                std::cerr << "Response not received for the request, instance "
-                             "ID expired."
-                          << " EID = " << (unsigned)key.eid
-                          << " INSTANCE_ID = " << (unsigned)key.instanceId
-                          << " TYPE = " << (unsigned)key.type
-                          << " COMMAND = " << (unsigned)key.command << "\n";
+                error(
+                    "Response not received for the request, instance ID expired. EID = {EID} INSTANCE_ID = {INST_ID} TYPE = {KEY_TYP} COMMAND = {CMD}",
+                    "EID", (unsigned)key.eid, "INST_ID",
+                    (unsigned)key.instanceId, "KEY_TYP", (unsigned)key.type,
+                    "CMD", (unsigned)key.command);
                 auto& [request, responseHandler,
                        timerInstance] = this->handlers[key];
                 request->stop();
                 auto rc = timerInstance->stop();
                 if (rc)
                 {
-                    std::cerr
-                        << "Failed to stop the instance ID expiry timer. RC = "
-                        << rc << "\n";
+                    error(
+                        "Failed to stop the instance ID expiry timer. RC = {RC}",
+                        "RC", rc);
                 }
                 // Call response handler with an empty response to indicate no
                 // response
@@ -173,8 +173,7 @@ class Handler
         if (rc)
         {
             requester.markFree(eid, instanceId);
-            std::cerr << "Failure to send the PLDM request message"
-                      << "\n";
+            error("Failure to send the PLDM request message");
             return rc;
         }
 
@@ -186,8 +185,9 @@ class Handler
         catch (const std::runtime_error& e)
         {
             requester.markFree(eid, instanceId);
-            std::cerr << "Failed to start the instance ID expiry timer. RC = "
-                      << e.what() << "\n";
+            error(
+                "Failed to start the instance ID expiry timer. RC = {ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
             return PLDM_ERROR;
         }
 
@@ -218,9 +218,8 @@ class Handler
             auto rc = timerInstance->stop();
             if (rc)
             {
-                std::cerr
-                    << "Failed to stop the instance ID expiry timer. RC = "
-                    << rc << "\n";
+                error("Failed to stop the instance ID expiry timer. RC = {RC}",
+                      "RC", rc);
             }
             responseHandler(eid, response, respMsgLen);
             requester.markFree(key.eid, key.instanceId);

--- a/requester/request.hpp
+++ b/requester/request.hpp
@@ -9,6 +9,7 @@
 
 #include <sys/socket.h>
 
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/timer.hpp>
 #include <sdeventplus/event.hpp>
 
@@ -16,12 +17,12 @@
 #include <functional>
 #include <iostream>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldm
 {
-
 namespace requester
 {
-
 /** @class RequestRetryTimer
  *
  *  The abstract base class for implementing the PLDM request retry logic. This
@@ -75,8 +76,8 @@ class RequestRetryTimer
         }
         catch (const std::runtime_error& e)
         {
-            std::cerr << "Failed to start the request timer. RC = " << e.what()
-                      << "\n";
+            error("Failed to start the request timer. RC = {RC}", "RC",
+                  e.what());
             return PLDM_ERROR;
         }
 
@@ -89,8 +90,8 @@ class RequestRetryTimer
         auto rc = timer.stop();
         if (rc)
         {
-            std::cerr << "Failed to stop the request timer. RC = " << rc
-                      << "\n";
+            error("Failed to stop the request timer. RC = {RC}", "RC",
+                  static_cast<int>(rc));
         }
     }
 
@@ -188,11 +189,10 @@ class Request final : public RequestRetryTimer
                                  sizeof(currentSendbuffSize));
             if (res == -1)
             {
-                std::cerr
-                    << "Requester : Failed to set the new send buffer size [bytes] : "
-                    << currentSendbuffSize
-                    << " from current size [bytes]: " << oldSendbuffSize
-                    << " , Error : " << strerror(errno) << std::endl;
+                error(
+                    "Requester : Failed to set the new send buffer size [bytes] : {CUR_SND_BUFF_SIZE} from current size [bytes]: {OLD_BUF_SIZE} , Error : {ERR}",
+                    "CUR_SND_BUFF_SIZE", currentSendbuffSize, "OLD_BUF_SIZE",
+                    oldSendbuffSize, "ERR", strerror(errno));
                 return PLDM_ERROR;
             }
         }
@@ -201,8 +201,8 @@ class Request final : public RequestRetryTimer
         auto rc = pldm_send(eid, fd, requestMsg.data(), requestMsg.size());
         if (rc < 0)
         {
-            std::cerr << "Failed to send PLDM message. RC = " << rc
-                      << ", errno = " << errno << "\n";
+            error("Failed to send PLDM message. RC = {RC}, errno = {ERR}", "RC",
+                  static_cast<int>(rc), "ERR", errno);
             return PLDM_ERROR;
         }
         return PLDM_SUCCESS;

--- a/requester/test/meson.build
+++ b/requester/test/meson.build
@@ -19,6 +19,7 @@ foreach t : tests
                          gtest,
                          gmock,
                          libpldm_dep,
+			 phosphor_logging_dep,
                          nlohmann_json,
                          phosphor_dbus_interfaces,
                          sdbusplus,

--- a/softoff/main.cpp
+++ b/softoff/main.cpp
@@ -3,7 +3,11 @@
 
 #include <getopt.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 int main(int argc, char* argv[])
 {
@@ -16,7 +20,7 @@ int main(int argc, char* argv[])
     {
         case 't':
             noTimeOut = true;
-            std::cout << "Not applying any time outs\n";
+            info("Not applying any time outs");
             break;
         case -1:
             break;
@@ -37,15 +41,15 @@ int main(int argc, char* argv[])
 
     if (softPower.isError())
     {
-        std::cerr << "Host failed to gracefully shutdown, exiting "
-                     "pldm-softpoweroff app\n";
+        error(
+            "Host failed to gracefully shutdown, exiting pldm-softpoweroff app");
         return -1;
     }
 
     if (softPower.isCompleted())
     {
-        std::cerr << "Host current state is not Running, exiting "
-                     "pldm-softpoweroff app\n";
+        error(
+            "Host current state is not Running, exiting pldm-softpoweroff app");
         return 0;
     }
 
@@ -53,9 +57,8 @@ int main(int argc, char* argv[])
     // wait the host gracefully shutdown.
     if (softPower.hostSoftOff(event))
     {
-        std::cerr << "pldm-softpoweroff:Failure in sending soft off request to "
-                     "the host. Exiting pldm-softpoweroff app\n";
-
+        error(
+            "pldm-softpoweroff:Failure in sending soft off request to the host. Exiting pldm-softpoweroff app");
         return -1;
     }
 
@@ -78,14 +81,12 @@ int main(int argc, char* argv[])
         }
         catch (const sdbusplus::exception::exception& e)
         {
-            std::cerr << "SoftPowerOff:Failed to create BMC dump, ERROR="
-                      << e.what() << std::endl;
+            error("SoftPowerOff:Failed to create BMC dump, ERROR={ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
         }
 
-        std::cerr
-            << "PLDM host soft off: ERROR! Wait for the host soft off timeout."
-            << "Exit the pldm-softpoweroff "
-            << "\n";
+        error(
+            "PLDM host soft off: ERROR! Wait for the host soft off timeout. Exit the pldm-softpoweroff");
         return -1;
     }
 

--- a/softoff/meson.build
+++ b/softoff/meson.build
@@ -5,6 +5,7 @@ deps = [
     sdeventplus,
     sdbusplus,
     phosphor_dbus_interfaces,
+    phosphor_logging_dep,
     ]
 
 source = ['main.cpp','softoff.cpp']

--- a/subprojects/phosphor-logging.wrap
+++ b/subprojects/phosphor-logging.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/openbmc/phosphor-logging.git
+revision = HEAD
+
+[provide]
+phosphor-logging = phosphor_logging_dep

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,7 @@ foreach t : tests
                      build_rpath: get_option('oe-sdk').enabled() ? rpath : '',
                      dependencies: [
                          libpldm_dep,
+			 phosphor_logging_dep,
                          nlohmann_json,
                          gtest,
                          test_src]),

--- a/utilities/meson.build
+++ b/utilities/meson.build
@@ -1,4 +1,4 @@
-deps = [ CLI11_dep, libpldm_dep, sdeventplus ]
+deps = [ CLI11_dep, libpldm_dep, sdeventplus, phosphor_logging_dep ]
 
 executable('set-state-effecter', 'requester/set_state_effecter.cpp',
            implicit_include_directories: false,

--- a/utilities/requester/set_state_effecter.cpp
+++ b/utilities/requester/set_state_effecter.cpp
@@ -2,9 +2,12 @@
 #include "libpldm/pldm.h"
 
 #include <CLI/CLI.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <array>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 int main(int argc, char** argv)
 {
@@ -29,8 +32,8 @@ int main(int argc, char** argv)
                                                    &stateField, request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message encode failure. PLDM error code = " << std::hex
-                  << std::showbase << rc << "\n";
+        error("Message encode failure. PLDM error code = {RC}", "RC", lg2::hex,
+              rc);
         return -1;
     }
 
@@ -38,8 +41,7 @@ int main(int argc, char** argv)
     int fd = pldm_open();
     if (-1 == fd)
     {
-        std::cerr << "Failed to init mctp"
-                  << "\n";
+        error("Failed to init mctp");
         return -1;
     }
 
@@ -50,13 +52,14 @@ int main(int argc, char** argv)
                         &responseMsg, &responseMsgSize);
     if (0 > rc)
     {
-        std::cerr << "Failed to send message/receive response. RC = " << rc
-                  << ", errno = " << errno << "\n";
+        error(
+            "Failed to send message/receive response. RC = {RC}, errno = {ERR}",
+            "RC", rc, "ERR", errno);
         return -1;
     }
     pldm_msg* response = reinterpret_cast<pldm_msg*>(responseMsg);
-    std::cout << "Done. PLDM RC = " << std::hex << std::showbase
-              << static_cast<uint16_t>(response->payload[0]) << std::endl;
+    info("Done. PLDM RC = {RC}", "RC", lg2::hex,
+         static_cast<uint16_t>(response->payload[0]));
     free(responseMsg);
 
     return 0;

--- a/utilities/requester/set_state_effecter_async.cpp
+++ b/utilities/requester/set_state_effecter_async.cpp
@@ -3,11 +3,14 @@
 #include "libpldm/pldm.h"
 
 #include <CLI/CLI.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/source/io.hpp>
 
 #include <array>
 #include <iostream>
+
+PHOSPHOR_LOG2_USING;
 
 using namespace sdeventplus;
 using namespace sdeventplus::source;
@@ -35,8 +38,8 @@ int main(int argc, char** argv)
                                                    &stateField, request);
     if (rc != PLDM_SUCCESS)
     {
-        std::cerr << "Message encode failure. PLDM error code = " << std::hex
-                  << std::showbase << rc << "\n";
+        error("Message encode failure. PLDM error code = {RC}", "RC", lg2::hex,
+              rc);
         return -1;
     }
 
@@ -44,8 +47,7 @@ int main(int argc, char** argv)
     int fd = pldm_open();
     if (-1 == fd)
     {
-        std::cerr << "Failed to init mctp"
-                  << "\n";
+        error("Failed to init mctp");
         return -1;
     }
 
@@ -67,9 +69,8 @@ int main(int argc, char** argv)
             // sent out
             io.set_enabled(Enabled::Off);
             pldm_msg* response = reinterpret_cast<pldm_msg*>(responseMsg);
-            std::cout << "Done. PLDM RC = " << std::hex << std::showbase
-                      << static_cast<uint16_t>(response->payload[0])
-                      << std::endl;
+            info("Done. PLDM RC = {RC}", "RC", lg2::hex,
+                 static_cast<uint16_t>(response->payload[0]));
             free(responseMsg);
             exit(EXIT_SUCCESS);
         }
@@ -80,8 +81,9 @@ int main(int argc, char** argv)
     rc = pldm_send(mctpEid, fd, requestMsg.data(), requestMsg.size());
     if (0 > rc)
     {
-        std::cerr << "Failed to send message/receive response. RC = " << rc
-                  << ", errno = " << errno << "\n";
+        error(
+            "Failed to send message/receive response. RC = {RC}, errno = {ERR}",
+            "RC", rc, "ERR", errno);
         return -1;
     }
 


### PR DESCRIPTION
This commit adds changes in PLDM for implementing
structured LG2 logging, thereby moving away from
std::cout/cerr practice of logging which are
output streams and not logging mechanism.

PLDM now can make use of lg2 features like accurate CODE LINE Number and CODE_FUNCTION Name and better detailing in json object values which can be used in log tracking.

More detailed logging change:
https://gist.github.com/riyadixitagra/c251685c1ba84248181891f7bc282395

Tested:
Ran a power off, on, cycle, and reset-reload.