### PR TITLE
PLDM: 5 sec timeout for dbus calls without reply

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -289,7 +289,9 @@ void reportError(const char* errorMsg, const Severity& sev)
         }
         std::map<std::string, std::string> addlData{};
         method.append(errorMsg, severity, addlData);
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {
@@ -324,7 +326,9 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
                 service.c_str(), "/xyz/openbmc_project/inventory",
                 "xyz.openbmc_project.Inventory.Manager", "Notify");
             method.append(std::move(objectValueTree));
-            bus.call_noreply(method);
+            bus.call_noreply(
+                method, std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT))
+                            .count());
         }
         else
         {
@@ -343,7 +347,9 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
             }
             method.append(dBusMap.interface.c_str(),
                           dBusMap.propertyName.c_str(), variant);
-            bus.call_noreply(method);
+            bus.call_noreply(
+                method, std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT))
+                            .count());
         }
     };
 
@@ -727,7 +733,9 @@ void setBiosAttr(const BiosAttributeList& biosAttrList)
             method.append(
                 biosConfigIntf, "PendingAttributes",
                 std::variant<PendingAttributesType>(pendingAttributes));
-            bus.call_noreply(method);
+            bus.call_noreply(
+                method, std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT))
+                            .count());
         }
         catch (const sdbusplus::exception::SdBusError& e)
         {

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -485,7 +485,9 @@ void BIOSConfig::updateBaseBIOSTableProperty()
         }
 #endif
         method.append(biosConfigInterface, biosConfigPropertyName, value);
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {

--- a/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
+++ b/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
@@ -110,7 +110,9 @@ void SlotHandler::callVPDManager(const std::string& adapterObjPath,
                                               VPDInterface, "CollectFRUVPD");
             method.append(
                 static_cast<sdbusplus::message::object_path>(adapterObjPath));
-            bus.call_noreply(method);
+            bus.call_noreply(
+                method, std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT))
+                            .count());
         }
         else if (stateFiledValue == uint8_t(REMOVE) ||
                  stateFiledValue == uint8_t(REPLACE))
@@ -119,7 +121,9 @@ void SlotHandler::callVPDManager(const std::string& adapterObjPath,
                                               VPDInterface, "deleteFRUVPD");
             method.append(
                 static_cast<sdbusplus::message::object_path>(adapterObjPath));
-            bus.call_noreply(method);
+            bus.call_noreply(
+                method, std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT))
+                            .count());
         }
     }
     catch (const std::exception& e)

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -234,7 +234,9 @@ int PelHandler::fileAck(uint8_t /*fileStatus*/)
         auto method = bus.new_method_call(service.c_str(), logObjPath,
                                           logInterface, "HostAck");
         method.append(fileHandle);
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {
@@ -269,7 +271,9 @@ int PelHandler::storePel(std::string&& pelFileName)
                                           logInterface, "Create");
         method.append("xyz.openbmc_project.Host.Error.Event", severity,
                       addlData);
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
@@ -33,7 +33,9 @@ int ProgressCodeHandler::setRawBootProperty(
                       std::variant<std::tuple<uint64_t, std::vector<uint8_t>>>(
                           progressCodeBuffer));
 
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {

--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -198,7 +198,9 @@ void Handler::setFirmwareUAK(std::vector<uint8_t> data)
                                           uakInterface, "WriteKeyword");
         method.append(static_cast<sdbusplus::message::object_path>(fruPath),
                       fruRecord, fruKeyword, data);
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -595,7 +595,9 @@ void CodeUpdate::deleteImage()
     {
         auto method = bus.new_method_call(UPDATER_SERVICE, SW_OBJ_PATH,
                                           DELETE_INTF, "DeleteAll");
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {
@@ -797,7 +799,9 @@ int CodeUpdate::assembleCodeUpdateImage()
         auto method = bus.new_method_call(UPDATER_SERVICE, SOFTWARE_PATH,
                                           LID_INTERFACE,
                                           "AssembleCodeUpdateImage");
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1288,7 +1288,9 @@ void pldm::responder::oem_ibm_platform::Handler::resetWatchDogTimer()
             bus.new_method_call(watchDogService, watchDogObjectPath,
                                 watchDogInterface, watchDogResetPropName);
         resetMethod.append(true);
-        bus.call_noreply(resetMethod);
+        bus.call_noreply(
+            resetMethod,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {
@@ -1357,7 +1359,9 @@ void pldm::responder::oem_ibm_platform::Handler::setBitmapMethodCall(
                                           dbusMethod);
         auto val = std::get_if<std::vector<uint8_t>>(&value);
         method.append(*val);
-        bus.call_noreply(method);
+        bus.call_noreply(
+            method,
+            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
     }
     catch (const std::exception& e)
     {

--- a/softoff/main.cpp
+++ b/softoff/main.cpp
@@ -77,7 +77,9 @@ int main(int argc, char* argv[])
             method.append(
                 std::vector<std::pair<std::string,
                                       std::variant<std::string, uint64_t>>>());
-            bus.call_noreply(method);
+            bus.call_noreply(
+                method, std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT))
+                            .count());
         }
         catch (const sdbusplus::exception::exception& e)
         {


### PR DESCRIPTION
This commit adds 5 second dbus timeout value to dbus calls with no reply. Previously a commit was merged that included 5 seconds dbus timeout value for all dbus call with reply.

This is added to make sure PLDM does not wait for more than 5 seconds when a dbus call is made with or without reply if no response is received from other daemon or host.

The 5 second  timeout value is overridden to 10 seconds in meta-ibm layer