### PR TITLE
pldm: Rebasing missed commits

### DIFF
--- a/oem/ibm/configurations/bios/ibm,bonnell/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,bonnell/enum_attrs.json
@@ -132,15 +132,27 @@
         },
         {
             "attribute_name": "pvm_default_os_type",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "CEC Primary OS",
             "displayName": "CEC Primary OS"
         },
         {
             "attribute_name": "pvm_default_os_type_current",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
             "displayName": "CEC Primary OS (current)",
             "readOnly": true
@@ -353,7 +365,7 @@
                 "property_name": "PowerRestorePolicy",
                 "property_type": "string",
                 "property_values": [
-                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
                     "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
                 ]
             }

--- a/oem/ibm/configurations/bios/ibm,everest/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,everest/enum_attrs.json
@@ -146,15 +146,27 @@
         },
         {
             "attribute_name": "pvm_default_os_type",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "CEC Primary OS",
             "displayName": "CEC Primary OS"
         },
         {
             "attribute_name": "pvm_default_os_type_current",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
             "displayName": "CEC Primary OS (current)",
             "readOnly": true
@@ -367,7 +379,7 @@
                 "property_name": "PowerRestorePolicy",
                 "property_type": "string",
                 "property_values": [
-                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
                     "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
                 ]
             }

--- a/oem/ibm/configurations/bios/ibm,rainier-1s4u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-1s4u/enum_attrs.json
@@ -146,15 +146,27 @@
         },
         {
             "attribute_name": "pvm_default_os_type",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "CEC Primary OS",
             "displayName": "CEC Primary OS"
         },
         {
             "attribute_name": "pvm_default_os_type_current",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
             "displayName": "CEC Primary OS (current)",
             "readOnly": true
@@ -367,7 +379,7 @@
                 "property_name": "PowerRestorePolicy",
                 "property_type": "string",
                 "property_values": [
-                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
                     "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
                 ]
             }

--- a/oem/ibm/configurations/bios/ibm,rainier-2u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-2u/enum_attrs.json
@@ -146,15 +146,27 @@
         },
         {
             "attribute_name": "pvm_default_os_type",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "CEC Primary OS",
             "displayName": "CEC Primary OS"
         },
         {
             "attribute_name": "pvm_default_os_type_current",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
             "displayName": "CEC Primary OS (current)",
             "readOnly": true
@@ -367,7 +379,7 @@
                 "property_name": "PowerRestorePolicy",
                 "property_type": "string",
                 "property_values": [
-                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
                     "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
                 ]
             }

--- a/oem/ibm/configurations/bios/ibm,rainier-4u/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-4u/enum_attrs.json
@@ -146,15 +146,27 @@
         },
         {
             "attribute_name": "pvm_default_os_type",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "CEC Primary OS",
             "displayName": "CEC Primary OS"
         },
         {
             "attribute_name": "pvm_default_os_type_current",
-            "possible_values": ["AIX", "Linux", "IBM I", "Linux KVM"],
-            "default_values": ["AIX"],
+            "possible_values": [
+                "AIX",
+                "Linux",
+                "IBM I",
+                "Linux KVM",
+                "Default"
+            ],
+            "default_values": ["Default"],
             "helpText": "Specifies the current CEC Primary OS type. Do not set this attribute directly; set pvm_default_os_type instead.",
             "displayName": "CEC Primary OS (current)",
             "readOnly": true
@@ -367,7 +379,7 @@
                 "property_name": "PowerRestorePolicy",
                 "property_type": "string",
                 "property_values": [
-                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.None",
+                    "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff",
                     "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn"
                 ]
             }


### PR DESCRIPTION
Below are the two commits which were missed in System specific bios attributes changes.
   1. Change customer power policy mapping (#496)
   2. oem-ibm: Change default OS type from "AIX" to "Default" (#493) Rebasing those changes.
   3. oem-ibm:Add default option for pvm_default_os_type (#484)

Tested:
     Normal Poweron/off operation was successful.