### PR TITLE
oem: ibm: fileTable: Add lid 81e00670

### DIFF
--- a/oem/ibm/configurations/fileTable.json
+++ b/oem/ibm/configurations/fileTable.json
@@ -84,6 +84,10 @@
         "file_traits": 1
     },
     {
+        "path": "/usr/local/share/hostfw/running/81e00670.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00670.lid",
+        "file_traits": 1
+    },
+    {
         "path": "/usr/local/share/hostfw/running/81e0066b.lid,/var/lib/phosphor-software-manager/hostfw/running/81e0066b.lid",
         "file_traits": 4
     },


### PR DESCRIPTION
Add read-only lid 81e00670 which is a partition table that hostboot uses to get information about the other partition files.

Tested: Verified this lid was read by hostboot on a p10bmc system and that the system powered on.

Change-Id: If09ec0ae0938925f8a147dc28ea2d8b24f94c13d