### PR TITLE
OEM-IBM: BIOS attribute support for LINUX KVM

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -146,15 +146,15 @@
         },
         {
             "attribute_name": "pvm_default_os_type",
-            "possible_values": ["AIX", "Linux", "IBM I", "Default"],
-            "default_values": ["Default"],
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
             "helpText": "CEC Primary OS",
             "displayName": "CEC Primary OS"
         },
         {
             "attribute_name": "pvm_default_os_type_current",
-            "possible_values": ["AIX", "Linux", "IBM I", "Default"],
-            "default_values": ["Default"],
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
             "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
             "displayName": "CEC Primary OS (current)",
             "readOnly": true
@@ -573,6 +573,21 @@
             "default_values": ["MTU1500"],
             "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
             "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
         }
     ]
 }

--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -285,6 +285,25 @@
             "default_value": 0,
             "helpText": "Specifies the port that is used for the iSCSI connection.",
             "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
         }
     ]
 }


### PR DESCRIPTION
This commit adds new BIOS attributes to support Linux KVM