### PR TITLE
BIOS attribute to configure network parameter

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -197,15 +197,15 @@
             "attribute_name": "pvm_os_boot_type",
             "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
             "default_values": ["A_Mode"],
-            "helpText": "Select the IBMi partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
-            "displayName": "IBMi Partition Boot Mode"
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
         },
         {
             "attribute_name": "pvm_os_boot_type_current",
             "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
             "default_values": ["A_Mode"],
-            "helpText": "Specifies the current IBMi partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
-            "displayName": "IBMi Partition Boot Mode (current)",
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
             "readOnly": true
         },
         {
@@ -552,6 +552,27 @@
                 "property_type": "bool",
                 "property_values": [true, false]
             }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
         }
     ]
 }

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -267,6 +267,24 @@
                 "property_type": "double",
                 "property_name": "Value"
             }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
         }
     ]
 }

--- a/oem/ibm/configurations/bios/string_attrs.json
+++ b/oem/ibm/configurations/bios/string_attrs.json
@@ -209,7 +209,7 @@
             "default_string_length": 0,
             "default_string": "",
             "helpText": "Specifies the load source the system will use to start the logical partition.",
-            "displayName": "Tagged IBMi Load Source"
+            "displayName": "Tagged IBM i Load Source"
         },
         {
             "attribute_name": "pvm_ibmi_alt_load_source",
@@ -219,7 +219,7 @@
             "default_string_length": 0,
             "default_string": "",
             "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
-            "displayName": "Tagged IBMi Alternate Load Source"
+            "displayName": "Tagged IBM i Alternate Load Source"
         },
         {
             "attribute_name": "pvm_ibmi_console",
@@ -229,7 +229,77 @@
             "default_string_length": 0,
             "default_string": "",
             "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
-            "displayName": "Tagged IBMi Console"
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
         }
     ]
 }


### PR DESCRIPTION
Adding bios attribute to configure network boot parameter from the GUI webpage, GUI would then populate these BIOS attributes through redfish and this selection will be communicated to pldm remote terminus via these PLDM BIOS attributes.

