### PR TITLE
pldm: System specific BIOS attributes

### DIFF
--- a/common/test/mocked_utils.hpp
+++ b/common/test/mocked_utils.hpp
@@ -7,7 +7,6 @@ namespace pldm
 {
 namespace utils
 {
-
 /** @brief helper function for parameter matching
  *  @param[in] lhs - left-hand side value
  *  @param[in] rhs - right-hand side value
@@ -36,4 +35,8 @@ class MockdBusHandler : public pldm::utils::DBusHandler
 
     MOCK_METHOD(pldm::utils::PropertyValue, getDbusPropertyVariant,
                 (const char*, const char*, const char*), (const override));
+
+    MOCK_METHOD(pldm::utils::GetSubTreeResponse, getSubtree,
+                (const std::string&, int, const std::vector<std::string>&),
+                (const override));
 };

--- a/common/types.hpp
+++ b/common/types.hpp
@@ -41,9 +41,9 @@ using Interface = std::string;
 using Interfaces = std::vector<std::string>;
 using Property = std::string;
 using PropertyType = std::string;
-using Value =
-    std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-                 uint64_t, double, std::string, std::vector<uint8_t>>;
+using Value = std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+                           int64_t, uint64_t, double, std::string,
+                           std::vector<uint8_t>, std::vector<std::string>>;
 
 using PropertyMap = std::map<Property, Value>;
 using InterfaceMap = std::map<Interface, PropertyMap>;

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -167,7 +167,8 @@ struct DBusMapping
 
 using PropertyValue =
     std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-                 uint64_t, double, std::string, std::vector<uint8_t>>;
+                 uint64_t, double, std::string, std::vector<uint8_t>,
+                 std::vector<std::string>>;
 using DbusProp = std::string;
 using DbusChangedProps = std::map<DbusProp, PropertyValue>;
 using DBusInterfaceAdded = std::vector<

--- a/host-bmc/dbus/serialize.cpp
+++ b/host-bmc/dbus/serialize.cpp
@@ -87,7 +87,16 @@ void Serialize::serialize(const std::string& path, const std::string& intf,
 
     std::ofstream os(filePath.c_str(), std::ios::binary);
     cereal::BinaryOutputArchive oarchive(os);
-    oarchive(savedObjs);
+    oarchive(savedObjs, savedKeyVal);
+}
+
+void Serialize::serializeKeyVal(const std::string& key,
+                                dbus::PropertyValue value)
+{
+    std::ofstream os(filePath.c_str(), std::ios::binary);
+    cereal::BinaryOutputArchive oarchive(os);
+    savedKeyVal[key] = value;
+    oarchive(savedObjs, savedKeyVal);
 }
 
 bool Serialize::deserialize()
@@ -102,9 +111,10 @@ bool Serialize::deserialize()
     try
     {
         savedObjs.clear();
+        savedKeyVal.clear();
         std::ifstream is(filePath.c_str(), std::ios::in | std::ios::binary);
         cereal::BinaryInputArchive iarchive(is);
-        iarchive(savedObjs);
+        iarchive(savedObjs, savedKeyVal);
 
         return true;
     }
@@ -158,7 +168,7 @@ void Serialize::reSerialize(const std::vector<uint16_t> types)
 
     std::ofstream os(filePath.c_str(), std::ios::binary);
     cereal::BinaryOutputArchive oarchive(os);
-    oarchive(this->savedObjs);
+    oarchive(this->savedObjs, this->savedKeyVal);
 }
 
 } // namespace serialize

--- a/host-bmc/dbus/serialize.hpp
+++ b/host-bmc/dbus/serialize.hpp
@@ -45,11 +45,24 @@ class Serialize
                    const std::string& type = "",
                    dbus::PropertyValue value = {});
 
+    /** @brief Save the map of Key Value
+     *
+     *  @param[in] key
+     *  @param[in] Property value
+     *  @return void
+     */
+    void serializeKeyVal(const std::string& key, dbus::PropertyValue value);
+
     bool deserialize();
 
     dbus::SavedObjs getSavedObjs()
     {
         return savedObjs;
+    }
+
+    std::map<std::string, pldm::dbus::PropertyValue> getSavedKeyVals()
+    {
+        return savedKeyVal;
     }
 
     void setObjectPathMaps(const ObjectPathMaps& maps);
@@ -65,6 +78,7 @@ class Serialize
     fs::path filePath{PERSISTENT_FILE};
     std::set<uint16_t> storeEntityTypes;
     std::map<ObjectPath, pldm_entity> entityPathMaps;
+    std::map<std::string, pldm::dbus::PropertyValue> savedKeyVal;
 };
 
 } // namespace serialize

