### PR TITLE
PLDM: Comment explaining dbus-timeout-value option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,7 +15,12 @@ option('number-of-request-retries', type: 'integer', min: 2, max: 30, descriptio
 option('instance-id-expiration-interval', type: 'integer', min: 5, max: 6, description: 'Instance ID expiration interval in seconds', value: 5)
 # Default response-time-out set to 2 seconds to facilitate a minimum retry of the request of 2.
 option('response-time-out', type: 'integer', min: 300, max: 4800, description: 'The amount of time a requester has to wait for a response message in milliseconds', value: 2000)
-# Time taken to wait for the reply for any PLDM dbus call is set to 5 seconds. After 5 seconds the dbus method will exit.
+# As per PLDM spec DSP0240 version 1.1.0, in Timing Specification for PLDM messages (Table 6),
+# the instance ID for a given response will expire and become reusable if a response has not been
+# received within a maximum of 6 seconds after a request is sent. By setting the dbus timeout
+# value to 5 seconds we ensure that PLDM does not wait for a response from a dbus call even after
+# the instance ID has expired. If the option is set to 5 seconds, any dbus call originated from
+# PLDM daemon will timeout after 5 seconds.
 option('dbus-timeout-value', type: 'integer', min: 3, max: 10, description: 'The amount of time pldm waits to get a response for a dbus message before timing out', value: 5)
 
 option('heartbeat-timeout-seconds', type: 'integer', description: ' The amount of time host waits for BMC to respond to pings from host, as part of host-bmc surveillance', value: 120)


### PR DESCRIPTION
To give more clarity, this commit adds an elaborate comment in meson_options explaining why 5 seconds DBUS timeout value was chosen for PLDM.