### PR TITLE
Adding response mechanism to remote terminus

### DIFF
--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -61,11 +61,13 @@ struct CustomFD
     CustomFD(CustomFD&&) = delete;
     CustomFD& operator=(CustomFD&&) = delete;
 
-    CustomFD(int fd) : fd(fd) {}
+    CustomFD(int fd, bool closeOnOutScope = true) :
+        fd(fd), closeOnOutScope(closeOnOutScope)
+    {}
 
     ~CustomFD()
     {
-        if (fd >= 0)
+        if (fd >= 0 && closeOnOutScope)
         {
             close(fd);
         }
@@ -78,6 +80,7 @@ struct CustomFD
 
   private:
     int fd = -1;
+    bool closeOnOutScope;
 };
 
 /** @brief Calculate the pad for PLDM data

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "common/utils.hpp"
+#include "file_io_by_type.hpp"
 #include "oem/ibm/requester/dbus_to_file_handler.hpp"
 #include "oem_ibm_handler.hpp"
 #include "pldmd/handler.hpp"
+#include "pldmd/pldm_resp_interface.hpp"
 #include "requester/handler.hpp"
 
 #include <fcntl.h>
@@ -11,6 +13,7 @@
 #include <libpldm/file_io.h>
 #include <libpldm/host.h>
 #include <stdint.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -18,6 +21,7 @@
 #include <phosphor-logging/lg2.hpp>
 
 #include <filesystem>
+#include <functional>
 #include <iostream>
 #include <vector>
 
@@ -29,6 +33,14 @@ namespace responder
 {
 namespace dma
 {
+
+struct IOPart
+{
+    uint32_t length;
+    uint32_t offset;
+    uint64_t address;
+};
+
 // The minimum data size of dma transfer in bytes
 constexpr uint32_t minSize = 16;
 
@@ -172,10 +184,12 @@ class Handler : public CmdHandler
   public:
     Handler(oem_platform::Handler* oemPlatformHandler, int hostSockFd,
             uint8_t hostEid, dbus_api::Requester* dbusImplReqester,
-            pldm::requester::Handler<pldm::requester::Request>* handler) :
+            pldm::requester::Handler<pldm::requester::Request>* handler,
+            pldm::response_api::Transport* respInterface) :
         oemPlatformHandler(oemPlatformHandler),
         hostSockFd(hostSockFd), hostEid(hostEid),
-        dbusImplReqester(dbusImplReqester), handler(handler)
+        dbusImplReqester(dbusImplReqester), handler(handler),
+        responseHdr({0, 0, respInterface, 0, -1})
     {
         handlers.emplace(PLDM_READ_FILE_INTO_MEMORY,
                          [this](const pldm_msg* request, size_t payloadLength) {
@@ -490,6 +504,7 @@ class Handler : public CmdHandler
     pldm::requester::Handler<pldm::requester::Request>* handler;
     std::vector<std::unique_ptr<pldm::requester::oem_ibm::DbusToFileHandler>>
         dbusToFileHandlers;
+    ResponseHdr responseHdr;
 };
 
 } // namespace oem_ibm

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -1,12 +1,28 @@
 #pragma once
 
-#include "file_io.hpp"
+#include "oem_ibm_handler.hpp"
+#include "pldmd/pldm_resp_interface.hpp"
 
 namespace pldm
 {
 
 namespace responder
 {
+
+class FileHandler;
+namespace dma
+{
+class DMA;
+} // namespace dma
+
+struct ResponseHdr
+{
+    uint8_t instance_id;
+    uint8_t command;
+    pldm::response_api::Transport* respInterface;
+    std::shared_ptr<FileHandler> functionPtr = nullptr;
+    int key;
+};
 
 namespace fs = std::filesystem;
 

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "file_io_by_type.hpp"
+#include "file_io.hpp"
 
 #include <tuple>
 

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "file_io_by_type.hpp"
+#include "file_io.hpp"
 
 namespace pldm
 {

--- a/oem/ibm/libpldmresponder/file_io_type_lic.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "file_io_by_type.hpp"
+#include "file_io.hpp"
 
 namespace pldm
 {

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "file_io_by_type.hpp"
-#include "xyz/openbmc_project/Common/error.hpp"
+#include "file_io.hpp"
 
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "file_io_by_type.hpp"
+#include "file_io.hpp"
 
 #include <arpa/inet.h>
 #include <fcntl.h>

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "file_io_by_type.hpp"
+#include "file_io.hpp"
 
 namespace pldm
 {

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "file_io_by_type.hpp"
+#include "file_io.hpp"
 
 namespace pldm
 {

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "file_io_by_type.hpp"
+#include "file_io.hpp"
 
 namespace pldm
 {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -5,7 +5,6 @@
 
 #include "collect_slot_vpd.hpp"
 #include "file_io_type_lid.hpp"
-#include "libpldmresponder/file_io.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
 
 #include <phosphor-logging/lg2.hpp>

--- a/oem/ibm/test/libpldmresponder_fileio_test.cpp
+++ b/oem/ibm/test/libpldmresponder_fileio_test.cpp
@@ -225,7 +225,7 @@ TEST(ReadFileIntoMemory, BadPath)
     // Pass invalid payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.readFileIntoMemory(request, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -259,7 +259,7 @@ TEST_F(TestFileTable, ReadFileInvalidFileHandle)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.readFileIntoMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_INVALID_FILE_HANDLE);
@@ -294,7 +294,7 @@ TEST_F(TestFileTable, ReadFileInvalidOffset)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.readFileIntoMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_DATA_OUT_OF_RANGE);
@@ -329,7 +329,7 @@ TEST_F(TestFileTable, ReadFileInvalidLength)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.readFileIntoMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -367,7 +367,7 @@ TEST_F(TestFileTable, ReadFileInvalidEffectiveLength)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.readFileIntoMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -399,7 +399,7 @@ TEST(WriteFileFromMemory, BadPath)
     // Pass invalid payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.writeFileFromMemory(request, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -438,7 +438,7 @@ TEST_F(TestFileTable, WriteFileInvalidFileHandle)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.writeFileFromMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_INVALID_FILE_HANDLE);
@@ -474,7 +474,7 @@ TEST_F(TestFileTable, WriteFileInvalidOffset)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.writeFileFromMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_DATA_OUT_OF_RANGE);
@@ -547,7 +547,7 @@ TEST_F(TestFileTable, GetFileTableCommand)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.getFileTable(requestMsgPtr, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_SUCCESS);
@@ -574,7 +574,7 @@ TEST_F(TestFileTable, GetFileTableCommandReqLengthMismatch)
     // Pass invalid command payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.getFileTable(request, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -600,7 +600,7 @@ TEST_F(TestFileTable, GetFileTableCommandOEMAttrTable)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.getFileTable(requestMsgPtr, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_INVALID_FILE_TABLE_TYPE);
@@ -632,7 +632,7 @@ TEST_F(TestFileTable, ReadFileBadPath)
     // Invalid payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.readFile(requestMsgPtr, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -686,7 +686,7 @@ TEST_F(TestFileTable, ReadFileGoodPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto responseMsg = handler.readFile(requestMsgPtr, payload_length);
     auto response = reinterpret_cast<pldm_read_file_resp*>(
         responseMsg.data() + sizeof(pldm_msg_hdr));
@@ -740,7 +740,7 @@ TEST_F(TestFileTable, WriteFileBadPath)
     // Invalid payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.writeFile(requestMsgPtr, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -791,7 +791,7 @@ TEST_F(TestFileTable, WriteFileGoodPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto responseMsg = handler.writeFile(requestMsgPtr, payload_length);
     auto response = reinterpret_cast<pldm_read_file_resp*>(
         responseMsg.data() + sizeof(pldm_msg_hdr));
@@ -829,7 +829,7 @@ TEST(writeFileByTypeFromMemory, testBadPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.writeFileByTypeFromMemory(req, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
 
@@ -909,7 +909,7 @@ TEST(readFileByTypeIntoMemory, testBadPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.readFileByTypeIntoMemory(req, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     struct pldm_read_write_file_by_type_memory_resp* resp =
@@ -951,7 +951,7 @@ TEST(readFileByType, testBadPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr);
+                             nullptr, nullptr, nullptr);
     auto response = handler.readFileByType(req, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     struct pldm_read_write_file_by_type_resp* resp =

--- a/pldmd/pldm_resp_interface.hpp
+++ b/pldmd/pldm_resp_interface.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "common/flight_recorder.hpp"
+#include "common/utils.hpp"
+
+#include <sys/socket.h>
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <vector>
+using namespace pldm;
+using namespace pldm::utils;
+using namespace pldm::flightrecorder;
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm
+{
+namespace response_api
+{
+
+/** @class Transport
+ *
+ *  @brief This class performs the necessary operation in pldm for
+ *         responding remote pldm. This class is mostly designed in special case
+ *         when pldm need to send reply to host after FILE IO operation
+ *         completed.
+ */
+class Transport
+{
+  public:
+    /** @brief Transport constructor
+     */
+    Transport() = delete;
+    Transport(const Transport&) = delete;
+    Transport(int socketFd, bool verbose = false) :
+        sockFd(socketFd), verbose(verbose)
+    {}
+
+    /** @brief method to send response to remote pldm using transport interface
+     * @param response - response of each request
+     * @param index - index to delete header from maintained map
+     * @returns returns 0 if success else -1
+     */
+    int sendPLDMRespMsg(Response& response, int index)
+    {
+        struct iovec iov[2]{};
+        struct msghdr msg
+        {};
+
+        FlightRecorder::GetInstance().saveRecord(response, true);
+        if (verbose)
+        {
+            printBuffer(Tx, response);
+        }
+
+        iov[0].iov_base = &requestMap[index][0];
+        iov[0].iov_len = sizeof(requestMap[index][0]) +
+                         sizeof(requestMap[index][1]);
+        iov[1].iov_base = response.data();
+        iov[1].iov_len = response.size();
+        msg.msg_iov = iov;
+        msg.msg_iovlen = sizeof(iov) / sizeof(iov[0]);
+
+        int rc = sendmsg(sockFd, &msg, 0);
+        removeHeader(index);
+        if (rc < 0)
+        {
+            rc = errno;
+            error("sendto system call failed, errno= {ERRNO}", "ERRNO", rc);
+        }
+        return rc;
+    }
+
+    /** @brief method to acquire one copy of request header into request map.
+     * @param reqMsg - overwrite each request header into existing mRequestMsg
+     * variable
+     */
+    void setRequestMsgRef(std::vector<uint8_t>& reqMsg)
+    {
+        mRequestMsg = reqMsg;
+    }
+
+    /** @brief method to store request header into map when DMA data transfer
+     * request received.
+     */
+    int getRequestHeaderIndex()
+    {
+        int index = getUniqueKey();
+        requestMap[index] = mRequestMsg;
+        return index;
+    }
+
+  private:
+    /** @brief method to remove request header after sending response to host
+     */
+    void removeHeader(int index)
+    {
+        requestMap.erase(index);
+    }
+
+    /** @brief method to generate unique key to store request header into map
+     * @returns available nearest key value as integer
+     */
+    int getUniqueKey()
+    {
+        int key = 0;
+        for (size_t index = 0; index <= requestMap.size(); index++)
+        {
+            if (requestMap.find(index) == requestMap.end())
+            {
+                key = index;
+                break;
+            }
+        }
+        return key;
+    }
+
+  private:
+    std::vector<uint8_t> mRequestMsg;
+    std::map<int, std::vector<uint8_t>> requestMap;
+    int sockFd;
+    bool verbose;
+};
+
+struct Interfaces
+{
+    std::unique_ptr<Transport> transport = nullptr;
+};
+
+} // namespace response_api
+
+} // namespace pldm

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -9,6 +9,7 @@
 #include "fw-update/manager.hpp"
 #include "host-bmc/dbus/deserialize.hpp"
 #include "invoker.hpp"
