### PR TITLE
Throw Marker Lid validate error

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "file_io_by_type.hpp"
+#include "xyz/openbmc_project/Common/error.hpp"
 
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Software/Version/error.hpp>
 
@@ -21,9 +24,13 @@ using MarkerLIDremainingSize = uint64_t;
 
 constexpr auto markerLidName = "80a00001.lid";
 constexpr auto accessKeyExpired =
-    "sdbusplus::xyz::openbmc_project::Software::Version::Error::ExpiredAccessKey";
+    "xyz.openbmc_project.Software.Version.Error.ExpiredAccessKey";
+using AccessKeyExpired =
+    sdbusplus::xyz::openbmc_project::Software::Version::Error::ExpiredAccessKey;
 constexpr auto incompatibleErr =
-    "sdbusplus::xyz::openbmc_project::Software::Version::Error::Incompatible";
+    "xyz.openbmc_project.Software.Version.Error.Incompatible";
+using IncompatibleErr =
+    sdbusplus::xyz::openbmc_project::Software::Version::Error::Incompatible;
 
 /** @class LidHandler
  *
@@ -148,12 +155,14 @@ class LidHandler : public FileHandler
             }
             catch (const sdbusplus::exception::exception& e)
             {
-                if (strcmp(e.name(), accessKeyExpired) != 0)
+                if (strcmp(e.name(), accessKeyExpired) == 0)
                 {
+                    phosphor::logging::commit<AccessKeyExpired>();
                     validateStatus = ENTITLEMENT_FAIL;
                 }
-                else if (strcmp(e.name(), incompatibleErr) != 0)
+                else if (strcmp(e.name(), incompatibleErr) == 0)
                 {
+                    phosphor::logging::commit<IncompatibleErr>();
                     validateStatus = MIN_MIF_FAIL;
                 }
                 std::cerr << "Marker lid validate error, "


### PR DESCRIPTION
Commit the marker lid validate errors for the
min-mif level and access key expiration so that
it generates an SRC when we hit the error during
code update.