### PR TITLE
requester: Queue the request messages to one endpoint

### DIFF
--- a/requester/handler.hpp
+++ b/requester/handler.hpp
@@ -16,7 +16,10 @@
 
 #include <cassert>
 #include <chrono>
+#include <deque>
 #include <memory>
+#include <mutex>
+#include <queue>
 #include <tuple>
 #include <unordered_map>
 
@@ -62,6 +65,25 @@ struct RequestKeyHasher
 
 using ResponseHandler = fu2::unique_function<void(
     mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen)>;
+
+struct RegisteredRequest
+{
+    RequestKey key;                  //!< Responder MCTP endpoint ID
+    std::vector<uint8_t> reqMsg;     //!< Request messages queue
+    ResponseHandler responseHandler; //!< Waiting for response flag
+};
+
+struct EndpointMessageQueue
+{
+    mctp_eid_t eid; //!< Responder MCTP endpoint ID
+    std::deque<std::shared_ptr<RegisteredRequest>> requestQueue; //!< Queue
+    bool waitForRespMsg; //!< Waiting for response flag
+
+    bool operator==(const mctp_eid_t& mctpEid) const
+    {
+        return (eid == mctpEid);
+    }
+};
 
 /** @class Handler
  *
@@ -111,6 +133,97 @@ class Handler
         numRetries(numRetries), responseTimeOut(responseTimeOut)
     {}
 
+    void instanceIdExpiryCallBack(RequestKey key)
+    {
+        auto eid = key.eid;
+        if (this->handlers.contains(key))
+        {
+            error("The eid:InstanceID {EID}:{IID} is using.", "EID",
+                  (unsigned)key.eid, "IID", (unsigned)key.instanceId);
+            auto& [request, responseHandler,
+                   timerInstance] = this->handlers[key];
+            request->stop();
+            auto rc = timerInstance->stop();
+            if (rc)
+            {
+                error("Failed to stop the instance ID expiry timer. RC = {RC}",
+                      "RC", static_cast<int>(rc));
+            }
+            // Call response handler with an empty response to indicate no
+            // response
+            responseHandler(eid, nullptr, 0);
+            this->removeRequestContainer.emplace(
+                key,
+                std::make_unique<sdeventplus::source::Defer>(
+                    event, std::bind(&Handler::removeRequestEntry, this, key)));
+            endpointMessageQueues[eid]->waitForRespMsg = false;
+
+            /* try to send new request if the endpoint is free */
+            startNewRequest(eid);
+        }
+        else
+        {
+            // This condition is not possible, if a response is received
+            // before the instance ID expiry, then the response handler
+            // is executed and the entry will be removed.
+            assert(false);
+        }
+    }
+
+    /** @brief Send the remaining PLDM request messages in endpoint queue
+     *
+     *  @param[in] eid - endpoint ID of the remote MCTP endpoint
+     */
+    int startNewRequest(mctp_eid_t eid)
+    {
+        if (endpointMessageQueues[eid]->waitForRespMsg ||
+            endpointMessageQueues[eid]->requestQueue.empty())
+        {
+            return PLDM_SUCCESS;
+        }
+
+        endpointMessageQueues[eid]->waitForRespMsg = true;
+        auto requestMsg = endpointMessageQueues[eid]->requestQueue.front();
+        endpointMessageQueues[eid]->requestQueue.pop_front();
+
+        auto request = std::make_unique<RequestInterface>(
+            fd, requestMsg->key.eid, event, std::move(requestMsg->reqMsg),
+            numRetries, responseTimeOut, currentSendbuffSize, verbose);
+        auto timer = std::make_unique<phosphor::Timer>(
+            event.get(), std::bind(&Handler::instanceIdExpiryCallBack, this,
+                                   requestMsg->key));
+
+        auto rc = request->start();
+        if (rc)
+        {
+            requester.markFree(requestMsg->key.eid, requestMsg->key.instanceId);
+            error("Failure to send the PLDM request message");
+            endpointMessageQueues[eid]->waitForRespMsg = false;
+            return rc;
+        }
+
+        try
+        {
+            timer->start(duration_cast<std::chrono::microseconds>(
+                instanceIdExpiryInterval));
+        }
+        catch (const std::runtime_error& e)
+        {
+            requester.markFree(requestMsg->key.eid, requestMsg->key.instanceId);
+            error(
+                "Failed to start the instance ID expiry timer. RC = {ERR_EXCEP}",
+                "ERR_EXCEP", e.what());
+            endpointMessageQueues[eid]->waitForRespMsg = false;
+            return PLDM_ERROR;
+        }
+
+        handlers.emplace(requestMsg->key,
+                         std::make_tuple(std::move(request),
+                                         std::move(requestMsg->responseHandler),
+                                         std::move(timer)));
+        return PLDM_SUCCESS;
+    }
+
     /** @brief Register a PLDM request message
      *
      *  @param[in] eid - endpoint ID of the remote MCTP endpoint
@@ -128,73 +241,24 @@ class Handler
     {
         RequestKey key{eid, instanceId, type, command};
 
-        auto instanceIdExpiryCallBack = [key, this](void) {
-            if (this->handlers.contains(key))
-            {
-                error(
-                    "Response not received for the request, instance ID expired. EID = {EID} INSTANCE_ID = {INST_ID} TYPE = {KEY_TYP} COMMAND = {CMD}",
-                    "EID", (unsigned)key.eid, "INST_ID",
-                    (unsigned)key.instanceId, "KEY_TYP", (unsigned)key.type,
-                    "CMD", (unsigned)key.command);
-                auto& [request, responseHandler,
-                       timerInstance] = this->handlers[key];
-                request->stop();
-                auto rc = timerInstance->stop();
-                if (rc)
-                {
-                    error(
-                        "Failed to stop the instance ID expiry timer. RC = {RC}",
-                        "RC", rc);
-                }
-                // Call response handler with an empty response to indicate no
-                // response
-                responseHandler(key.eid, nullptr, 0);
-                this->removeRequestContainer.emplace(
-                    key, std::make_unique<sdeventplus::source::Defer>(
-                             event, std::bind(&Handler::removeRequestEntry,
-                                              this, key)));
-            }
-            else
-            {
-                // This condition is not possible, if a response is received
-                // before the instance ID expiry, then the response handler
-                // is executed and the entry will be removed.
-                assert(false);
-            }
-        };
-
-        auto request = std::make_unique<RequestInterface>(
-            fd, eid, event, std::move(requestMsg), numRetries, responseTimeOut,
-            currentSendbuffSize, verbose);
-        auto timer = std::make_unique<phosphor::Timer>(
-            event.get(), instanceIdExpiryCallBack);
-
-        auto rc = request->start();
-        if (rc)
+        auto inputRequest = std::make_shared<RegisteredRequest>(
+            key, std::move(requestMsg), std::move(responseHandler));
+        if (endpointMessageQueues.find(eid) != endpointMessageQueues.end())
         {
-            requester.markFree(eid, instanceId);
-            error("Failure to send the PLDM request message");
-            return rc;
+            endpointMessageQueues[eid]->requestQueue.push_back(inputRequest);
+        }
+        else
+        {
+            std::deque<std::shared_ptr<RegisteredRequest>> reqQueue;
+            reqQueue.push_back(inputRequest);
+            endpointMessageQueues[eid] =
+                std::make_shared<EndpointMessageQueue>(eid, reqQueue, false);
         }
 
-        try
-        {
-            timer->start(duration_cast<std::chrono::microseconds>(
-                instanceIdExpiryInterval));
-        }
-        catch (const std::runtime_error& e)
-        {
-            requester.markFree(eid, instanceId);
-            error(
-                "Failed to start the instance ID expiry timer. RC = {ERR_EXCEP}",
-                "ERR_EXCEP", e.what());
-            return PLDM_ERROR;
-        }
+        /* try to send new request if the endpoint is free */
+        startNewRequest(eid);
 