--- a/libpldmresponder/bios.cpp
+++ b/libpldmresponder/bios.cpp
@@ -70,9 +70,10 @@ using EpochTimeUS = uint64_t;
 DBusHandler dbusHandler;
 
 Handler::Handler(int fd, uint8_t eid, dbus_api::Requester* requester,
-                 pldm::requester::Handler<pldm::requester::Request>* handler) :
+                 pldm::requester::Handler<pldm::requester::Request>* handler,
+                 pldm::responder::oem_bios::Handler* oemBiosHandler) :
     biosConfig(BIOS_JSONS_DIR, BIOS_TABLES_DIR, &dbusHandler, fd, eid,
-               requester, handler)
+               requester, handler, oemBiosHandler)
 {
     biosConfig.removeTables();
     biosConfig.buildTables();

--- a/libpldmresponder/bios.hpp
+++ b/libpldmresponder/bios.hpp
@@ -33,9 +33,11 @@ class Handler : public CmdHandler
      *  @param[in] eid - MCTP EID of host firmware
      *  @param[in] requester - pointer to Requester object
      *  @param[in] handler - PLDM request handler
+     *  @param[in] oemBiosHandler - pointer to oem bios handler
      */
     Handler(int fd, uint8_t eid, dbus_api::Requester* requester,
-            pldm::requester::Handler<pldm::requester::Request>* handler);
+            pldm::requester::Handler<pldm::requester::Request>* handler,
+            pldm::responder::oem_bios::Handler* oemBiosHandler);
 
     /** @brief Handler for GetDateTime
      *

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -45,12 +45,20 @@ constexpr auto attrValueTableFile = "attributeValueTable";
 BIOSConfig::BIOSConfig(
     const char* jsonDir, const char* tableDir, DBusHandler* const dbusHandler,
     int fd, uint8_t eid, dbus_api::Requester* requester,
-    pldm::requester::Handler<pldm::requester::Request>* handler) :
+    pldm::requester::Handler<pldm::requester::Request>* handler,
+    pldm::responder::oem_bios::Handler* oemBiosHandler) :
     jsonDir(jsonDir),
     tableDir(tableDir), dbusHandler(dbusHandler), fd(fd), eid(eid),
-    requester(requester), handler(handler)
-
+    requester(requester), handler(handler), oemBiosHandler(oemBiosHandler)
 {
+    if (oemBiosHandler)
+    {
+        auto systemType = oemBiosHandler->getPlatformName();
+        if (systemType.has_value())
+        {
+            sysType = systemType.value();
+        }
+    }
     fs::create_directories(tableDir);
     constructAttributes();
     listenPendingAttributes();
@@ -496,13 +504,14 @@ void BIOSConfig::updateBaseBIOSTableProperty()
 
 void BIOSConfig::constructAttributes()
 {
-    load(jsonDir / stringJsonFile, [this](const Json& entry) {
+    info("Bios Attribute file path: {PATH}", "PATH", (jsonDir / sysType));
+    load(jsonDir / sysType / stringJsonFile, [this](const Json& entry) {
         constructAttribute<BIOSStringAttribute>(entry);
     });
-    load(jsonDir / integerJsonFile, [this](const Json& entry) {
+    load(jsonDir / sysType / integerJsonFile, [this](const Json& entry) {
         constructAttribute<BIOSIntegerAttribute>(entry);
     });
-    load(jsonDir / enumJsonFile, [this](const Json& entry) {
+    load(jsonDir / sysType / enumJsonFile, [this](const Json& entry) {
         constructAttribute<BIOSEnumAttribute>(entry);
     });
 }
@@ -582,9 +591,12 @@ std::optional<Table> BIOSConfig::buildAndStoreStringTable()
         strings.emplace(entry.at("attribute_name"));
     };
 
-    load(jsonDir / stringJsonFile, handler);
-    load(jsonDir / integerJsonFile, handler);
-    load(jsonDir / enumJsonFile, [&strings](const Json& entry) {
+    info("Bios Attribute file for building table path: {PATH}", "PATH",
+         (jsonDir / sysType));
+
+    load(jsonDir / sysType / stringJsonFile, handler);
+    load(jsonDir / sysType / integerJsonFile, handler);
+    load(jsonDir / sysType / enumJsonFile, [&strings](const Json& entry) {
         strings.emplace(entry.at("attribute_name"));
         auto possibleValues = entry.at("possible_values");
         for (auto& pv : possibleValues)
@@ -1107,7 +1119,6 @@ void BIOSConfig::listenPendingAttributes()
         propertiesChanged(objPath, objInterface),
         [this](sdbusplus::message_t& msg) {
         constexpr auto propertyName = "PendingAttributes";
-
         using Value =
             std::variant<std::string, PendingAttributes, BaseBIOSTable>;
         using Properties = std::map<DbusProp, Value>;

--- a/libpldmresponder/bios_config.hpp
+++ b/libpldmresponder/bios_config.hpp
@@ -4,6 +4,7 @@
 
 #include "bios_attribute.hpp"
 #include "bios_table.hpp"
+#include "oem_handler.hpp"
 #include "pldmd/dbus_impl_requester.hpp"
 #include "requester/handler.hpp"
 
@@ -76,12 +77,14 @@ class BIOSConfig
      *  @param[in] eid - MCTP EID of host firmware
      *  @param[in] requester - pointer to Requester object
      *  @param[in] handler - PLDM request handler
+     *  @param[in] oemBiosHandler - pointer to oem Bios Handler
      */
     explicit BIOSConfig(
         const char* jsonDir, const char* tableDir,
         pldm::utils::DBusHandler* const dbusHandler, int fd, uint8_t eid,
         dbus_api::Requester* requester,
-        pldm::requester::Handler<pldm::requester::Request>* handler);
+        pldm::requester::Handler<pldm::requester::Request>* handler,
+        pldm::responder::oem_bios::Handler* oemBiosHandler);
 
     /** @brief Set attribute value on dbus and attribute value table
      *  @param[in] entry - attribute value entry
@@ -154,6 +157,9 @@ class BIOSConfig
     /** @brief PLDM request handler */
     pldm::requester::Handler<pldm::requester::Request>* handler;
 
