### PR TITLE
For/1060/libpldm v0.6.0

### DIFF
--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -221,8 +221,16 @@ void FruImpl::buildFRUTable()
         }
     }
 
-    pldm_entity_association_pdr_add(entityTree, pdrRepo, false,
-                                    TERMINUS_HANDLE);
+    int rc = pldm_entity_association_pdr_add_check(entityTree, pdrRepo, false,
+                                                   TERMINUS_HANDLE);
+    if (rc < 0)
+    {
+        // pldm_entity_assocation_pdr_add() assert()ed on failure
+        error("Failed to add PLDM entity association PDR: {LIBPLDM_ERROR}",
+              "LIBPLDM_ERROR", rc);
+        throw std::runtime_error("Failed to add PLDM entity association PDR");
+    }
+
     // save a copy of bmc's entity association tree
     pldm_entity_association_tree_copy_root(entityTree, bmcEntityTree);
 

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -466,8 +466,8 @@ class GetPDR : public CommandInterface
         {PLDM_STATE_SET_BOOT_PROG_STATE_OSSTART, "OSStart"}};
 
     static inline const std::map<uint8_t, std::string> setOpFaultStatus{
-        {PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS_NORMAL, "Normal"},
-        {PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS_STRESSED, "Stressed"}};
+        {PLDM_STATE_SET_OPERATIONAL_STRESS_STATUS_NORMAL, "Normal"},
+        {PLDM_STATE_SET_OPERATIONAL_STRESS_STATUS_STRESSED, "Stressed"}};
 
     static inline const std::map<uint8_t, std::string> setSysPowerState{
         {PLDM_STATE_SET_SYS_POWER_STATE_OFF_SOFT_GRACEFUL, "Off-Soft Graceful"},


### PR DESCRIPTION
Backport two patches from upstream openbmc/pldm that allow us to move forward to v0.6.0 of openbmc/libpldm