### PR TITLE
Change customer power policy mapping

### DIFF
--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -367,7 +367,7 @@
                 "property_name": "PowerRestorePolicy",
                 "property_type": "string",
                 "property_values": [
-                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
                     "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
                 ]
             }


### PR DESCRIPTION
This commit adds changes to change the mapping of "Disabled" value from "None" to "AlwaysOff" for the BIOS attrubute pvm_auto_poweron_restart, which is the BIOS attribute mapped in the backend with the customer APR policy.

Change the mapping of "Disabled" value from "None" to "AlwaysOff" for the PLDM BIOS attrubute pvm_auto_poweron_restart, which is the BIOS attribute mapped in the backend with the customer APR policy. So that if the OS/PHYP sets the customer policy to "Disabled" the Dbus backend value for the customer policy will get changed to "AlwaysOff" instead of "None" as, if its "None" then when we check the customer policy before we set the one_time APR policy we do not see and "None" and see "AlwaysOff" instead.

Defect:588703

TESTED: tested by powering on the IBMi system till OS runtime where in the OS tries to set the customer policy to "Disabled", made sure that the one_time policy is not changed due to this. Previously when the OS tried to change the customer policy the BIOS attribute pvm_auto_poweron_restart. to "Disabled" at the backend as the D-Bus property was mapped to value "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None", it would get updated to "None" and the next time when we are trying to set the one_time APR policy to "AlwaysOn" in the host gracefull shut down path, pldm would see the the customer value is "AlwaysOff" and set it to "AlwaysOn", which is why the system would always poweron after recovery from UPS loss, as opposed to what the customer wanted.