### PR TITLE
oem_ibm:Adding vmi_if_count bios attribute

### DIFF
--- a/oem/ibm/configurations/bios/integer_attrs.json
+++ b/oem/ibm/configurations/bios/integer_attrs.json
@@ -1,6 +1,15 @@
 {
     "entries": [
         {
+            "attribute_name" : "vmi_if_count",
+            "lower_bound" : 0,
+            "upper_bound" : 2,
+            "scalar_increment" : 1,
+            "default_value" : 1,
+            "helpText" : "vmi_if_count",
+            "displayName" : "vmi_if_count"
+        },
+        {
             "attribute_name": "vmi_if0_ipv4_prefix_length",
             "lower_bound": 0,
             "upper_bound": 32,


### PR DESCRIPTION
-This attribute is needed by
 phosphor-networkd to identify
 total number of ethernet interfaces

Change-Id: I804b120086ab30f4579de830ba64ea358f059987