-        handlers.emplace(key, std::make_tuple(std::move(request),
-                                              std::move(responseHandler),
-                                              std::move(timer)));
-        return rc;
+        return PLDM_SUCCESS;
     }
 
     /** @brief Handle PLDM response message
@@ -224,6 +288,10 @@ class Handler
             responseHandler(eid, response, respMsgLen);
             requester.markFree(key.eid, key.instanceId);
             handlers.erase(key);
+
+            endpointMessageQueues[eid]->waitForRespMsg = false;
+            /* try to send new request if the endpoint is free */
+            startNewRequest(eid);
         }
         else
         {
@@ -254,6 +322,9 @@ class Handler
     using RequestValue =
         std::tuple<std::unique_ptr<RequestInterface>, ResponseHandler,
                    std::unique_ptr<phosphor::Timer>>;
+    // Manage the requests of responders base on MCTP EID
+    std::map<mctp_eid_t, std::shared_ptr<EndpointMessageQueue>>
+        endpointMessageQueues;
 
     /** @brief Container for storing the PLDM request entries */
     std::unordered_map<RequestKey, RequestValue, RequestKeyHasher> handlers;

--- a/requester/test/handler_test.cpp
+++ b/requester/test/handler_test.cpp
@@ -134,7 +134,7 @@ TEST_F(HandlerTest, multipleRequestResponseScenario)
 
     pldm::Response response(sizeof(pldm_msg_hdr) + sizeof(uint8_t));
     auto responsePtr = reinterpret_cast<const pldm_msg*>(response.data());
-    reqHandler.handleResponse(eid, instanceIdNxt, 0, 0, responsePtr,
+    reqHandler.handleResponse(eid, instanceId, 0, 0, responsePtr,
                               sizeof(response));
     EXPECT_EQ(validResponse, true);
     EXPECT_EQ(callbackCount, 1);
@@ -144,7 +144,7 @@ TEST_F(HandlerTest, multipleRequestResponseScenario)
     // simulate a delayed response for the first request
     waitEventExpiry(milliseconds(500));
 
-    reqHandler.handleResponse(eid, instanceId, 0, 0, responsePtr,
+    reqHandler.handleResponse(eid, instanceIdNxt, 0, 0, responsePtr,
                               sizeof(response));
 
     EXPECT_EQ(validResponse, true);


### PR DESCRIPTION
Section "Requirements for requesters" in DSP0240 details "A PLDM terminus that issues PLDM requests to another PLDM terminus shall wait until one of the following occurs before issuing a new PLDM request: it gets the response to a particular request, it times out waiting for the response, or it receives an indication that transmission of the particular request failed." So the registered request messages to one endpoint have to be queued before sending to meet the requester requirement.

When a sensor manager is added to pldmd daemon to manage the sensors of one terminus, the sensor manager will support the sensor polling timers. The timers will poll the PLDM sensors with different intervals so there can be many `getSensorReading` requests to one endpoint to get the sensor values. Moreover, BMC also sends
`PollForPlatformEventMessage` requests to get the event data when it receives the `pldmMessagePollEvent` event from the terminus. So those TX request messages have to be queued.

Change-Id: Ifa32501596d99aa09d56e703ff962570525a70ec