+#include "pldm_resp_interface.hpp"
 #include "requester/handler.hpp"
 #include "requester/mctp_endpoint_discovery.hpp"
 #include "requester/request.hpp"
@@ -214,7 +215,7 @@ int main(int argc, char** argv)
     Invoker invoker{};
     requester::Handler<requester::Request> reqHandler(
         sockfd, event, dbusImplReq, currentSendbuffSize, verbose);
-
+    pldm::response_api::Interfaces respInterface;
 #ifdef LIBPLDMRESPONDER
     using namespace pldm::state_sensor;
     dbus_api::Host dbusImplHost(bus, "/xyz/openbmc_project/pldm");
@@ -265,6 +266,8 @@ int main(int argc, char** argv)
     }
 
 #ifdef OEM_IBM
+    respInterface.transport =
+        std::make_unique<pldm::response_api::Transport>(sockfd, verbose);
     std::unique_ptr<pldm::responder::CodeUpdate> codeUpdate =
         std::make_unique<pldm::responder::CodeUpdate>(&dbusHandler);
     std::unique_ptr<pldm::responder::SlotHandler> slotHandler =
@@ -280,7 +283,8 @@ int main(int argc, char** argv)
     slotHandler->setOemPlatformHandler(oemPlatformHandler.get());
     invoker.registerHandler(PLDM_OEM, std::make_unique<oem_ibm::Handler>(
                                           oemPlatformHandler.get(), sockfd,
-                                          hostEID, &dbusImplReq, &reqHandler));
+                                          hostEID, &dbusImplReq, &reqHandler,
+                                          respInterface.transport.get()));
 
     // host lamp test
     std::unique_ptr<pldm::led::HostLampTest> hostLampTest =
@@ -374,7 +378,8 @@ int main(int argc, char** argv)
         std::make_unique<MctpDiscovery>(bus, fwManager.get());
 
     auto callback = [verbose, &invoker, &reqHandler, currentSendbuffSize,
-                     &fwManager](IO& io, int fd, uint32_t revents) mutable {
+                     &fwManager,
+                     &respInterface](IO& io, int fd, uint32_t revents) mutable {
         if (!(revents & EPOLLIN))
         {
             return;
@@ -424,6 +429,10 @@ int main(int argc, char** argv)
                 }
                 else
                 {
+                    if (respInterface.transport)
+                    {
+                        respInterface.transport->setRequestMsgRef(requestMsg);
+                    }
                     // process message and send response
                     auto response = processRxMsg(requestMsg, invoker,
                                                  reqHandler, fwManager.get());


### PR DESCRIPTION
- this changes are in suppoort of aynchronous file io operation between pldm and remote terminus.
- previously pldm send response to remote terminus when it's complete the operation and that duration pldm is blocked but new response mechanism will be introduced in case of event loop, pldm can take time to process request and meanwhile it can receive another request.

