### PR TITLE
oem-ibm: TCE Table Preallocation for Dynamic Drawer Add

### DIFF
--- a/oem/ibm/configurations/bios/ibm,everest/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,everest/integer_attrs.json
@@ -187,6 +187,25 @@
             "displayName": "Requested Core Freq MHZ (current)"
         },
         {
+            "attribute_name": "hb_storage_preallocation_for_drawer_attach",
+            "lower_bound": 0,
+            "upper_bound": 9,
+            "scalar_increment": 1,
+            "default_value": 9,
+            "helpText": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
+            "displayName": "Dynamic I/O Drawer Attachment"
+        },
+        {
+            "attribute_name": "hb_storage_preallocation_for_drawer_attach_current",
+            "lower_bound": 0,
+            "upper_bound": 9,
+            "scalar_increment": 1,
+            "default_value": 9,
+            "readOnly": true,
+            "helpText": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
+            "displayName": "Dynamic I/O Drawer Attachment"
+        },
+        {
             "attribute_name": "pvm_rpd_scheduled_tod",
             "lower_bound": 0,
             "upper_bound": 86399,

--- a/oem/ibm/configurations/bios/ibm,rainier-1s4u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-1s4u/integer_attrs.json
@@ -187,6 +187,25 @@
             "displayName": "Requested Core Freq MHZ (current)"
         },
         {
+            "attribute_name": "hb_storage_preallocation_for_drawer_attach",
+            "lower_bound": 0,
+            "upper_bound": 4,
+            "scalar_increment": 1,
+            "default_value": 4,
+            "helpText": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
+            "displayName": "Dynamic I/O Drawer Attachment"
+        },
+        {
+            "attribute_name": "hb_storage_preallocation_for_drawer_attach_current",
+            "lower_bound": 0,
+            "upper_bound": 4,
+            "scalar_increment": 1,
+            "default_value": 4,
+            "readOnly": true,
+            "helpText": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
+            "displayName": "Dynamic I/O Drawer Attachment"
+        },
+        {
             "attribute_name": "pvm_rpd_scheduled_tod",
             "lower_bound": 0,
             "upper_bound": 86399,

--- a/oem/ibm/configurations/bios/ibm,rainier-2u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-2u/integer_attrs.json
@@ -187,6 +187,25 @@
             "displayName": "Requested Core Freq MHZ (current)"
         },
         {
+            "attribute_name": "hb_storage_preallocation_for_drawer_attach",
+            "lower_bound": 0,
+            "upper_bound": 4,
+            "scalar_increment": 1,
+            "default_value": 4,
+            "helpText": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
+            "displayName": "Dynamic I/O Drawer Attachment"
+        },
+        {
+            "attribute_name": "hb_storage_preallocation_for_drawer_attach_current",
+            "lower_bound": 0,
+            "upper_bound": 4,
+            "scalar_increment": 1,
+            "default_value": 4,
+            "readOnly": true,
+            "helpText": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
+            "displayName": "Dynamic I/O Drawer Attachment"
+        },
+        {
             "attribute_name": "pvm_rpd_scheduled_tod",
             "lower_bound": 0,
             "upper_bound": 86399,

--- a/oem/ibm/configurations/bios/ibm,rainier-4u/integer_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,rainier-4u/integer_attrs.json
@@ -187,6 +187,25 @@
             "displayName": "Requested Core Freq MHZ (current)"
         },
         {
+            "attribute_name": "hb_storage_preallocation_for_drawer_attach",
+            "lower_bound": 0,
+            "upper_bound": 4,
+            "scalar_increment": 1,
+            "default_value": 4,
+            "helpText": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
+            "displayName": "Dynamic I/O Drawer Attachment"
+        },
+        {
+            "attribute_name": "hb_storage_preallocation_for_drawer_attach_current",
+            "lower_bound": 0,
+            "upper_bound": 4,
+            "scalar_increment": 1,
+            "default_value": 4,
+            "readOnly": true,
+            "helpText": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
+            "displayName": "Dynamic I/O Drawer Attachment"
+        },
+        {
             "attribute_name": "pvm_rpd_scheduled_tod",
             "lower_bound": 0,
             "upper_bound": 86399,


### PR DESCRIPTION
This commit supports the Translation Control Entry (TCE) table preallocation for dynamic drawer add by introducing a new BIOS attribute of integer type that helps customers to control the number of additional slots that support dynamic external I/O drawer attach. That value is then communicated to the Hypervisor to control the amount
of TCE space that is pre-allocated during system power ON. The customer selects the number of additional slots from eBMC GUI.

Tested By: System power ON/OFF and checking the system specific values of BIOS attribute on respective systems