### PR TITLE
Moving fetch activation property

### DIFF
--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -335,15 +335,15 @@ void CodeUpdate::setVersions()
 
                 try
                 {
-                    auto propVal =
-                        pldm::utils::DBusHandler().getDbusPropertyVariant(
-                            imageObjPath, "Activation", imageInterface);
-                    const auto& activation = std::get<std::string>(propVal);
-
-                    if (activation ==
-                        "xyz.openbmc_project.Software.Activation.Activations.Invalid")
+                    if (isCodeUpdateInProgress())
                     {
-                        if (isCodeUpdateInProgress())
+                        auto propVal =
+                            pldm::utils::DBusHandler().getDbusPropertyVariant(
+                                imageObjPath, "Activation", imageInterface);
+                        const auto& activation = std::get<std::string>(propVal);
+
+                        if (activation ==
+                            "xyz.openbmc_project.Software.Activation.Activations.Invalid")
                         {
                             error(
                                 "InbandCodeUpdate Failed: Received Invalid Signal, Sending Error on End update sensor event to PHYP");


### PR DESCRIPTION
This commit adds change to move the fetching of activation property inside the inband code update path. As it is a no-op for out of band updates.

Defect: [565265](https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=565265)