### PR TITLE
pdr: Missing nvme slot entries in the json (#447)

### DIFF
--- a/oem/ibm/configurations/pdr/ibm,rainier-1s4u/11.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-1s4u/11.json
@@ -552,6 +552,44 @@
         }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0",
+        "effecters": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme0_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1",
+        "effecters": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme1_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2",
         "effecters" : [{
             "set" : {
@@ -620,6 +658,82 @@
         }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6",
+        "effecters": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme6_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7",
+        "effecters": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme7_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0",
+        "effecters": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme8_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1",
+        "effecters": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme9_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2",
         "effecters" : [{
             "set" : {
@@ -686,6 +800,44 @@
                 "property_values" : [false, true]
              }
         }]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6",
+        "effecters": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme14_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7",
+        "effecters": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme15_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
     },
     {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
@@ -1474,6 +1626,43 @@
              }
         }]
      },
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0",
+        "effecters": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0",
+                    "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    "property_name": "Functional",
+                    "property_type": "bool",
+                    "property_values": [true, false]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1",
+        "effecters": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1",
+                    "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    "property_name": "Functional",
+                    "property_type": "bool",
+                    "property_values": [true, false]
+                }
+            }
+        ]
+    },
     {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2",
         "effecters" : [{
@@ -1543,6 +1732,82 @@
         }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6",
+        "effecters": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6",
+                    "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    "property_name": "Functional",
+                    "property_type": "bool",
+                    "property_values": [true, false]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7",
+        "effecters": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7",
+                    "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    "property_name": "Functional",
+                    "property_type": "bool",
+                    "property_values": [true, false]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0",
+        "effecters": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0",
+                    "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    "property_name": "Functional",
+                    "property_type": "bool",
+                    "property_values": [true, false]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1",
+        "effecters": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1",
+                    "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    "property_name": "Functional",
+                    "property_type": "bool",
+                    "property_values": [true, false]
+                }
+            }
+        ]
+    },
+    {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2",
         "effecters" : [{
             "set" : {
@@ -1609,6 +1874,44 @@
                 "property_values" : [true, false]
              }
         }]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6",
+        "effecters": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6",
+                    "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    "property_name": "Functional",
+                    "property_type": "bool",
+                    "property_values": [true, false]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7",
+        "effecters": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7",
+                    "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    "property_name": "Functional",
+                    "property_type": "bool",
+                    "property_values": [true, false]
+                }
+            }
+        ]
     },
     {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
@@ -2063,6 +2366,52 @@
       }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0",
+        "effecters": [
+            {
+                "set": {
+                    "id": 257,
+                    "size": 1,
+                    "states": [0, 1, 4]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0",
+                    "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                    "property_name": "PowerState",
+                    "property_type": "string",
+                    "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1",
+        "effecters": [
+            {
+                "set": {
+                    "id": 257,
+                    "size": 1,
+                    "states": [0, 1, 4]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1",
+                    "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                    "property_name": "PowerState",
+                    "property_type": "string",
+                    "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off"
+                    ]
+                }
+            }
+        ]
+    },
+    {
        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2",
        "effecters" : [{
            "set" : {
@@ -2147,6 +2496,98 @@
       }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6",
+        "effecters": [
+            {
+                "set": {
+                    "id": 257,
+                    "size": 1,
+                    "states": [0, 1, 4]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6",
+                    "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                    "property_name": "PowerState",
+                    "property_type": "string",
+                    "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7",
+        "effecters": [
+            {
+                "set": {
+                    "id": 257,
+                    "size": 1,
+                    "states": [0, 1, 4]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7",
+                    "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                    "property_name": "PowerState",
+                    "property_type": "string",
+                    "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0",
+        "effecters": [
+            {
+                "set": {
+                    "id": 257,
+                    "size": 1,
+                    "states": [0, 1, 4]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0",
+                    "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                    "property_name": "PowerState",
+                    "property_type": "string",
+                    "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1",
+        "effecters": [
+            {
+                "set": {
+                    "id": 257,
+                    "size": 1,
+                    "states": [0, 1, 4]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1",
+                    "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                    "property_name": "PowerState",
+                    "property_type": "string",
+                    "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off"
+                    ]
+                }
+            }
+        ]
+    },
+    {
        "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2",
        "effecters" : [{
            "set" : {
@@ -2229,6 +2670,52 @@
                ]
            }
       }]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6",
+        "effecters": [
+            {
+                "set": {
+                    "id": 257,
+                    "size": 1,
+                    "states": [0, 1, 4]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6",
+                    "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                    "property_name": "PowerState",
+                    "property_type": "string",
+                    "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On",
+                                    "xyz.openbmc_project.State.Decorator.PowerState.State.Off"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7",
+        "effecters": [
+            {
+                "set": {
+                    "id": 257,
+                    "size": 1,
+                    "states": [0, 1, 4]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7",
+                    "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                    "property_name": "PowerState",
+                    "property_type": "string",
+                    "property_values": [
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Unknown",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.On",
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off"
+                    ]
+                }
+            }
+        ]
     }]
   }]
 }

--- a/oem/ibm/configurations/pdr/ibm,rainier-1s4u/4.json
+++ b/oem/ibm/configurations/pdr/ibm,rainier-1s4u/4.json
@@ -575,6 +575,44 @@
         }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0",
+        "sensors": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme0_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1",
+        "sensors": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme1_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2",
         "sensors" : [{
             "set" : {
@@ -643,6 +681,82 @@
         }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6",
+        "sensors": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme6_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7",
+        "sensors": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme7_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0",
+        "sensors": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme8_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1",
+        "sensors": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme9_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2",
         "sensors" : [{
             "set" : {
@@ -709,6 +823,44 @@
                 "property_values" : [false, true]
              }
         }]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6",
+        "sensors": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme14_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7",
+        "sensors": [
+            {
+                "set": {
+                    "id": 17,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme15_identify",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
     },
     {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
@@ -1508,6 +1660,44 @@
         }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme0",
+        "sensors": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme0_fault",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme1",
+        "sensors": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme1_fault",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme2",
         "sensors" : [{
             "set" : {
@@ -1576,6 +1766,82 @@
         }]
     },
     {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme6",
+        "sensors": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme6_fault",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0/nvme7",
+        "sensors": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme7_fault",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme0",
+        "sensors": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme8_fault",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme1",
+        "sensors": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme9_fault",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme2",
         "sensors" : [{
             "set" : {
@@ -1642,6 +1908,44 @@
                 "property_values" : [false, true]
              }
         }]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme6",
+        "sensors": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme14_fault",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
+    },
+    {
+        "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1/nvme7",
+        "sensors": [
+            {
+                "set": {
+                    "id": 10,
+                    "size": 1,
+                    "states": [1, 2]
+                },
+                "dbus": {
+                    "path": "/xyz/openbmc_project/led/groups/nvme15_fault",
+                    "interface": "xyz.openbmc_project.Led.Group",
+                    "property_name": "Asserted",
+                    "property_type": "bool",
+                    "property_values": [false, true]
+                }
+            }
+        ]
     },
     {
         "entity_path" : "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",


### PR DESCRIPTION
The ibm,rainier1s-4u json had missing nvme slots and were not modelled by PLDM. This commit adds the same.

Fixes: 561341

Change-Id: I0559f1761a6ec223fa62aa14c283885d3aa37e49