+    /** @brief oem Bios Handler*/
+    pldm::responder::oem_bios::Handler* oemBiosHandler;
+
     // vector persists all attributes
     using BIOSAttributes = std::vector<std::unique_ptr<BIOSAttribute>>;
     BIOSAttributes biosAttributes;
@@ -166,6 +172,9 @@ class BIOSConfig
 
     // vector to catch the D-Bus property change signals for BIOS attributes
     std::vector<std::unique_ptr<sdbusplus::bus::match_t>> biosAttrMatch;
+
+    /** @brief system type/model */
+    std::string sysType;
 
     /** @brief Method to update a BIOS attribute when the corresponding Dbus
      *  property is changed

--- a/libpldmresponder/fru.hpp
+++ b/libpldmresponder/fru.hpp
@@ -30,9 +30,9 @@ namespace responder
 namespace dbus
 {
 
-using Value =
-    std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-                 uint64_t, double, std::string, std::vector<uint8_t>>;
+using Value = std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+                           int64_t, uint64_t, double, std::string,
+                           std::vector<uint8_t>, std::vector<std::string>>;
 using PropertyMap = std::map<Property, Value>;
 using InterfaceMap = std::map<Interface, PropertyMap>;
 using ObjectValueTree = std::map<sdbusplus::message::object_path, InterfaceMap>;

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -79,6 +79,7 @@ if get_option('oem-ibm').enabled()
     '../oem/ibm/libpldmresponder/file_io_type_pcie.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_vpd.cpp',
     '../oem/ibm/host-bmc/host_lamp_test.cpp',
+    '../oem/ibm/libpldmresponder/bios_oem_ibm.cpp',
   ]
 endif
 

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -160,6 +160,28 @@ class Handler : public CmdHandler
 
 } // namespace oem_platform
 
+namespace oem_bios
+{
+/** Interface to the oem bios Handler class*/
+class Handler : public CmdHandler
+{
+  public:
+    Handler(const pldm::utils::DBusHandler* dBusIntf) : dBusIntf(dBusIntf) {}
+
+    /** @brief Interface to get the system type information
+     *
+     *  @return - the system type information
+     */
+    virtual std::optional<std::string> getPlatformName() = 0;
+
+    virtual ~Handler() = default;
+
+  protected:
+    const pldm::utils::DBusHandler* dBusIntf;
+};
+
+} // namespace oem_bios
+
 namespace oem_fru
 {
 

--- a/libpldmresponder/test/libpldmresponder_bios_config_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_bios_config_test.cpp
@@ -2,6 +2,7 @@
 #include "common/test/mocked_utils.hpp"
 #include "libpldmresponder/bios_config.hpp"
 #include "libpldmresponder/bios_string_attribute.hpp"
+#include "libpldmresponder/oem_handler.hpp"
 #include "mocked_bios.hpp"
 
 #include <nlohmann/json.hpp>
@@ -18,6 +19,8 @@ using namespace pldm::utils;
 
 using ::testing::_;
 using ::testing::ElementsAreArray;
+using ::testing::Return;
+using ::testing::StrEq;
 using ::testing::Throw;
 
 class TestBIOSConfig : public ::testing::Test
@@ -74,15 +77,28 @@ class TestBIOSConfig : public ::testing::Test
 fs::path TestBIOSConfig::tableDir;
 std::vector<Json> TestBIOSConfig::jsons;
 
+class MockBiosSystemConfig : public pldm::responder::oem_bios::Handler
+{
+  public:
+    MockBiosSystemConfig(const pldm::utils::DBusHandler* dBusIntf) :
+        pldm::responder::oem_bios::Handler(dBusIntf)
+    {}
+    MOCK_METHOD(void, ibmCompatibleAddedCallback,
+                (sdbusplus::message::message&), ());
+    MOCK_METHOD(std::optional<std::string>, getPlatformName, ());
+};
+
 TEST_F(TestBIOSConfig, buildTablesTest)
 {
     MockdBusHandler dbusHandler;
+
+    MockBiosSystemConfig mockBiosSystemConfig(&dbusHandler);
 
     ON_CALL(dbusHandler, getDbusPropertyVariant(_, _, _))
         .WillByDefault(Throw(std::exception()));
 
     BIOSConfig biosConfig("./bios_jsons", tableDir.c_str(), &dbusHandler, 0, 0,
-                          nullptr, nullptr);
+                          nullptr, nullptr, &mockBiosSystemConfig);
     biosConfig.buildTables();
 
     auto stringTable = biosConfig.getBIOSTable(PLDM_BIOS_STRING_TABLE);
@@ -100,6 +116,7 @@ TEST_F(TestBIOSConfig, buildTablesTest)
                                              "Perm",
                                              "Temp",
                                              "InbandCodeUpdate",
+                                             "Allowed",
                                              "Allowed",
                                              "NotAllowed",
                                              "CodeUpdatePolicy",
@@ -246,12 +263,87 @@ TEST_F(TestBIOSConfig, buildTablesTest)
     }
 }
 
