### PR TITLE
1060: Responder support for GetNumericEffecterCommand (#470)

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -217,6 +217,27 @@ std::optional<std::vector<set_effecter_state_field>>
     return std::make_optional(std::move(stateField));
 }
 
+size_t getEffecterDataSize(uint8_t effecterDataSize)
+{
+    switch (effecterDataSize)
+    {
+        case PLDM_EFFECTER_DATA_SIZE_UINT8:
+            return sizeof(uint8_t);
+        case PLDM_EFFECTER_DATA_SIZE_SINT8:
+            return sizeof(int8_t);
+        case PLDM_EFFECTER_DATA_SIZE_UINT16:
+            return sizeof(uint16_t);
+        case PLDM_EFFECTER_DATA_SIZE_SINT16:
+            return sizeof(int16_t);
+        case PLDM_EFFECTER_DATA_SIZE_UINT32:
+            return sizeof(uint32_t);
+        case PLDM_EFFECTER_DATA_SIZE_SINT32:
+            return sizeof(int32_t);
+        default:
+            return 0;
+    }
+}
+
 std::string DBusHandler::getService(const char* path,
                                     const char* interface) const
 {

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -113,6 +113,15 @@ std::optional<std::vector<set_effecter_state_field>>
     parseEffecterData(const std::vector<uint8_t>& effecterData,
                       uint8_t effecterCount);
 
+/** @brief Return the size of data type based on the effecterDataSize enum value
+ *
+ *  @param[in] effecterDataSize - Bitwidth and format of setting the effecter
+ * value
+ *  @return[out] Map the effecterDataSize enum value to datatype and return the
+ * size of dataType
+ */
+size_t getEffecterDataSize(uint8_t effecterDataSize);
+
 /**
  *  @brief creates an error log
  *  @param[in] errorMsg - the error message

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -81,6 +81,10 @@ class Handler : public CmdHandler
                          [this](const pldm_msg* request, size_t payloadLength) {
             return this->setNumericEffecterValue(request, payloadLength);
         });
+        handlers.emplace(PLDM_GET_NUMERIC_EFFECTER_VALUE,
+                         [this](const pldm_msg* request, size_t payloadLength) {
+            return this->getNumericEffecterValue(request, payloadLength);
+        });
         handlers.emplace(PLDM_SET_STATE_EFFECTER_STATES,
                          [this](const pldm_msg* request, size_t payloadLength) {
             return this->setStateEffecterStates(request, payloadLength);
@@ -235,6 +239,15 @@ class Handler : public CmdHandler
      *  @return Response - PLDM Response message
      */
     Response setNumericEffecterValue(const pldm_msg* request,
+                                     size_t payloadLength);
+
+    /** @brief Handler for getNumericEffecterValue
+     *
+     *  @param[in] request - Request message
+     *  @param[in] payloadLength - Request payload length
+     *  @return Response - PLDM Response message
+     */
+    Response getNumericEffecterValue(const pldm_msg* request,
                                      size_t payloadLength);
 
     /** @brief Handler for getStateSensorReadings

--- a/libpldmresponder/platform_numeric_effecter.hpp
+++ b/libpldmresponder/platform_numeric_effecter.hpp
@@ -337,6 +337,222 @@ int setNumericEffecterValueHandler(const DBusInterface& dBusIntf,
     return PLDM_SUCCESS;
 }
 
+/** @brief Function to convert the D-Bus value by effecterdataSize and create
+ * the response
+ *  @for getNumericEffecterValue request.
+ *  @param[in] PropertyValue - D-Bus Value
+ *  @param[in] effecterDataSize - effecter value size.
+ *  @param[in,out] responsePtr - Response of getNumericEffecterValue.
+ *  @param[in] responsePayloadLength - reponse length.
+ *  @param[in] instanceId - instance id for response
+ *
+ *  @return PLDM_SUCCESS/PLDM_ERROR
+ */
+template <typename T>
+int getEffecterValue(T propertyValue, uint8_t effecterDataSize,
+                     pldm_msg* responsePtr, size_t responsePayloadLength,
+                     int instanceId)
+{
+    switch (effecterDataSize)
+    {
+        case PLDM_EFFECTER_DATA_SIZE_UINT8:
+        {
+            uint8_t value = static_cast<uint8_t>(propertyValue);
+            return (encode_get_numeric_effecter_value_resp(
+                instanceId, PLDM_SUCCESS, effecterDataSize,
+                EFFECTER_OPER_STATE_ENABLED_NOUPDATEPENDING, &value, &value,
+                responsePtr, responsePayloadLength));
+        }
+        case PLDM_EFFECTER_DATA_SIZE_SINT8:
+        {
+            int8_t value = static_cast<int8_t>(propertyValue);
+            return (encode_get_numeric_effecter_value_resp(
+                instanceId, PLDM_SUCCESS, effecterDataSize,
+                EFFECTER_OPER_STATE_ENABLED_NOUPDATEPENDING,
+                reinterpret_cast<uint8_t*>(&value),
+                reinterpret_cast<uint8_t*>(&value), responsePtr,
+                responsePayloadLength));
+        }
+        case PLDM_EFFECTER_DATA_SIZE_UINT16:
+        case PLDM_EFFECTER_DATA_SIZE_SINT16:
+        {
+            uint16_t value = static_cast<uint16_t>(propertyValue);
+            return (encode_get_numeric_effecter_value_resp(
+                instanceId, PLDM_SUCCESS, effecterDataSize,
+                EFFECTER_OPER_STATE_ENABLED_NOUPDATEPENDING,
+                reinterpret_cast<uint8_t*>(&value),
+                reinterpret_cast<uint8_t*>(&value), responsePtr,
+                responsePayloadLength));
+        }
+        case PLDM_EFFECTER_DATA_SIZE_UINT32:
+        case PLDM_EFFECTER_DATA_SIZE_SINT32:
+        {
+            uint32_t value = static_cast<uint32_t>(propertyValue);
+            return (encode_get_numeric_effecter_value_resp(
+                instanceId, PLDM_SUCCESS, effecterDataSize,
+                EFFECTER_OPER_STATE_ENABLED_NOUPDATEPENDING,
+                reinterpret_cast<uint8_t*>(&value),
+                reinterpret_cast<uint8_t*>(&value), responsePtr,
+                responsePayloadLength));
+        }
+        default:
+        {
+            error("Unknown Effecter Size");
+            return PLDM_ERROR;
+        }
+    }
+}
+
+/** @brief Function to convert the D-Bus value to the effector data size value
+ *  @param[in] PropertyType - String contains the dataType of the Dbus value.
+ *  @param[in] PropertyValue - Variant contains the D-Bus Value
+ *  @param[in] effecterDataSize - effecter value size.
+ *  @param[in,out] responsePtr - Response of getNumericEffecterValue.
+ *  @param[in] responsePayloadLength - reponse length.
+ *  @param[in] instanceId - instance id for response
+ *
+ *  @return PLDM_SUCCESS/PLDM_ERROR
+ */
+int getNumericEffecterValueHandler(std::string propertyType,
+                                   pldm::utils::PropertyValue propertyValue,
+                                   uint8_t effecterDataSize,
+                                   pldm_msg* responsePtr,
+                                   size_t responsePayloadLength, int instanceId)
+{
+    if (propertyType == "uint32_t")
+    {
+        uint32_t propVal = std::get<uint32_t>(propertyValue);
+        return getEffecterValue<uint32_t>(propVal, effecterDataSize,
+                                          responsePtr, responsePayloadLength,
+                                          instanceId);
+        error("Property is Uint32 , Vlaue = {VALUE}", "VALUE", propVal);
+    }
+    else if (propertyType == "uint64_t")
+    {
+        uint64_t propVal = std::get<uint64_t>(propertyValue);
+        return getEffecterValue<uint64_t>(propVal, effecterDataSize,
+                                          responsePtr, responsePayloadLength,
+                                          instanceId);
+    }
+    else if (propertyType == "uint16_t")
+    {
+        uint16_t propVal = std::get<uint16_t>(propertyValue);
+        return getEffecterValue<uint16_t>(propVal, effecterDataSize,
+                                          responsePtr, responsePayloadLength,
+                                          instanceId);
+    }
+    else if (propertyType == "uint8_t")
+    {
+        uint8_t propVal = std::get<uint8_t>(propertyValue);
+        return getEffecterValue<uint8_t>(propVal, effecterDataSize, responsePtr,
+                                         responsePayloadLength, instanceId);
+    }
+    else
+    {
+        error("Property Type [{PROPERTYTYPE}] not supported", "PROPERTYTYPE",
+              propertyType);
+    }
+    return PLDM_ERROR;
+}
+
+/** @brief Function to get the effecter details as data size, D-Bus property
+ * type, D-Bus Value
+ *  @tparam[in] DBusInterface - DBus interface type
+ *  @tparam[in] Handler - pldm::responder::platform::Handler
+ *  @param[in] dBusIntf - The interface object of DBusInterface
+ *  @param[in] handler - The interface object of
+ *             pldm::responder::platform::Handler
+ *  @param[in] effecterId - Effecter ID sent by the requester to act on
+ *  @param[in] effecterDataSize - The bit width and format of the setting
+ * 				value for the effecter
+ *  @param[in] propertyType - The data type of the D-Bus value
+ *  @param[in] propertyValue - The value of numeric effecter being
+ * 				requested.
+ *  @return - Success or failure in getting the D-Bus property or the
+ *  effecterId not found in the PDR repo
+ */
+template <class DBusInterface, class Handler>
+int getNumericEffecterData(const DBusInterface& dBusIntf, Handler& handler,
+                           uint16_t effecterId, uint8_t& effecterDataSize,
+                           std::string& propertyType,
+                           pldm::utils::PropertyValue& propertyValue)
+{
+    pldm_numeric_effecter_value_pdr* pdr = nullptr;
+
+    std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)>
+        numericEffecterPdrRepo(pldm_pdr_init(), pldm_pdr_destroy);
+    pldm::responder::pdr_utils::Repo numericEffecterPDRs(
+        numericEffecterPdrRepo.get());
+    pldm::responder::pdr::getRepoByType(handler.getRepo(), numericEffecterPDRs,
+                                        PLDM_NUMERIC_EFFECTER_PDR);
+    if (numericEffecterPDRs.empty())
+    {
+        error("The Numeric Effecter PDR repo is empty.");
+        return PLDM_ERROR;
+    }
+
+    // Get the pdr structure of pldm_numeric_effecter_value_pdr according
+    // to the effecterId
+    pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+    auto pdrRecord = numericEffecterPDRs.getFirstRecord(pdrEntry);
+
+    while (pdrRecord)
+    {
+        pdr = reinterpret_cast<pldm_numeric_effecter_value_pdr*>(pdrEntry.data);
+        if (pdr->effecter_id != effecterId)
+        {
+            pdr = nullptr;
+            pdrRecord = numericEffecterPDRs.getNextRecord(pdrRecord, pdrEntry);
+            continue;
+        }
+        effecterDataSize = pdr->effecter_data_size;
+        break;
+    }
+
+    if (!pdr)
+    {
+        error("The Numeric Effecter not found EFFECTERID={EFFECTERID}",
+              "EFFECTERID", effecterId);
+        return PLDM_PLATFORM_INVALID_EFFECTER_ID;
+    }
+
+    try
+    {
+        const auto& [dbusMappings,
+                     dbusValMaps] = handler.getDbusObjMaps(effecterId);
+        if (dbusMappings.size() > 0)
+        {
+            pldm::utils::DBusMapping dbusMapping{
+                dbusMappings[0].objectPath, dbusMappings[0].interface,
+                dbusMappings[0].propertyName, dbusMappings[0].propertyType};
+            try
+            {
+                propertyValue = dBusIntf.getDbusPropertyVariant(
+                    dbusMapping.objectPath.c_str(),
+                    dbusMapping.propertyName.c_str(),
+                    dbusMapping.interface.c_str());
+                propertyType = dbusMappings[0].propertyType;
+            }
+            catch (const std::exception& e)
+            {
+                error(
+                    "Get StateNumericEffecter from dbus Error, interface : {INTF} ,exception : {ERR_EXCEP}",
+                    "INTF", dbusMapping.interface.c_str(), "ERR_EXCEP",
+                    e.what());
+                return PLDM_ERROR;
+            }
+        }
+    }
+    catch (const std::out_of_range& e)
+    {
+        error(
+            "the effecterId does not exist. effecter id: {EFFECTER_ID}, {ERR_EXCEP}",
+            "EFFECTER_ID", effecterId, "ERR_EXCEP", e.what());
+        return PLDM_ERROR;
+    }
+    return PLDM_SUCCESS;
+}
+
 } // namespace platform_numeric_effecter
 } // namespace responder
 } // namespace pldm


### PR DESCRIPTION
#### Responder support for GetNumericEffecterCommand (#470)
```
Added responder support for GetNumericEffecter Command

Test:
Using pldmtool raw command
    pldmtool raw -d 0x80 0x02 0x32 0x23 00
    pldmtool: Tx: 08 01 80 02 32 23 00
    pldmtool: Rx: 08 01 00 02 32 00 00 01 03 03

Signed-off-by: Archana Kakani <archana.kakani@ibm.com>```