### PR TITLE
Adding System specific bios attribute files

### DIFF
--- a/oem/ibm/configurations/bios/ibm,bonnell/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,bonnell/enum_attrs.json
@@ -1,0 +1,565 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
+            "default_values": ["AIX"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,bonnell/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,bonnell/integer_attrs.json
@@ -1,0 +1,273 @@
+{
+    "entries": [
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,bonnell/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,bonnell/string_attrs.json
@@ -1,0 +1,225 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,everest/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,everest/enum_attrs.json
@@ -1,0 +1,605 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if1_ipv4_method",
+            "displayName": "vmi_if1_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if1_ipv6_method",
+            "displayName": "vmi_if1_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,everest/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,everest/integer_attrs.json
@@ -1,0 +1,309 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if1_ipv4_prefix_length",
+            "displayName": "vmi_if1_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if1_ipv6_prefix_length",
+            "displayName": "vmi_if1_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,everest/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,everest/string_attrs.json
@@ -1,0 +1,305 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_gateway",
+            "displayName": "vmi_if1_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_ipaddr",
+            "displayName": "vmi_if1_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_gateway",
+            "displayName": "vmi_if1_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_ipaddr",
+            "displayName": "vmi_if1_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-1s4u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-1s4u/enum_attrs.json
@@ -1,0 +1,605 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if1_ipv4_method",
+            "displayName": "vmi_if1_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if1_ipv6_method",
+            "displayName": "vmi_if1_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-1s4u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-1s4u/integer_attrs.json
@@ -1,0 +1,309 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if1_ipv4_prefix_length",
+            "displayName": "vmi_if1_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if1_ipv6_prefix_length",
+            "displayName": "vmi_if1_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-1s4u/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-1s4u/string_attrs.json
@@ -1,0 +1,305 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_gateway",
+            "displayName": "vmi_if1_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_ipaddr",
+            "displayName": "vmi_if1_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_gateway",
+            "displayName": "vmi_if1_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_ipaddr",
+            "displayName": "vmi_if1_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-2u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-2u/enum_attrs.json
@@ -1,0 +1,605 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if1_ipv4_method",
+            "displayName": "vmi_if1_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if1_ipv6_method",
+            "displayName": "vmi_if1_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-2u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-2u/integer_attrs.json
@@ -1,0 +1,309 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if1_ipv4_prefix_length",
+            "displayName": "vmi_if1_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if1_ipv6_prefix_length",
+            "displayName": "vmi_if1_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-2u/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-2u/string_attrs.json
@@ -1,0 +1,305 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_gateway",
+            "displayName": "vmi_if1_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_ipaddr",
+            "displayName": "vmi_if1_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_gateway",
+            "displayName": "vmi_if1_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_ipaddr",
+            "displayName": "vmi_if1_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-4u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-4u/enum_attrs.json
@@ -1,0 +1,605 @@
+{
+    "entries": [
+        {
+            "attribute_name": "fw_boot_side",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the next boot side to the host, i.e. Temp or Perm. Host can set/query this attribute at anytime to know which is the side the host would boot in the next reboot.",
+            "displayName": "Current Firmware Boot Side (pending)"
+        },
+        {
+            "attribute_name": "fw_boot_side_current",
+            "possible_values": ["Perm", "Temp"],
+            "default_values": ["Temp"],
+            "helpText": "Specifies the current boot side to the host, i.e. Temp or Perm. Host can query this attribute at anytime to know which side it is running on. This attribute is set by the BMC. Set fw_boot_side instead.",
+            "displayName": "Current Firmware Boot Side (current)"
+        },
+        {
+            "attribute_name": "pvm_pcie_error_inject",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "pvm_pcie_error_inject",
+            "displayName": "pvm_pcie_error_inject"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if0_ipv4_method",
+            "displayName": "vmi_if0_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_method",
+            "possible_values": ["IPv4Static", "IPv4DHCP"],
+            "default_values": ["IPv4Static"],
+            "helpText": "vmi_if1_ipv4_method",
+            "displayName": "vmi_if1_ipv4_method"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if0_ipv6_method",
+            "displayName": "vmi_if0_ipv6_method"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_method",
+            "possible_values": ["IPv6Static", "IPv6DHCP", "IPv6SLAAC"],
+            "default_values": ["IPv6Static"],
+            "helpText": "vmi_if1_ipv6_method",
+            "displayName": "vmi_if1_ipv6_method"
+        },
+        {
+            "attribute_name": "hb_hyp_switch",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Tells the host boot fw which type of hypervisor will be loaded.",
+            "displayName": "hb_hyp_switch",
+            "dbus": {
+                "object_path": "/com/ibm/host0/hypervisor",
+                "interface": "com.ibm.Host.Target",
+                "property_name": "Target",
+                "property_type": "string",
+                "property_values": [
+                    "com.ibm.Host.Target.Hypervisor.PowerVM",
+                    "com.ibm.Host.Target.Hypervisor.OPAL"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_hyp_switch_current",
+            "possible_values": ["PowerVM", "OPAL"],
+            "default_values": ["PowerVM"],
+            "helpText": "Do not set this attribute directly; set hb_hyp_switch instead.",
+            "displayName": "hb_hyp_switch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Select hypervisor boot policy, requires a reboot for a change to be applied. Disabled: Instructs server not to activate server firmware and partitions for either a user-initated power on or a recovery power on, Enabled: Instructs the server to automatically activate certain partitions for either a user-initated power on or a recovery power on, ManualOnly: Instructs the server to activate server firmware and partitions automatically only in case of a recovery power on after an abnormal termination.",
+            "displayName": "pvm_stop_at_standby",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/boot",
+                "interface": "xyz.openbmc_project.Control.Boot.Mode",
+                "property_name": "BootMode",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Regular",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Setup",
+                    "xyz.openbmc_project.Control.Boot.Mode.Modes.Safe"
+                ]
+            }
+        },
+        {
+            "attribute_name": "pvm_stop_at_standby_current",
+            "possible_values": ["Disabled", "Enabled", "ManualOnly"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies the current hypervisor boot policy. Do not set this attribute directly; set pvm_stop_at_standby instead.",
+            "displayName": "pvm_stop_at_standby_current (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_debug_console",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When set to Enabled Hostboot should emit debug trace information to the VUART2 device.",
+            "displayName": "hb-debug-console"
+        },
+        {
+            "attribute_name": "hb_inhibit_bmc_reset",
+            "possible_values": ["NoInhibit", "Inhibit"],
+            "default_values": ["NoInhibit"],
+            "helpText": "When set to Inhibit, the hypervisor shall not reset/reload the BMC at runtime.",
+            "displayName": "hb-inhibit-bmc-reset",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_power_off_policy",
+            "possible_values": ["Power Off", "Stay On", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "The system power off policy flag is a system parameter that controls the system's behavior when the last partition (or only partition in the case of a system that is not managed by an HMC) is powered off.",
+            "displayName": "System Automatic Power Off Policy"
+        },
+        {
+            "attribute_name": "pvm_hmc_managed",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the system is managed by HMC.",
+            "displayName": "HMC managed System"
+        },
+        {
+            "attribute_name": "pvm_vmi_support",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Indicates whether or not VMI support has been provisioned by Hypervisor. Enabled - VMI is available, Disabled - VMI is not available.",
+            "displayName": "VMI Support",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rtad",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+            "displayName": "Remote Trusted Attestation Daemon State"
+        },
+        {
+            "attribute_name": "pvm_default_os_type",
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
+            "helpText": "CEC Primary OS",
+            "displayName": "CEC Primary OS"
+        },
+        {
+            "attribute_name": "pvm_default_os_type_current",
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
+            "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
+            "displayName": "CEC Primary OS (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_system_operating_mode",
+            "possible_values": ["Normal", "Manual"],
+            "default_values": ["Normal"],
+            "helpText": "Manual mode is used for service or maintenance purpose of the system hardware. When the system is in manual mode, various automatic functions such as recovery on error, system poweron on power loss and reboot of host on failure are disabled.",
+            "displayName": "Server Operating Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Select the boot type for an AIX/Linux partition. Normal: The partition boots directly to the operating system, SavedList: The system boots from the saved service mode boot list, SmsMenu: The partition stops at the System Management Services(SMS) menu, OkPrompt: The system stops at the open firmware prompt, DefaultList: The system boots from the default boot list.",
+            "displayName": "AIX/Linux Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_rpa_boot_mode_current",
+            "possible_values": [
+                "Normal",
+                "SavedList",
+                "SmsMenu",
+                "OkPrompt",
+                "DefaultList"
+            ],
+            "default_values": ["Normal"],
+            "helpText": "Specifies the current boot type for an AIX/Linux partition. Do not set this attribute directly; set pvm_rpa_boot_mode instead.",
+            "displayName": "AIX/Linux Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_os_boot_type",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Select the IBM i partition boot mode for next system boot. A_Mode: Boot from disk using copy A, B_Mode: Boot from disk using copy B, C_Mode: Reserved for IBM lab use only, D_Mode: Boot from media/drives.",
+            "displayName": "IBM i Partition Boot Mode"
+        },
+        {
+            "attribute_name": "pvm_os_boot_type_current",
+            "possible_values": ["A_Mode", "B_Mode", "C_Mode", "D_Mode"],
+            "default_values": ["A_Mode"],
+            "helpText": "Specifies the current IBM i partition boot mode for next system boot. Do not set this attribute directly; set pvm_os_boot_type instead.",
+            "displayName": "IBM i Partition Boot Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_vtpm",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabling vTPM makes a TPM available to the guest operating system.",
+            "displayName": "Virtual Trusted Platform Module"
+        },
+        {
+            "attribute_name": "pvm_vtpm_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies the current vTPM policy. Do not set this attribute directly; set pvm_vtpm instead.",
+            "displayName": "Virtual Trusted Platform Module (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_sys_dump_active",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled when a system dump is in progress or stored in hypervisor memory and ready for offload, Disabled otherwise.",
+            "displayName": "System Dump Active"
+        },
+        {
+            "attribute_name": "hb_memory_region_size",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory, requires a reboot for a change to be applied.",
+            "displayName": "Memory Region Size (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_region_size_current",
+            "possible_values": ["128MB", "256MB", "1024MB", "2048MB", "4096MB"],
+            "default_values": ["256MB"],
+            "helpText": "Specifies the size of the logical memory block the system uses to read memory for the current IPL. Do not set this attribute directly; set hb_memory_region_size instead.",
+            "displayName": "Memory Region Size (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_limit_enable",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Power Limit Enable (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_name": "PowerCapEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_limit_enable_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the power limit is enabled for the current IPL. Do not set this attribute directly; set hb_power_limit_enable instead.",
+            "displayName": "Power Limit Enable (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_secure_ver_lockin_enabled",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the secure version lockin functionality is enabled.",
+            "displayName": "Secure Version Lockin Enabled"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
+            "displayName": "Memory Mirror Mode (pending)"
+        },
+        {
+            "attribute_name": "hb_memory_mirror_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
+            "displayName": "Memory Mirror Mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_tpm_required",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system",
+            "displayName": "TPM Required Policy (pending)",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/TPMEnable",
+                "interface": "xyz.openbmc_project.Control.TPM.Policy",
+                "property_name": "TPMEnable",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_tpm_required_current",
+            "possible_values": ["Required", "Not Required"],
+            "default_values": ["Required"],
+            "helpText": "When the 'TPM Required Policy' is 'Required', a functional TPM is required to boot the system. Do not set this attribute directly; set hb_tpm_required instead.",
+            "displayName": "TPM Required Policy (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_key_clear_request",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system, requires a reboot to take effect",
+            "displayName": "Key Clear Request (pending)"
+        },
+        {
+            "attribute_name": "hb_key_clear_request_current",
+            "possible_values": [
+                "NONE",
+                "ALL",
+                "OS_KEYS",
+                "POWERVM_SYSKEY",
+                "MFG_ALL",
+                "MFG"
+            ],
+            "default_values": ["NONE"],
+            "helpText": "Specifies the requested level of security keys to be cleared from the system for the current IPL. Do not set this attribute directly; set hb_key_clear_request instead.",
+            "displayName": "Key Clear Request (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons, requires a reboot for a change to be applied.",
+            "displayName": "Host USB Enablement (pending)"
+        },
+        {
+            "attribute_name": "hb_host_usb_enablement_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Specifies if Host USB is disabled or enabled for security reasons. Do not set this attribute directly; set hb_host_usb_enablement instead.",
+            "displayName": "Host USB Enablement (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_auto_poweron_restart",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Select auto poweron policy. Disabled: Instructs server not to activate any auto poweron logic, Enabled: The system will boot automatically once power is restored after a power disturbance.",
+            "displayName": "pvm_auto_poweron_restart",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_restore_policy",
+                "interface": "xyz.openbmc_project.Control.Power.RestorePolicy",
+                "property_name": "PowerRestorePolicy",
+                "property_type": "string",
+                "property_values": [
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
+                ]
+            }
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Lateral Cast Out mode (pending)"
+        },
+        {
+            "attribute_name": "hb_lateral_cast_out_mode_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Lateral Cast Out mode is disabled or enabled. Do not set this attribute directly; set hb_lateral_cast_out_mode instead.",
+            "displayName": "Lateral Cast Out mode (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled, requires a reboot for a change to be applied.",
+            "displayName": "Proc Favor Aggressive Prefetch (pending)"
+        },
+        {
+            "attribute_name": "hb_proc_favor_aggressive_prefetch_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if Proc Favor Aggressive Prefetch is disabled or enabled. Do not set this attribute directly; set hb_proc_favor_aggressive_prefetch instead.",
+            "displayName": "Proc Favor Aggressive Prefetch (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.",
+            "displayName": "pvm_create_default_lpar (pending)"
+        },
+        {
+            "attribute_name": "pvm_create_default_lpar_current",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "When enabled creates a new default partition after NVRAM is cleared. This is primarily for machines that are managed by hardware management console.Do not set this attribute directly; set pvm_create_default_lpar instead.",
+            "displayName": "pvm_create_default_lpar (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_keep_and_clear",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "The hypervisor needs to clear most of PHYP NVRAM, but preserve the NVRAM for the manufacturing default partition",
+            "displayName": "pvm_keep_and_clear"
+        },
+        {
+            "attribute_name": "pvm_clear_nvram",
+            "possible_values": ["Disabled", "Enabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if the hypervisor needs to clear PHYP NVRAM",
+            "displayName": "pvm_clear_nvram"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL.",
+            "displayName": "IPL Initiator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_initiator_current",
+            "possible_values": ["User", "HMC", "Host", "Auto"],
+            "default_values": ["User"],
+            "helpText": "Specifies who initiated the IPL. Set pvm_boot_initiator instead.",
+            "displayName": "IPL Initiator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_boot_type",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL",
+            "displayName": "Boot Type Indicator (pending)"
+        },
+        {
+            "attribute_name": "pvm_boot_type_current",
+            "possible_values": ["IPL", "ReIPL"],
+            "default_values": ["IPL"],
+            "helpText": "Specifies if the boot type is an IPL or a ReIPL. Set pvm_boot_type instead",
+            "displayName": "Boot Type Indicator (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "pvm_rpd_guard_policy",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Controls whether or not a processor core will be de-configured on error.",
+            "displayName": "Guard on error"
+        },
+        {
+            "attribute_name": "pvm_rpd_policy",
+            "possible_values": ["Enabled", "Scheduled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Run Now (Run sequentially on each core starting immediately), Scheduled (Run sequentially on each core at the scheduled time each day), Disabled (No diagnostics or exercisers will be run).",
+            "displayName": "Runtime Processor Diagnostics Policy"
+        },
+        {
+            "attribute_name": "pvm_rpd_immediate_test",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Enabled (Override the pvm_rpd_policy and start a diagnostic test run immediately. RPD will set pvm_rpd_immediate_test to “Disabled” when an immediate test run completes), Disabled (The pvm_rpd_policy is used).",
+            "displayName": "Immediate Test Requested"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature"
+        },
+        {
+            "attribute_name": "pvm_rpd_feature_current",
+            "possible_values": ["Enabled", "Disabled", "Automatic"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+            "displayName": "Runtime Processor Diagnostics Feature",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_power_PS0_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 0 is present. (Enabled is Present)",
+            "displayName": "Power Supply 0 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 1 is present or not. (Enabled is present)",
+            "displayName": "Power Supply 1 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 2 is Present. (Enabled is Present)",
+            "displayName": "Power Supply 2 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_functional",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies if Power Supply 3 is present. (Enabled is Present)",
+            "displayName": "Power Supply 3 is present",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property_name": "Present",
+                "property_type": "bool",
+                "property_values": [true, false]
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_network_install_type",
+            "possible_values": ["Disabled", "NFS", "iSCSI"],
+            "default_values": ["Disabled"],
+            "helpText": "Specifies whether the IBM i network install type is NFS Optical or iSCSI Tape. Disabled: indicates the IBM i Network Install BIOS attributes should not be used.",
+            "displayName": "IBM i Network Install Type"
+        },
+        {
+            "attribute_name": "pvm_ibmi_ipaddress_protocol",
+            "possible_values": ["IPv4", "IPv6"],
+            "default_values": ["IPv4"],
+            "helpText": "Specifies whether the IP address protocol for IBM i network install is IPv4 or IPv6.",
+            "displayName": "IBM i IP Address Protocol"
+        },
+        {
+            "attribute_name": "pvm_ibmi_max_frame_size",
+            "possible_values": ["MTU1500", "MTU9000"],
+            "default_values": ["MTU1500"],
+            "helpText": "Specifies the maximum frame size (maximum transmission unit, MTU). The value is in terms of bytes per packet size.",
+            "displayName": "Maximum Frame Size"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests",
+            "displayName": "Memory setting for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_memory_current",
+            "possible_values": ["Automatic", "Custom"],
+            "default_values": ["Automatic"],
+            "helpText": "Controls whether the system or user specified percentage of available system memory will be reserved for the management of KVM guests. Automatic (default) – The system will determine the percentage of available system memory to be reserved for the management of KVM guests. Custom – The user specified percentage of available system memory will be reserved for the management of KVM guests. This attribute is set by the BMC. Set pvm_linux_kvm_memory instead.",
+            "displayName": "Memory setting for KVM Guest Management (current)",
+            "readOnly": true
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-4u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-4u/integer_attrs.json
@@ -1,0 +1,309 @@
+{
+    "entries": [
+        {
+            "attribute_name": "vmi_if0_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if0_ipv4_prefix_length",
+            "displayName": "vmi_if0_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 32,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "vmi_if1_ipv4_prefix_length",
+            "displayName": "vmi_if1_ipv4_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if0_ipv6_prefix_length",
+            "displayName": "vmi_if0_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_prefix_length",
+            "lower_bound": 0,
+            "upper_bound": 128,
+            "scalar_increment": 1,
+            "default_value": 128,
+            "helpText": "vmi_if1_ipv6_prefix_length",
+            "displayName": "vmi_if1_ipv6_prefix_length"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the number of huge pages available for memory management, requires a reboot for a change to be applied.",
+            "displayName": "Number Huge Pages (pending)"
+        },
+        {
+            "attribute_name": "hb_number_huge_pages_current",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the number of huge pages available for memory management for the current IPL. Do not set this attribute directly; set hb_number_huge_pages instead.",
+            "displayName": "Number Huge Pages (current)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, requires a reboot for a change to be applied.",
+            "displayName": "Huge Page Size (pending)"
+        },
+        {
+            "attribute_name": "hb_huge_page_size_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the size of huge pages, 0 = 16GB, for the current IPL. Do not set this attribute directly; set hb_huge_page_size instead.",
+            "displayName": "Huge Page Size (current)"
+        },
+        {
+            "attribute_name": "hb_field_core_override",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Requires a reboot for a change to be applied.",
+            "displayName": "Field Core Override (pending)"
+        },
+        {
+            "attribute_name": "hb_field_core_override_current",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "The maximum number of cores to activate where 0 being to activate all available cores. Value applicable for the current IPL. Do not set this attribute directly; set hb_field_core_override instead.",
+            "displayName": "Field Core Override (current)"
+        },
+        {
+            "attribute_name": "hb_power_limit_in_watts",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the power limit in watts.",
+            "displayName": "Power Limit In Watts",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/control/host0/power_cap",
+                "interface": "xyz.openbmc_project.Control.Power.Cap",
+                "property_type": "uint32_t",
+                "property_name": "PowerCap"
+            }
+        },
+        {
+            "attribute_name": "hb_max_number_huge_pages",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the actual maximum number of huge pages available given the current system configuration.",
+            "displayName": "Max Number Huge Pages"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the enlarged IO capacity, requires a reboot for a change to be applied.",
+            "displayName": "Enlarged IO Capacity (pending)"
+        },
+        {
+            "attribute_name": "hb_ioadapter_enlarged_capacity_current",
+            "lower_bound": 0,
+            "upper_bound": 21,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the enlarged IO capacity for the current IPL. Do not set this attribute directly; set hb_ioadapter_enlarged_capacity instead.",
+            "displayName": "Enlarged IO Capacity (current)"
+        },
+        {
+            "attribute_name": "hb_effective_secure_version",
+            "lower_bound": 0,
+            "upper_bound": 255,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the effective secure version of the host FW. In secure mode, the secure version value of a driver must be greater than or equal to this effective secure version to allow the system to boot.",
+            "displayName": "Effective Secure Version"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_min",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the lowest floor frequency across all chips in the system.",
+            "displayName": "Minimum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_max",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the highest ceiling frequency across all chips in the system.",
+            "displayName": "Maximum Core Freq MHZ"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Requires a reboot for a change to be applied.",
+            "displayName": "Requested Core Freq MHZ (pending)"
+        },
+        {
+            "attribute_name": "hb_cap_freq_mhz_request_current",
+            "lower_bound": 0,
+            "upper_bound": 4294967295,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the desired frequency across all chips in the system.  Do not set this attribute directly; set hb_cap_freq_mhz_request instead.",
+            "displayName": "Requested Core Freq MHZ (current)"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_tod",
+            "lower_bound": 0,
+            "upper_bound": 86399,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+            "displayName": "RPD Scheduled Run Time of Day in Seconds"
+        },
+        {
+            "attribute_name": "pvm_rpd_scheduled_duration",
+            "lower_bound": 30,
+            "upper_bound": 1440,
+            "scalar_increment": 1,
+            "default_value": 1440,
+            "helpText": "Only used when pvm_rpd_policy is set to “Scheduled”. This value represents the duration in minutes to run the processor diagnostics, starting at the Scheduled Time of Day. Note: If the RPD is unable to test every core within the specified Run Time Duration, the RPD will resume where it left off, at the next Schedule Run Time of Day.",
+            "displayName": "RPD Scheduled Run Time Duration in Minutes"
+        },
+        {
+            "attribute_name": "hb_power_PS0_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 0 input voltage(volts)",
+            "displayName": "Power Supply 0 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 1 input voltage(volts)",
+            "displayName": "Power Supply 1 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 2 input voltage(volts)",
+            "displayName": "Power Supply 2 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps2_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_input_voltage",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies power supply 3 input voltage(volts)",
+            "displayName": "Power Supply 3 input Voltage",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/sensors/voltage/ps3_input_voltage_rating",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property_type": "double",
+                "property_name": "Value"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_vlan_tag_id",
+            "lower_bound": 0,
+            "upper_bound": 4094,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the VLAN ID that is used when performing a network installation of an IBM i logical partition. Ethernet packets are tagged with the specified VLAN ID. If this option is not specified, Ethernet packets are untagged.",
+            "displayName": "VLAN Tag Identifier"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_port",
+            "lower_bound": 0,
+            "upper_bound": 65535,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the port that is used for the iSCSI connection.",
+            "displayName": "Target Port"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent.",
+            "displayName": "System Memory Reserved for KVM Guest Management"
+        },
+        {
+            "attribute_name": "pvm_linux_kvm_percentage_current",
+            "lower_bound": 0,
+            "upper_bound": 1000,
+            "scalar_increment": 1,
+            "default_value": 0,
+            "readOnly": true,
+            "helpText": "Specifies the percentage of available system memory that will be reserved for the management of KVM guests. The percentage is specified to the 10th of a percent. Do not set this attribute directly; set pvm_linux_kvm_percentage instead.",
+            "displayName": "System Memory Reserved for KVM Guest Management (current)"
+        }
+    ]
+}

--- a/oem/ibm/configurations/bios/ibm,rainier-4u/string_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-4u/string_attrs.json
@@ -1,0 +1,305 @@
+{
+    "entries": [
+        {
+            "attribute_name": "pvm_system_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 100,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "pvm_system_name",
+            "displayName": "pvm_system_name",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.AssetTag",
+                "property_name": "AssetTag",
+                "property_type": "string"
+            }
+        },
+        {
+            "attribute_name": "vmi_hostname",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 255,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "vmi_hostname",
+            "displayName": "vmi_hostname"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_gateway",
+            "displayName": "vmi_if0_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_gateway",
+            "displayName": "vmi_if1_ipv4_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if0_ipv4_ipaddr",
+            "displayName": "vmi_if0_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv4_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 7,
+            "maximum_string_length": 15,
+            "default_string_length": 7,
+            "default_string": "0.0.0.0",
+            "helpText": "vmi_if1_ipv4_ipaddr",
+            "displayName": "vmi_if1_ipv4_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_gateway",
+            "displayName": "vmi_if0_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_gateway",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_gateway",
+            "displayName": "vmi_if1_ipv6_gateway"
+        },
+        {
+            "attribute_name": "vmi_if0_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if0_ipv6_ipaddr",
+            "displayName": "vmi_if0_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "vmi_if1_ipv6_ipaddr",
+            "string_type": "ASCII",
+            "minimum_string_length": 2,
+            "maximum_string_length": 45,
+            "default_string_length": 2,
+            "default_string": "::",
+            "helpText": "vmi_if1_ipv6_ipaddr",
+            "displayName": "vmi_if1_ipv6_ipaddr"
+        },
+        {
+            "attribute_name": "hb_mfg_flags",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing, requires a reboot for a change to be applied.",
+            "displayName": "Manufacturing Flags (pending)"
+        },
+        {
+            "attribute_name": "hb_mfg_flags_current",
+            "string_type": "Hex",
+            "minimum_string_length": 32,
+            "maximum_string_length": 32,
+            "default_string_length": 32,
+            "default_string": "00000000000000000000000000000000",
+            "helpText": "Specifies the configuration flags used by manufacturing for the current IPL. Do not set this attribute directly; set hb_mfg_flags instead.",
+            "displayName": "Manufacturing Flags (current)",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_lid_ids",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 1024,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the host a mapping of the lid IDs to human readable names.",
+            "displayName": "Hostboot Lid IDs"
+        },
+        {
+            "attribute_name": "hb_power_PS0_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 0 model CCIN in hex.",
+            "displayName": "Power Supply 0 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS1_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 1 model CCIN in hex.",
+            "displayName": "Power Supply 1 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS2_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 2 model CCIN in hex.",
+            "displayName": "Power Supply 2 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply2",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "hb_power_PS3_model",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 4,
+            "default_string_length": 4,
+            "default_string": "0000",
+            "helpText": "Specifies the power supply 3 model CCIN in hex.",
+            "displayName": "Power Supply 3 Model",
+            "dbus": {
+                "object_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply3",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property_type": "string",
+                "property_name": "Model"
+            }
+        },
+        {
+            "attribute_name": "pvm_ibmi_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the load source the system will use to start the logical partition.",
+            "displayName": "Tagged IBM i Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_alt_load_source",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the device the system will use when a D-mode initial program load (IPL) is performed.",
+            "displayName": "Tagged IBM i Alternate Load Source"
+        },
+        {
+            "attribute_name": "pvm_ibmi_console",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 42,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the first workstation that the system will activate in the logical partition.",
+            "displayName": "Tagged IBM i Console"
+        },
+        {
+            "attribute_name": "pvm_ibmi_server_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the IP address of the boot server or the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Server IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_local_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the local IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Local IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_subnet_mask",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the subnet mask for an IBM i network install when the IBM i IP Address Protocol is IPv4.",
+            "displayName": "Subnet Mask"
+        },
+        {
+            "attribute_name": "pvm_ibmi_gateway_ipaddress",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 45,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the Gateway IP address for an IBM i network install in the protocol specified by IBM i IP Address Protocol.",
+            "displayName": "Gateway IP Address"
+        },
+        {
+            "attribute_name": "pvm_ibmi_nfs_image_directory",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 127,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the directory path on the boot server that contains the network installation image for the IBM i partition.",
+            "displayName": "Image Directory Path"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_target_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI target that contains the network installation image for the IBM i partition.",
+            "displayName": "Target Name"
+        },
+        {
+            "attribute_name": "pvm_ibmi_iscsi_initiator_name",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 223,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Specifies the name of the iSCSI initiator associated with the iSCSI target. PHYP will generate an initial initiator name which the user can change. PHYP will restore the initial value if the value is changed.",
+            "displayName": "Initiator Name"
+        }
+    ]
+}


### PR DESCRIPTION
Added bios attribute files for each of the system type supported. List of the system types supported
1. Everest
2. Rainier-1s4u
3. Rainier-2u
4. Rainier-4u
5. Bonnell

Tested:
   This is been tested with infrastructure commit for system specific bios attribute support