+TEST_F(TestBIOSConfig, buildTablesSystemSpecificTest)
+{
+    MockdBusHandler dbusHandler;
+
+    MockBiosSystemConfig mockBiosSystemConfig(&dbusHandler);
+
+    ON_CALL(dbusHandler, getDbusPropertyVariant(_, _, _))
+        .WillByDefault(Throw(std::exception()));
+
+    BIOSConfig biosConfig("./system_type1/bios_jsons", tableDir.c_str(),
+                          &dbusHandler, 0, 0, nullptr, nullptr,
+                          &mockBiosSystemConfig);
+
+    biosConfig.buildTables();
+
+    auto stringTable = biosConfig.getBIOSTable(PLDM_BIOS_STRING_TABLE);
+    auto attrTable = biosConfig.getBIOSTable(PLDM_BIOS_ATTR_TABLE);
+    auto attrValueTable = biosConfig.getBIOSTable(PLDM_BIOS_ATTR_VAL_TABLE);
+
+    EXPECT_TRUE(stringTable);
+    EXPECT_TRUE(attrTable);
+    EXPECT_TRUE(attrValueTable);
+
+    BIOSStringTable biosStringTable(*stringTable);
+
+    for (auto entry : BIOSTableIter<PLDM_BIOS_ATTR_TABLE>(attrTable->data(),
+                                                          attrTable->size()))
+    {
+        auto header = table::attribute::decodeHeader(entry);
+        auto attrName = biosStringTable.findString(header.stringHandle);
+        auto jsonEntry = findJsonEntry(attrName);
+        EXPECT_TRUE(jsonEntry);
+        switch (header.attrType)
+        {
+            case PLDM_BIOS_STRING:
+            case PLDM_BIOS_STRING_READ_ONLY:
+            {
+                if (attrName == "str_example2")
+                {
+                    auto stringField =
+                        table::attribute::decodeStringEntry(entry);
+                    EXPECT_EQ(stringField.maxLength, 200);
+                }
+
+                break;
+            }
+            case PLDM_BIOS_INTEGER:
+            case PLDM_BIOS_INTEGER_READ_ONLY:
+            {
+                if (attrName == "SBE_IMAGE_MINIMUM_VALID_ECS")
+                {
+                    auto integerField =
+                        table::attribute::decodeIntegerEntry(entry);
+                    EXPECT_EQ(integerField.upperBound, 30);
+                }
+                break;
+            }
+            case PLDM_BIOS_ENUMERATION:
+            case PLDM_BIOS_ENUMERATION_READ_ONLY:
+            {
+                if (attrName == "FWBootSide")
+                {
+                    auto [pvHdls,
+                          defInds] = table::attribute::decodeEnumEntry(entry);
+                    auto defValue =
+                        biosStringTable.findString(pvHdls[defInds[0]]);
+                    EXPECT_EQ(defValue, "Temp");
+                }
+            }
+        }
+    }
+}
+
 TEST_F(TestBIOSConfig, setAttrValue)
 {
     MockdBusHandler dbusHandler;
 
+    MockBiosSystemConfig mockBiosSystemConfig(&dbusHandler);
+
     BIOSConfig biosConfig("./bios_jsons", tableDir.c_str(), &dbusHandler, 0, 0,
-                          nullptr, nullptr);
+                          nullptr, nullptr, &mockBiosSystemConfig);
     biosConfig.removeTables();
     biosConfig.buildTables();
 

