### PR TITLE
1060: PLDM: LG2 migration for missed out traces (#466)

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -257,8 +257,9 @@ GetSubTreeResponse
     }
     catch (const std::exception& e)
     {
-        std::cerr << "failed GetSubTree query for interface " << ifaceList[0]
-                  << " with ERROR=" << e.what() << "\n";
+        error(
+            "failed GetSubTree query for interface {FACE_LIST} with ERROR = {ERR_EXCEP}",
+            "FACE_LIST", ifaceList[0], "ERR_EXCEP", e.what());
     }
     return response;
 }

--- a/host-bmc/dbus/serialize.cpp
+++ b/host-bmc/dbus/serialize.cpp
@@ -143,7 +143,7 @@ void Serialize::reSerialize(const std::vector<uint16_t> types)
     {
         if (savedObjs.contains(type))
         {
-            error(
+            info(
                 "Removing objects of type : {OBJ_TYP} from the persistent cache",
                 "OBJ_TYP", (unsigned)type);
             savedObjs.erase(savedObjs.find(type));

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1504,7 +1504,7 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
             ++sensorMapIndex;
             if (sensorMapIndex == sensorMap.end())
             {
-                // std::cerr << "sensor map completed\n";
+                // error("sensor map completed");
                 ++objMapIndex;
                 sensorMapIndex = sensorMap.begin();
             }
@@ -1571,7 +1571,7 @@ void HostPDRHandler::getPresentStateBySensorReadigs(
         ++sensorMapIndex;
         if (sensorMapIndex == sensorMap.end())
         {
-            // std::cerr << "sensor map completed\n";
+            // error("sensor map completed");
             ++objMapIndex;
             sensorMapIndex = sensorMap.begin();
         }

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -212,7 +212,7 @@ void FruImpl::buildFRUTable()
                 }
                 catch (const std::exception& e)
                 {
-                    info(
+                    error(
                         "Config JSONs missing for the item interface type, interface = {INTF}",
                         "INTF", interface.first);
                     break;
@@ -574,7 +574,7 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
         pldm_entity node_entity = pldm_entity_extract(node);
         objToEntityNode[fruObjectPath] = node_entity;
         error(
-            "Building Individual FRU [FRU_OBJ_PATH] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ] Parent :[ {P_ENTITY_TYP}, {P_ENTITY_NUM}, {P_ENTITY_ID} ]",
+            "Building Individual FRU [{FRU_OBJ_PATH}] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ] Parent :[ {P_ENTITY_TYP}, {P_ENTITY_NUM}, {P_ENTITY_ID} ]",
             "FRU_OBJ_PATH", fruObjectPath, "ENTITY_TYP",
             static_cast<unsigned>(node_entity.entity_type), "ENTITY_NUM",
             static_cast<unsigned>(node_entity.entity_instance_num), "ENTITY_ID",
@@ -615,7 +615,7 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
     }
     catch (const std::exception& e)
     {
-        info(
+        error(
             "Config JSONs missing for the item in concurrent add path interface type, interface = {FRU_INTF}",
             "FRU_INTF", fruInterface);
     }

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -73,7 +73,7 @@ void Handler::generate(const pldm::utils::DBusHandler& dBusIntf,
 {
     for (const auto& directory : dir)
     {
-        error("checking if : {DIR} exists", "DIR", directory.c_str());
+        info("checking if : {DIR} exists", "DIR", directory.c_str());
         if (!fs::exists(directory))
         {
             return;

--- a/libpldmresponder/test/libpldmresponder_platform_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_platform_test.cpp
@@ -198,13 +198,10 @@ TEST(getPDR, testFindPDR)
                                            // current is not what we want
 
         pldm_pdr_hdr* hdr = reinterpret_cast<pldm_pdr_hdr*>(resp->record_data);
-        std::cerr << "PDR next record handle " << handle << "\n";
-        std::cerr << "PDR type " << hdr->type << "\n";
         if (hdr->type == PLDM_STATE_EFFECTER_PDR)
         {
             pldm_state_effecter_pdr* pdr =
                 reinterpret_cast<pldm_state_effecter_pdr*>(resp->record_data);
-            std::cerr << "PDR entity type " << pdr->entity_type << "\n";
             if (pdr->entity_type == 100)
             {
                 found = true;

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -628,9 +628,9 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
             }
             catch (const std::exception& e)
             {
-                std::cerr << "failed to set token for resource dump, ERROR="
-                          << e.what() << "\n";
-                return PLDM_ERROR;
+                error("failed to set token for resource dump,
+                ERROR={ERR_EXCEP}", "ERR_EXCEP", e.what());
+            return PLDM_ERROR;
             }*/
         }
 

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -163,8 +163,8 @@ class LidHandler : public FileHandler
                     phosphor::logging::commit<IncompatibleErr>();
                     validateStatus = MIN_MIF_FAIL;
                 }
-                std::cerr << "Marker lid validate error, "
-                          << "ERROR=" << e.what() << std::endl;
+                error("Marker lid validate error, ERROR={ERR_EXCEP}",
+                      "ERR_EXCEP", e.what());
             }
             oemIbmPlatformHandler->sendStateSensorEvent(
                 sensorId, PLDM_STATE_SENSOR_STATE, 0, validateStatus, VALID);

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -620,8 +620,8 @@ void PCIeInfoHandler::parseSecondaryLink(
         std::filesystem::path mexConnecter(mexConnecterPath);
         auto mexSlotandAdapter = getMexSlotandAdapter(mexConnecter);
 
-        std::cout << "Creating associations under "
-                  << std::get<1>(mexSlotandAdapter) << std::endl;
+        info("Creating associations under {MEX_SLOT_ADAPTER}",
+             "MEX_SLOT_ADAPTER", std::get<1>(mexSlotandAdapter));
         std::vector<std::tuple<std::string, std::string, std::string>>
             associations;
         for (auto slot : ioSlotLocationCode)
@@ -973,7 +973,7 @@ void PCIeInfoHandler::parseTopologyData()
                 (struct SlotLocCodeSuf_t*)suffix_data;
             if (slot_loc_suf_data == nullptr)
             {
-                std::cerr << "slot location suffix data is nullptr \n";
+                error("slot location suffix data is nullptr");
                 break;
             }
 

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.cpp
@@ -52,8 +52,9 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
 
     if (length < keywrdSize)
     {
-        std::cerr << "length requested is less the keyword size, length: "
-                  << length << " keyword size: " << keywrdSize << std::endl;
+        error(
+            "length requested is less the keyword size, length: {LEN} keyword size: {KEYWORD_SIZE}",
+            "LEN", length, "KEYWORD_SIZE", keywrdSize);
         return PLDM_ERROR_INVALID_DATA;
     }
 
@@ -82,8 +83,8 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
 
     if (offset > keywrdSize)
     {
-        std::cerr << "Offset exceeds file size, OFFSET=" << offset
-                  << " FILE_SIZE=" << keywrdSize << std::endl;
+        error("Offset exceeds file size, OFFSET={OFFSET} FILE_SIZE={FILE_SIZE}",
+              "OFFSET", offset, "FILE_SIZE", keywrdSize);
         return PLDM_DATA_OUT_OF_RANGE;
     }
     // length of keyword data should be same as keyword data size in dbus object
@@ -91,9 +92,7 @@ int keywordHandler::read(uint32_t offset, uint32_t& length, Response& response,
     auto returnCode = lseek(fd, offset, SEEK_SET);
     if (returnCode == -1)
     {
-        std::cerr
-            << "Could not find keyword data at given offset. File Seek failed"
-            << std::endl;
+        error("Could not find keyword data at given offset. File Seek failed");
         return PLDM_ERROR;
     }
 


### PR DESCRIPTION
#### PLDM: LG2 migration for missed out traces (#466)
```
As part of adding new features there were
traces that are still using standard ostream
pattern of logging. As PLDM repository migrated
to structured logging hence migrating the new
log traces to follow the same practice.

Additionally minor refinement of traces is also
handled as a part of this commit, listed below -

1. Correction in type of log (ex- error or info)
2. Correction in spelling of log message
3. Removing logs from test file.

Signed-off-by: Riya Dixit <riyadixitagra@gmail.com>```