### PR TITLE
Migrate off of APIs deprecated in libpldm v0.4.0 

### DIFF
--- a/common/bios_utils.hpp
+++ b/common/bios_utils.hpp
@@ -51,10 +51,16 @@ class BIOSTableIter
          *  @param[in] data - Pointer to a table
          *  @param[in] length - The length of the table
          */
-        explicit iterator(const void* data, size_t length) noexcept :
+        explicit iterator(const void* data, size_t length) :
             iter(pldm_bios_table_iter_create(data, length, tableType),
                  pldm_bios_table_iter_free)
-        {}
+        {
+            if (!iter)
+            {
+                throw std::runtime_error(
+                    "Unable to create bios table iterator");
+            }
+        }
 
         /** @brief Get the entry pointed by the iterator
          *

--- a/common/test/pldm_utils_test.cpp
+++ b/common/test/pldm_utils_test.cpp
@@ -104,7 +104,9 @@ TEST(FindStateEffecterPDR, testOneMatch)
     state->state_set_id = 196;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -137,7 +139,9 @@ TEST(FindStateEffecterPDR, testNoMatch)
     state->state_set_id = 196;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -186,7 +190,9 @@ TEST(FindStateEffecterPDR, testMoreMatch)
     state->state_set_id = 129;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -206,7 +212,10 @@ TEST(FindStateEffecterPDR, testMoreMatch)
     state_second->state_set_id = 129;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
+    handle = 0;
+    ASSERT_EQ(pldm_pdr_add_check(repo, pdr_second.data(), pdr_second.size(),
+                                 false, 1, &handle),
+              0);
 
     uint16_t entityID_ = 31;
     uint16_t stateSetId_ = 129;
@@ -243,7 +252,9 @@ TEST(FindStateEffecterPDR, testManyNoMatch)
     state->state_set_id = 198;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -263,7 +274,10 @@ TEST(FindStateEffecterPDR, testManyNoMatch)
     state_second->state_set_id = 169;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
+    handle = 0;
+    ASSERT_EQ(pldm_pdr_add_check(repo, pdr_second.data(), pdr_second.size(),
+                                 false, 1, &handle),
+              0);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -296,7 +310,9 @@ TEST(FindStateEffecterPDR, testOneMatchOneNoMatch)
     state->state_set_id = 198;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -316,7 +332,10 @@ TEST(FindStateEffecterPDR, testOneMatchOneNoMatch)
     state_second->state_set_id = 192;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
+    handle = 0;
+    ASSERT_EQ(pldm_pdr_add_check(repo, pdr_second.data(), pdr_second.size(),
+                                 false, 1, &handle),
+              0);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -350,7 +369,9 @@ TEST(FindStateEffecterPDR, testOneMatchManyNoMatch)
     state->state_set_id = 198;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -370,7 +391,10 @@ TEST(FindStateEffecterPDR, testOneMatchManyNoMatch)
     state_second->state_set_id = 192;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
+    handle = 0;
+    ASSERT_EQ(pldm_pdr_add_check(repo, pdr_second.data(), pdr_second.size(),
+                                 false, 1, &handle),
+              0);
 
     std::vector<uint8_t> pdr_third(
         sizeof(struct pldm_state_effecter_pdr) - sizeof(uint8_t) +
@@ -434,7 +458,9 @@ TEST(FindStateEffecterPDR, testCompositeEffecter)
     state->state_set_id = 192;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -479,7 +505,9 @@ TEST(FindStateEffecterPDR, testNoMatchCompositeEffecter)
     state->state_set_id = 123;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     auto record = findStateEffecterPDR(tid, entityID, stateSetId, repo);
 
@@ -512,7 +540,9 @@ TEST(FindStateSensorPDR, testOneMatch)
     state->state_set_id = 1;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -545,7 +575,9 @@ TEST(FindStateSensorPDR, testNoMatch)
     state->state_set_id = 1;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -594,7 +626,9 @@ TEST(FindStateSensorPDR, testMoreMatch)
     state->state_set_id = 1;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_sensor_pdr) - sizeof(uint8_t) +
@@ -614,7 +648,10 @@ TEST(FindStateSensorPDR, testMoreMatch)
     state_second->state_set_id = 1;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
+    handle = 0;
+    ASSERT_EQ(pldm_pdr_add_check(repo, pdr_second.data(), pdr_second.size(),
+                                 false, 1, &handle),
+              0);
 
     uint16_t entityID_ = 5;
     uint16_t stateSetId_ = 1;
@@ -651,7 +688,9 @@ TEST(FindStateSensorPDR, testManyNoMatch)
     state->state_set_id = 2;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_sensor_pdr) - sizeof(uint8_t) +
@@ -671,7 +710,10 @@ TEST(FindStateSensorPDR, testManyNoMatch)
     state_second->state_set_id = 3;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
+    handle = 0;
+    ASSERT_EQ(pldm_pdr_add_check(repo, pdr_second.data(), pdr_second.size(),
+                                 false, 1, &handle),
+              0);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -704,7 +746,9 @@ TEST(FindStateSensorPDR, testOneMatchOneNoMatch)
     state->state_set_id = 20;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_sensor_pdr) - sizeof(uint8_t) +
@@ -724,7 +768,10 @@ TEST(FindStateSensorPDR, testOneMatchOneNoMatch)
     state_second->state_set_id = 1;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
+    handle = 0;
+    ASSERT_EQ(pldm_pdr_add_check(repo, pdr_second.data(), pdr_second.size(),
+                                 false, 1, &handle),
+              0);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -758,7 +805,9 @@ TEST(FindStateSensorPDR, testOneMatchManyNoMatch)
     state->state_set_id = 9;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     std::vector<uint8_t> pdr_second(
         sizeof(struct pldm_state_sensor_pdr) - sizeof(uint8_t) +
@@ -778,7 +827,10 @@ TEST(FindStateSensorPDR, testOneMatchManyNoMatch)
     state_second->state_set_id = 1;
     state_second->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr_second.data(), pdr_second.size(), 0, false, 1);
+    handle = 0;
+    ASSERT_EQ(pldm_pdr_add_check(repo, pdr_second.data(), pdr_second.size(),
+                                 false, 1, &handle),
+              0);
 
     std::vector<uint8_t> pdr_third(sizeof(struct pldm_state_sensor_pdr) -
                                    sizeof(uint8_t) +
@@ -843,7 +895,9 @@ TEST(FindStateSensorPDR, testCompositeSensor)
     state->state_set_id = 1;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 
@@ -888,7 +942,9 @@ TEST(FindStateSensorPDR, testNoMatchCompositeSensor)
     state->state_set_id = 39;
     state->possible_states_size = 1;
 
-    pldm_pdr_add(repo, pdr.data(), pdr.size(), 0, false, 1);
+    uint32_t handle = 0;
+    ASSERT_EQ(
+        pldm_pdr_add_check(repo, pdr.data(), pdr.size(), false, 1, &handle), 0);
 
     auto record = findStateSensorPDR(tid, entityID, stateSetId, repo);
 

--- a/host-bmc/dbus_to_event_handler.cpp
+++ b/host-bmc/dbus_to_event_handler.cpp
@@ -191,6 +191,10 @@ void DbusToPLDMEvent::listenSensorEvent(const pdr_utils::Repo& repo,
     pldm_state_sensor_pdr* pdr = nullptr;
     std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)> sensorPdrRepo(
         pldm_pdr_init(), pldm_pdr_destroy);
+    if (!sensorPdrRepo)
+    {
+        throw std::runtime_error("Unable to instantiate sensor PDR repository");
+    }
 
     for (auto pdrType : pdrTypes)
     {

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -477,8 +477,15 @@ void HostPDRHandler::mergeEntityAssociations(
 #ifdef OEM_IBM
     if (oemPlatformHandler && isHBRange(record_handle))
     {
+        uint32_t applied_handle = record_handle;
         // Adding the HostBoot range PDRs to the repo before merging it
-        pldm_pdr_add(repo, pdr.data(), size, record_handle, true, 0xFFFF);
+        int rc = pldm_pdr_add_check(repo, pdr.data(), size, true, 0xFFFF,
+                                    &applied_handle);
+        if (rc)
+        {
+            // pldm_pdr_add() assert()ed on failure to add a PDR.
+            throw std::runtime_error("Failed to add PDR");
+        }
     }
 #endif
 
@@ -933,8 +940,15 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
                         }
                         else
                         {
-                            pldm_pdr_add(repo, pdr.data(), respCount, rh, true,
-                                         pdrTerminusHandle);
+                            rc = pldm_pdr_add_check(repo, pdr.data(), respCount,
+                                                    true, pdrTerminusHandle,
+                                                    &rh);
+                            if (rc)
+                            {
+                                // pldm_pdr_add() assert()ed on failure to add a
+                                // PDR.
+                                throw std::runtime_error("Failed to add PDR");
+                            }
                         }
                     }
                 }

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -560,17 +560,31 @@ void HostPDRHandler::mergeEntityAssociations(
             {
                 // Record Handle is 0xFFFFFFFF(max value uint32_t), for merging
                 // entity association pdr to bmc range
-                pldm_entity_association_pdr_add_from_node(
-                    node, repo, &entities, numEntities, true, TERMINUS_HANDLE,
-                    0xFFFFFFFF);
+                int rc =
+                    pldm_entity_association_pdr_add_from_node_with_record_handle(
+                        node, repo, &entities, numEntities, true,
+                        TERMINUS_HANDLE, 0xFFFFFFFF);
+                if (rc)
+                {
+                    std::cerr
+                        << "Failed to add entity association PDR from node: "
+                        << rc << std::endl;
+                }
             }
             else
             {
                 // Record Handle is 0xFFFFFFFF(max value uint32_t), for merging
                 // entity association pdr to bmc range
-                pldm_entity_association_pdr_add_from_node(
-                    node, repo, &entities, numEntities, true, terminus_handle,
-                    0xFFFFFFFF);
+                int rc =
+                    pldm_entity_association_pdr_add_from_node_with_record_handle(
+                        node, repo, &entities, numEntities, true,
+                        terminus_handle, 0xFFFFFFFF);
+                if (rc)
+                {
+                    std::cerr
+                        << "Failed to add entity association PDR from node: "
+                        << rc << std::endl;
+                }
             }
         }
     }

--- a/libpldmresponder/bios_table.cpp
+++ b/libpldmresponder/bios_table.cpp
@@ -163,7 +163,6 @@ const pldm_bios_attr_table_entry*
     {
         throw std::runtime_error("Failed to encode BIOS table string entry");
     }
-
     return reinterpret_cast<pldm_bios_attr_table_entry*>(table.data() +
                                                          tableSize);
 }
@@ -175,8 +174,13 @@ const pldm_bios_attr_table_entry*
     auto entryLength = pldm_bios_table_attr_entry_integer_encode_length();
     auto tableSize = table.size();
     table.resize(tableSize + entryLength, 0);
-    pldm_bios_table_attr_entry_integer_encode(table.data() + tableSize,
-                                              entryLength, info);
+    int rc = pldm_bios_table_attr_entry_integer_encode_check(
+        table.data() + tableSize, entryLength, info);
+    if (rc != PLDM_SUCCESS)
+    {
+        throw std::runtime_error(
+            "Failed to encode BIOS attribute table integer entry");
+    }
     return reinterpret_cast<pldm_bios_attr_table_entry*>(table.data() +
                                                          tableSize);
 }
@@ -296,9 +300,14 @@ const pldm_bios_attr_val_table_entry*
         pldm_bios_table_attr_value_entry_encode_string_length(strLen);
     auto tableSize = table.size();
     table.resize(tableSize + entryLength);
-    pldm_bios_table_attr_value_entry_encode_string(
+    int rc = pldm_bios_table_attr_value_entry_encode_string_check(
         table.data() + tableSize, entryLength, attrHandle, attrType, strLen,
         str.c_str());
+    if (rc != PLDM_SUCCESS)
+    {
+        throw std::runtime_error(
+            "Failed to encode BIOS attribute table string entry");
+    }
     return reinterpret_cast<pldm_bios_attr_val_table_entry*>(table.data() +
                                                              tableSize);
 }
@@ -326,9 +335,14 @@ const pldm_bios_attr_val_table_entry*
         handleIndices.size());
     auto tableSize = table.size();
     table.resize(tableSize + entryLength);
-    pldm_bios_table_attr_value_entry_encode_enum(
+    int rc = pldm_bios_table_attr_value_entry_encode_enum_check(
         table.data() + tableSize, entryLength, attrHandle, attrType,
         handleIndices.size(), handleIndices.data());
+    if (rc != PLDM_SUCCESS)
+    {
+        throw std::runtime_error(
+            "Failed to encode BIOS attribute table enum entry");
+    }
     return reinterpret_cast<pldm_bios_attr_val_table_entry*>(table.data() +
                                                              tableSize);
 }

--- a/libpldmresponder/bios_table.cpp
+++ b/libpldmresponder/bios_table.cpp
@@ -83,12 +83,11 @@ namespace table
 
 void appendPadAndChecksum(Table& table)
 {
-    auto sizeWithoutPad = table.size();
-    auto padAndChecksumSize = pldm_bios_table_pad_checksum_size(sizeWithoutPad);
-    table.resize(table.size() + padAndChecksumSize);
-
-    pldm_bios_table_append_pad_checksum(table.data(), table.size(),
-                                        sizeWithoutPad);
+    size_t payloadSize = table.size();
+    table.resize(payloadSize + pldm_bios_table_pad_checksum_size(payloadSize));
+    // No validation of return value as preconditions are satisfied
+    pldm_bios_table_append_pad_checksum_check(table.data(), table.size(),
+                                              &payloadSize);
 }
 
 namespace string

--- a/libpldmresponder/bios_table.cpp
+++ b/libpldmresponder/bios_table.cpp
@@ -320,8 +320,13 @@ const pldm_bios_attr_val_table_entry* constructIntegerEntry(Table& table,
 
     auto tableSize = table.size();
     table.resize(tableSize + entryLength);
-    pldm_bios_table_attr_value_entry_encode_integer(
+    int rc = pldm_bios_table_attr_value_entry_encode_integer_check(
         table.data() + tableSize, entryLength, attrHandle, attrType, value);
+    if (rc != PLDM_SUCCESS)
+    {
+        throw std::runtime_error(
+            "Failed to encode BIOS attribute table integery entry");
+    }
     return reinterpret_cast<pldm_bios_attr_val_table_entry*>(table.data() +
                                                              tableSize);
 }

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -340,11 +340,18 @@ uint32_t FruImpl::populateRecords(
                 {
                     bmc_record_handle = nextRecordHandle();
                 }
-                newRcord = pldm_pdr_add_fru_record_set(
+                int rc = pldm_pdr_add_fru_record_set_check(
                     pdrRepo, TERMINUS_HANDLE, recordSetIdentifier,
                     entity.entity_type, entity.entity_instance_num,
-                    entity.entity_container_id, bmc_record_handle,
+                    entity.entity_container_id, &bmc_record_handle,
                     concurrentAdd);
+                if (rc)
+                {
+                    // pldm_pdr_add_fru_record_set() assert()ed on failure
+                    throw std::runtime_error(
+                        "Failed to add PDR FRU record set");
+                }
+                newRcord = bmc_record_handle;
                 objectPathToRSIMap[objectPath] = recordSetIdentifier;
             }
             auto curSize = table.size();

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -794,11 +794,11 @@ int FruImpl::getFRURecordByOption(std::vector<uint8_t>& fruData,
     size_t recordTableSize = table.size() - padBytes + 7;
     fruData.resize(recordTableSize, 0);
 
-    get_fru_record_by_option(table.data(), table.size(), fruData.data(),
-                             &recordTableSize, recordSetIdentifer, recordType,
-                             fieldType);
+    int rc = get_fru_record_by_option_check(
+        table.data(), table.size(), fruData.data(), &recordTableSize,
+        recordSetIdentifer, recordType, fieldType);
 
-    if (recordTableSize == 0)
+    if (rc != PLDM_SUCCESS || recordTableSize == 0)
     {
         return PLDM_FRU_DATA_STRUCTURE_TABLE_UNAVAILABLE;
     }

--- a/libpldmresponder/pdr_utils.cpp
+++ b/libpldmresponder/pdr_utils.cpp
@@ -27,8 +27,15 @@ pldm_pdr* Repo::getPdr() const
 
 RecordHandle Repo::addRecord(const PdrEntry& pdrEntry)
 {
-    return pldm_pdr_add(repo, pdrEntry.data, pdrEntry.size,
-                        pdrEntry.handle.recordHandle, false, TERMINUS_HANDLE);
+    uint32_t handle = pdrEntry.handle.recordHandle;
+    int rc = pldm_pdr_add_check(repo, pdrEntry.data, pdrEntry.size, false,
+                                TERMINUS_HANDLE, &handle);
+    if (rc)
+    {
+        // pldm_pdr_add() assert()ed on failure to add PDR
+        throw std::runtime_error("Failed to add PDR");
+    }
+    return handle;
 }
 
 const pldm_pdr_record* Repo::getFirstRecord(PdrEntry& pdrEntry)

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -931,6 +931,10 @@ bool isOemStateSensor(Handler& handler, uint16_t sensorId,
 
     std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)> stateSensorPdrRepo(
         pldm_pdr_init(), pldm_pdr_destroy);
+    if (!stateSensorPdrRepo)
+    {
+        return false;
+    }
     Repo stateSensorPDRs(stateSensorPdrRepo.get());
     getRepoByType(handler.getRepo(), stateSensorPDRs, PLDM_STATE_SENSOR_PDR);
     if (stateSensorPDRs.empty())
@@ -997,6 +1001,10 @@ bool isOemStateEffecter(Handler& handler, uint16_t effecterId,
 
     std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)> stateEffecterPdrRepo(
         pldm_pdr_init(), pldm_pdr_destroy);
+    if (!stateEffecterPdrRepo)
+    {
+        return false;
+    }
     Repo stateEffecterPDRs(stateEffecterPdrRepo.get());
     getRepoByType(handler.getRepo(), stateEffecterPDRs,
                   PLDM_STATE_EFFECTER_PDR);

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -329,6 +329,11 @@ class Handler : public CmdHandler
 
         std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)>
             stateEffecterPdrRepo(pldm_pdr_init(), pldm_pdr_destroy);
+        if (!stateEffecterPdrRepo)
+        {
+            throw std::runtime_error(
+                "Failed to instantiate state effecter PDR repository");
+        }
         pldm::responder::pdr_utils::Repo stateEffecterPDRs(
             stateEffecterPdrRepo.get());
         getRepoByType(pdrRepo, stateEffecterPDRs, PLDM_STATE_EFFECTER_PDR);

--- a/libpldmresponder/platform_numeric_effecter.hpp
+++ b/libpldmresponder/platform_numeric_effecter.hpp
@@ -256,6 +256,10 @@ int setNumericEffecterValueHandler(const DBusInterface& dBusIntf,
 
     std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)>
         numericEffecterPdrRepo(pldm_pdr_init(), pldm_pdr_destroy);
+    if (!numericEffecterPdrRepo)
+    {
+        return PLDM_ERROR;
+    }
     pldm::responder::pdr_utils::Repo numericEffecterPDRs(
         numericEffecterPdrRepo.get());
     pldm::responder::pdr::getRepoByType(handler.getRepo(), numericEffecterPDRs,

--- a/libpldmresponder/platform_state_effecter.hpp
+++ b/libpldmresponder/platform_state_effecter.hpp
@@ -49,6 +49,11 @@ int setStateEffecterStatesHandler(
 
     std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)> stateEffecterPdrRepo(
         pldm_pdr_init(), pldm_pdr_destroy);
+    if (!stateEffecterPdrRepo)
+    {
+        throw std::runtime_error(
+            "Failed to instantiate state effecter PDR repository");
+    }
     pldm::responder::pdr_utils::Repo stateEffecterPDRs(
         stateEffecterPdrRepo.get());
     getRepoByType(handler.getRepo(), stateEffecterPDRs,

--- a/libpldmresponder/platform_state_sensor.hpp
+++ b/libpldmresponder/platform_state_sensor.hpp
@@ -105,6 +105,11 @@ int getStateSensorReadingsHandler(
 
     std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)> stateSensorPdrRepo(
         pldm_pdr_init(), pldm_pdr_destroy);
+    if (!stateSensorPdrRepo)
+    {
+        throw std::runtime_error(
+            "Failed to instantiate state sensor PDR repository");
+    }
     pldm::responder::pdr_utils::Repo stateSensorPDRs(stateSensorPdrRepo.get());
     getRepoByType(handler.getRepo(), stateSensorPDRs, PLDM_STATE_SENSOR_PDR);
     if (stateSensorPDRs.empty())

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -220,6 +220,10 @@ int main(int argc, char** argv)
     dbus_api::Host dbusImplHost(bus, "/xyz/openbmc_project/pldm");
     std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)> pdrRepo(
         pldm_pdr_init(), pldm_pdr_destroy);
+    if (!pdrRepo)
+    {
+        throw std::runtime_error("Failed to instantiate PDR repository");
+    }
     std::unique_ptr<pldm_entity_association_tree,
                     decltype(&pldm_entity_association_tree_destroy)>
         entityTree(pldm_entity_association_tree_init(),

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -228,10 +228,20 @@ int main(int argc, char** argv)
                     decltype(&pldm_entity_association_tree_destroy)>
         entityTree(pldm_entity_association_tree_init(),
                    pldm_entity_association_tree_destroy);
+    if (!entityTree)
+    {
+        throw std::runtime_error(
+            "Failed to instantiate general PDR entity association tree");
+    }
     std::unique_ptr<pldm_entity_association_tree,
                     decltype(&pldm_entity_association_tree_destroy)>
         bmcEntityTree(pldm_entity_association_tree_init(),
                       pldm_entity_association_tree_destroy);
+    if (!bmcEntityTree)
+    {
+        throw std::runtime_error(
+            "Failed to instantiate BMC PDR entity association tree");
+    }
     std::shared_ptr<HostPDRHandler> hostPDRHandler;
     std::unique_ptr<pldm::host_effecters::HostEffecterParser>
         hostEffecterParser;

--- a/pldmtool/pldm_bios_cmd.cpp
+++ b/pldmtool/pldm_bios_cmd.cpp
@@ -869,9 +869,16 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
 
                 attrValueEntry.resize(entryLength);
                 std::vector<uint8_t> handles = {i};
-                pldm_bios_table_attr_value_entry_encode_enum(
+                int rc = pldm_bios_table_attr_value_entry_encode_enum_check(
                     attrValueEntry.data(), attrValueEntry.size(),
                     attrEntry->attr_handle, attrType, 1, handles.data());
+                if (rc != PLDM_SUCCESS)
+                {
+                    std::cout
+                        << "Failed to encode BIOS table attribute enum: " << rc
+                        << std::endl;
+                    return;
+                }
                 break;
             }
             case PLDM_BIOS_STRING:
@@ -883,9 +890,16 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
 
                 attrValueEntry.resize(entryLength);
 
-                pldm_bios_table_attr_value_entry_encode_string(
+                int rc = pldm_bios_table_attr_value_entry_encode_string_check(
                     attrValueEntry.data(), entryLength, attrEntry->attr_handle,
                     attrType, attrValue.size(), attrValue.c_str());
+                if (rc != PLDM_SUCCESS)
+                {
+                    std::cout
+                        << "Failed to encode BIOS table attribute string: "
+                        << rc << std::endl;
+                    return;
+                }
                 break;
             }
             case PLDM_BIOS_INTEGER:

--- a/pldmtool/pldm_bios_cmd.cpp
+++ b/pldmtool/pldm_bios_cmd.cpp
@@ -909,9 +909,16 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                 entryLength =
                     pldm_bios_table_attr_value_entry_encode_integer_length();
                 attrValueEntry.resize(entryLength);
-                pldm_bios_table_attr_value_entry_encode_integer(
+                int rc = pldm_bios_table_attr_value_entry_encode_integer_check(
                     attrValueEntry.data(), entryLength, attrEntry->attr_handle,
                     attrType, value);
+                if (rc != PLDM_SUCCESS)
+                {
+                    std::cout
+                        << "Failed to encode BIOS table attribute integer: "
+                        << rc << std::endl;
+                    return;
+                }
                 break;
             }
         }


### PR DESCRIPTION
Many of these changes are backports of patches already merged upstream, though have needed to be modified due to various downstream constraints.

With these patches I've booted a Rainier platform to host firmware standby without issue.