--- a/libpldmresponder/test/system_type1/bios_jsons/enum_attrs.json
+++ b/libpldmresponder/test/system_type1/bios_jsons/enum_attrs.json
@@ -1,0 +1,60 @@
+{
+    "entries": [
+        {
+            "attribute_name": "HMCManagedState",
+            "possible_values": ["On", "Off"],
+            "default_values": ["On"],
+            "readOnly": false,
+            "helpText": "HMCManagedState HelpText",
+            "displayName": "HMCManagedState DisplayName",
+            "dbus": {
+                "object_path": "/xyz/abc/def",
+                "interface": "xyz.openbmc_project.HMCManaged.State",
+                "property_name": "State",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.State.On",
+                    "xyz.openbmc_project.State.Off"
+                ]
+            }
+        },
+        {
+            "attribute_name": "FWBootSide",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "readOnly": false,
+            "helpText": "FWBootSide HelpText",
+            "displayName": "FWBootSide DisplayName",
+            "dbus": {
+                "object_path": "/xyz/abc/def",
+                "interface": "xyz.openbmc.FWBoot.Side",
+                "property_name": "Side",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "InbandCodeUpdate",
+            "possible_values": ["Allowed", "NotAllowed"],
+            "default_values": ["Allowed"],
+            "readOnly": false,
+            "helpText": "InbandCodeUpdate HelpText",
+            "displayName": "InbandCodeUpdate DisplayName",
+            "dbus": {
+                "object_path": "/xyz/abc/def",
+                "interface": "xyz.openbmc.InBandCodeUpdate",
+                "property_name": "Policy",
+                "property_type": "uint8_t",
+                "property_values": [0, 1]
+            }
+        },
+        {
+            "attribute_name": "CodeUpdatePolicy",
+            "possible_values": ["Concurrent", "Disruptive"],
+            "default_values": ["Concurrent"],
+            "readOnly": true,
+            "helpText": "CodeUpdatePolicy HelpText",
+            "displayName": "CodeUpdatePolicy DisplayName"
+        }
+    ]
+}

--- a/libpldmresponder/test/system_type1/bios_jsons/integer_attrs.json
+++ b/libpldmresponder/test/system_type1/bios_jsons/integer_attrs.json
@@ -1,0 +1,40 @@
+{
+    "entries": [
+        {
+            "attribute_name": "VDD_AVSBUS_RAIL",
+            "lower_bound": 0,
+            "upper_bound": 15,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": false,
+            "helpText": "VDD_AVSBUS_RAIL HelpText",
+            "displayName": "VDD_AVSBUS_RAIL DisplayName",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/avsbus",
+                "interface": "xyz.openbmc.AvsBus.Manager",
+                "property_type": "uint8_t",
+                "property_name": "Rail"
+            }
+        },
+        {
+            "attribute_name": "SBE_IMAGE_MINIMUM_VALID_ECS",
+            "lower_bound": 1,
+            "upper_bound": 30,
+            "scalar_increment": 1,
+            "default_value": 2,
+            "readOnly": true,
+            "helpText": "SBE_IMAGE_MINIMUM_VALID_ECS HelpText",
+            "displayName": "SBE_IMAGE_MINIMUM_VALID_ECS DisplayName"
+        },
+        {
+            "attribute_name": "INTEGER_INVALID_CASE",
+            "lower_bound": 1,
+            "upper_bound": 15,
+            "scalar_increment": 2,
+            "default_value": 3,
+            "readOnly": true,
+            "helpText": "INTEGER_INVALID_CASE HelpText",
+            "displayName": "INTEGER_INVALID_CASE DisplayName"
+        }
+    ]
+}

