### PR TITLE
oem-ibm: Spelling correction Gard to Guard

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -466,7 +466,7 @@
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Controls whether or not a processor core will be de-configured on error.",
-            "displayName": "GARD on error"
+            "displayName": "Guard on error"
         },
         {
             "attribute_name": "pvm_rpd_policy",


### PR DESCRIPTION
Modified the display name for Runtime Processor Diagnostic Guard Policy.