### PR TITLE
oem-ibm: Change default OS type from "AIX" to "Default"

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -153,7 +153,7 @@
                 "Linux KVM",
                 "Default"
             ],
-            "default_values": ["AIX"],
+            "default_values": ["Default"],
             "helpText": "CEC Primary OS",
             "displayName": "CEC Primary OS"
         },
@@ -166,7 +166,7 @@
                 "Linux KVM",
                 "Default"
             ],
-            "default_values": ["AIX"],
+            "default_values": ["Default"],
             "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
             "displayName": "CEC Primary OS (current)",
             "readOnly": true


### PR DESCRIPTION
This change makes default OS type as "Default" instead of "AIX". Keeping default OS type as AIX can cause issues in systems where AIX is not installed. So the safer option is to keep default OS type as "Default" so PHYP can decide which OS has to boot. With Default, PHYP uses the RB keyword to boot to the default OS.