--- a/libpldmresponder/test/system_type1/bios_jsons/string_attrs.json
+++ b/libpldmresponder/test/system_type1/bios_jsons/string_attrs.json
@@ -1,0 +1,49 @@
+{
+    "entries": [
+        {
+            "attribute_name": "str_example1",
+            "string_type": "ASCII",
+            "minimum_string_length": 1,
+            "maximum_string_length": 100,
+            "default_string_length": 3,
+            "default_string": "abc",
+            "readOnly": false,
+            "helpText": "str_example1 HelpText",
+            "displayName": "str_example1 DisplayName",
+            "dbus": {
+                "object_path": "/xyz/abc/def",
+                "interface": "xyz.openbmc_project.str_example1.value",
+                "property_name": "Str_example1",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "str_example2",
+            "string_type": "Hex",
+            "minimum_string_length": 0,
+            "maximum_string_length": 200,
+            "default_string_length": 0,
+            "default_string": "",
+            "readOnly": false,
+            "helpText": "str_example2 HelpText",
+            "displayName": "str_example2 DisplayName",
+            "dbus": {
+                "object_path": "/xyz/abc/def",
+                "interface": "xyz.openbmc_project.str_example2.value",
+                "property_name": "Str_example2",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "str_example3",
+            "string_type": "Unknown",
+            "minimum_string_length": 1,
+            "maximum_string_length": 100,
+            "default_string_length": 2,
+            "default_string": "ef",
+            "readOnly": true,
+            "helpText": "str_example3 HelpText",
+            "displayName": "str_example3 DisplayName"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,bonnell/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,bonnell/enum_attrs.json
@@ -1,0 +1,579 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,bonnell/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,bonnell/integer_attrs.json
@@ -1,0 +1,291 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,bonnell/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,bonnell/string_attrs.json
@@ -1,0 +1,265 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,everest/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,everest/enum_attrs.json
@@ -1,0 +1,593 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if1_ipv4_method",
+            "displayName": "vmi_if1_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if1_ipv6_method",
+            "displayName": "vmi_if1_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,everest/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,everest/integer_attrs.json
@@ -1,0 +1,309 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if1_ipv4_prefix_length",
+            "displayName": "vmi_if1_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if1_ipv6_prefix_length",
+            "displayName": "vmi_if1_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,everest/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,everest/string_attrs.json
@@ -1,0 +1,305 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_gateway",
+            "displayName": "vmi_if1_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_ipaddr",
+            "displayName": "vmi_if1_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_gateway",
+            "displayName": "vmi_if1_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_ipaddr",
+            "displayName": "vmi_if1_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-1s4u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-1s4u/enum_attrs.json
@@ -1,0 +1,593 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if1_ipv4_method",
+            "displayName": "vmi_if1_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if1_ipv6_method",
+            "displayName": "vmi_if1_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-1s4u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-1s4u/integer_attrs.json
@@ -1,0 +1,309 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if1_ipv4_prefix_length",
+            "displayName": "vmi_if1_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if1_ipv6_prefix_length",
+            "displayName": "vmi_if1_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-1s4u/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-1s4u/string_attrs.json
@@ -1,0 +1,305 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_gateway",
+            "displayName": "vmi_if1_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_ipaddr",
+            "displayName": "vmi_if1_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_gateway",
+            "displayName": "vmi_if1_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_ipaddr",
+            "displayName": "vmi_if1_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-2u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-2u/enum_attrs.json
@@ -1,0 +1,593 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if1_ipv4_method",
+            "displayName": "vmi_if1_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if1_ipv6_method",
+            "displayName": "vmi_if1_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-2u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-2u/integer_attrs.json
@@ -1,0 +1,309 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if1_ipv4_prefix_length",
+            "displayName": "vmi_if1_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if1_ipv6_prefix_length",
+            "displayName": "vmi_if1_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-2u/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-2u/string_attrs.json
@@ -1,0 +1,305 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_gateway",
+            "displayName": "vmi_if1_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_ipaddr",
+            "displayName": "vmi_if1_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_gateway",
+            "displayName": "vmi_if1_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_ipaddr",
+            "displayName": "vmi_if1_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-4u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-4u/enum_attrs.json
@@ -1,0 +1,593 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if1_ipv4_method",
+            "displayName": "vmi_if1_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if1_ipv6_method",
+            "displayName": "vmi_if1_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-4u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-4u/integer_attrs.json
@@ -1,0 +1,309 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if1_ipv4_prefix_length",
+            "displayName": "vmi_if1_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if1_ipv6_prefix_length",
+            "displayName": "vmi_if1_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-4u/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-4u/string_attrs.json
@@ -1,0 +1,305 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_gateway",
+            "displayName": "vmi_if1_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_ipaddr",
+            "displayName": "vmi_if1_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_gateway",
+            "displayName": "vmi_if1_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_ipaddr",
+            "displayName": "vmi_if1_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/libpldmresponder/bios_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/bios_oem_ibm.cpp
@@ -1,0 +1,135 @@
+#include "bios_oem_ibm.hpp"
+
+#include "host-bmc/dbus/serialize.hpp"
+
+namespace pldm
+{
+namespace responder
+{
+namespace oem::ibm::bios
+{
+
+/** @brief Method to get the system type information
+ *
+ *  @return - the system type information
+ */
+std::optional<std::string>
+    pldm::responder::oem::ibm::bios::Handler::getPlatformName()
+{
+    if (!systemType.empty())
+    {
+        return systemType;
+    }
+
+    static constexpr auto searchpath = "/xyz/openbmc_project/";
+    int depth = 0;
+    std::vector<std::string> ibmCompatible = {compatibleInterface};
+    pldm::utils::GetSubTreeResponse response;
+    try
+    {
+        response = pldm::utils::DBusHandler().getSubtree(searchpath, depth,
+                                                         ibmCompatible);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        error(
+            " getSubtree call failed with, ERROR={ERROR} PATH={PATH} INTERFACE={INTERFACE}",
+            "ERROR", e.what(), "PATH", searchpath, "INTERFACE",
+            ibmCompatible[0]);
+        return std::nullopt;
+    }
+
+    for (const auto& [objectPath, serviceMap] : response)
+    {
+        try
+        {
+            auto value = pldm::utils::DBusHandler()
+                             .getDbusProperty<std::vector<std::string>>(
+                                 objectPath.c_str(), namesProperty,
+                                 ibmCompatible[0].c_str());
+            writeFile(value[0]);
+            return value[0];
+        }
+        catch (const sdbusplus::exception_t& e)
+        {
+            error(
+                " Error getting Names property, ERROR={ERROR} PATH={PATH} INTERFACE={INTERFACE}",
+                "ERROR", e.what(), "PATH", searchpath, "INTERFACE",
+                ibmCompatible[0]);
+        }
+    }
+
+    return readFile();
+}
+
+/** @brief callback function invoked when interfaces get added from
+ *      Entity manager
+ *
+ *  @param[in] msg - Data associated with subscribed signal
+ */
+void pldm::responder::oem::ibm::bios::Handler::ibmCompatibleAddedCallback(
+    sdbusplus::message::message& msg)
+{
+    sdbusplus::message::object_path path;
+
+    std::map<std::string,
+             std::map<std::string,
+                      std::variant<std::string, std::vector<std::string>>>>
+        interfaceMap;
+
+    msg.read(path, interfaceMap);
+
+    if (!interfaceMap.contains(compatibleInterface))
+    {
+        return;
+    }
+    // Get the "Name" property value of the
+    // "xyz.openbmc_project.Configuration.IBMCompatibleSystem" interface
+    const auto& properties = interfaceMap.at(compatibleInterface);
+
+    if (!properties.contains(namesProperty))
+    {
+        return;
+    }
+    auto names =
+        std::get<pldm::utils::Interfaces>(properties.at(namesProperty));
+
+    // get only the first system type
+    if (!names.empty())
+    {
+        systemType = names.front();
+        writeFile(systemType);
+    }
+
+    if (!systemType.empty())
+    {
+        ibmCompatibleMatchConfig.reset();
+    }
+}
+
+void pldm::responder::oem::ibm::bios::Handler::writeFile(std::string systemType)
+{
+    info("SystemType written in the file : {SYSTEM_TYPE}", "SYSTEM_TYPE",
+         systemType);
+    pldm::serialize::Serialize::getSerialize().serializeKeyVal("SystemType",
+                                                               systemType);
+}
+
+std::optional<std::string> pldm::responder::oem::ibm::bios::Handler::readFile()
+{
+    std::map<std::string, pldm::dbus::PropertyValue> persistedData =
+        pldm::serialize::Serialize::getSerialize().getSavedKeyVals();
+
+    if (persistedData.contains("SystemType"))
+    {
+        info("SystemType read from the file: {SYSTEM_TYPE}", "SYSTEM_TYPE",
+             std::get<std::string>(persistedData["SystemType"]));
+        return std::get<std::string>(persistedData["SystemType"]);
+    }
+    error("Error in reading SystemType from the file");
+    return std::nullopt;
+}
+
+} // namespace oem::ibm::bios
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/bios_oem_ibm.hpp
+++ b/oem/ibm/libpldmresponder/bios_oem_ibm.hpp
@@ -1,0 +1,72 @@
+#pragma once
+#include "common/utils.hpp"
+#include "libpldmresponder/bios.hpp"
+#include "libpldmresponder/oem_handler.hpp"
+
+#include <filesystem>
+
+namespace pldm
+{
+namespace responder
+{
+namespace oem::ibm::bios
+{
+static constexpr auto compatibleInterface =
+    "xyz.openbmc_project.Configuration.IBMCompatibleSystem";
+static constexpr auto namesProperty = "Names";
+namespace fs = std::filesystem;
+class Handler : public oem_bios::Handler
+{
+  public:
+    Handler(const pldm::utils::DBusHandler* dBusIntf) :
+        oem_bios::Handler(dBusIntf)
+    {
+        ibmCompatibleMatchConfig = std::make_unique<sdbusplus::bus::match_t>(
+            dBusIntf->getBus(),
+            sdbusplus::bus::match::rules::interfacesAdded() +
+                sdbusplus::bus::match::rules::sender(
+                    "xyz.openbmc_project.EntityManager"),
+            std::bind_front(&Handler::ibmCompatibleAddedCallback, this));
+    }
+
+    /** @brief Method to get the system type information
+     *
+     *  @return - the system type information
+     */
+    std::optional<std::string> getPlatformName();
+
+  private:
+    /** @brief system type/model */
+    std::string systemType;
+
+    pldm::responder::bios::Handler* biosHandler;
+
+    /** @brief D-Bus Interface added signal match for Entity Manager */
+    std::unique_ptr<sdbusplus::bus::match::match> ibmCompatibleMatchConfig;
+
+    /** @brief D-Bus Interface object*/
+    const pldm::utils::DBusHandler* dBusIntf;
+
+    /** @brief callback function invoked when interfaces get added from
+     *     Entity manager
+     *
+     *  @param[in] msg - Data associated with subscribed signal
+     */
+    void ibmCompatibleAddedCallback(sdbusplus::message::message& msg);
+
+    /** @brief Method to get the persisted system type information
+     *
+     *  @return - the system type information
+     */
+    std::optional<std::string> readFile();
+
+    /** @brief Method to persist system type information
+     *  @param[in] systemType - the system type
+     *  @return - void
+     */
+    void writeFile(std::string systemType);
+};
+
+} // namespace oem::ibm::bios
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -47,7 +47,8 @@ using LicJsonObjMap = std::map<fs::path, nlohmann::json>;
 LicJsonObjMap licJsonMap;
 using PropertyValue =
     std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-                 uint64_t, double, std::string, std::vector<uint8_t>>;
+                 uint64_t, double, std::string, std::vector<uint8_t>,
+                 std::vector<std::string>>;
 using PropertyMap = std::map<std::string, PropertyValue>;
 using InterfaceMap = std::map<std::string, PropertyMap>;
 using ObjectValueTree = std::map<sdbusplus::message::object_path, InterfaceMap>;


### PR DESCRIPTION
This commit adds code to populate BIOS attributes
based on the system type that is the platform.

The BIOS Jsons are installed based on the platform/ system type. The system type is populated by entity manager. Added support for below system types:
Bonnell
Everest
Rainier-1s4u
Rainier-2u
Rainier-4u

TESTED on hardware across different platform/system type. On systems where the compatible system interface is not implemented or entity manager not running, then the BIOS Jsons with default values are installed.