### PR TITLE
pldm: Catch exceptions precisely and printing it

### DIFF
--- a/fw-update/update_manager.cpp
+++ b/fw-update/update_manager.cpp
@@ -112,7 +112,8 @@ int UpdateManager::processPackage(const std::filesystem::path& packageFilePath)
     }
     catch (const std::exception& e)
     {
-        error("Invalid PLDM package header");
+        error("Invalid PLDM package header ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
         activation = std::make_unique<Activation>(
             pldm::utils::DBusHandler::getBus(), objPath,
             software::Activation::Activations::Invalid, this);

--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -190,7 +190,8 @@ void HostEffecterParser::processHostEffecterChangeNotification(
     }
     catch (const std::out_of_range& e)
     {
-        error("new state not found in json");
+        error("new state not found in json ERROR={ERR_EXCEP}", "ERR_EXCEP",
+              e.what());
         return;
     }
 

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -566,9 +566,8 @@ void HostPDRHandler::mergeEntityAssociations(
                         TERMINUS_HANDLE, 0xFFFFFFFF);
                 if (rc)
                 {
-                    std::cerr
-                        << "Failed to add entity association PDR from node: "
-                        << rc << std::endl;
+                    error("Failed to add entity association PDR from node:{RC}",
+                          "RC", rc);
                 }
             }
             else
@@ -581,9 +580,8 @@ void HostPDRHandler::mergeEntityAssociations(
                         terminus_handle, 0xFFFFFFFF);
                 if (rc)
                 {
-                    std::cerr
-                        << "Failed to add entity association PDR from node: "
-                        << rc << std::endl;
+                    error("Failed to add entity association PDR from node:{RC}",
+                          "RC", rc);
                 }
             }
         }
@@ -726,7 +724,7 @@ void HostPDRHandler::parseStateSensorPDRs()
         }
         // If there is no mapping for terminusHandle assign the reserved TID
         // value of 0xFF to indicate that.
-        catch (const std::out_of_range& e)
+        catch (const std::out_of_range&)
         {
             sensorEntry.terminusID = PLDM_TID_RESERVED;
         }
@@ -1240,7 +1238,7 @@ void HostPDRHandler::_setHostSensorState()
                                      stateSetIds) =
                                 lookupSensorInfo(sensorEntry);
                         }
-                        catch (const std::out_of_range& e)
+                        catch (const std::out_of_range&)
                         {
                             try
                             {
@@ -1249,7 +1247,7 @@ void HostPDRHandler::_setHostSensorState()
                                          stateSetIds) =
                                     lookupSensorInfo(sensorEntry);
                             }
-                            catch (const std::out_of_range& e)
+                            catch (const std::out_of_range&)
                             {
                                 error("No mapping for the events");
                                 continue;

--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -122,7 +122,7 @@ void addObjectPathEntityAssociations(
                     objPathMap[entity_path] = entity;
                 }
             }
-            catch (const std::exception& e)
+            catch (const std::exception&)
             {
                 objPathMap[entity_path] = entity;
             }
@@ -156,7 +156,7 @@ void addObjectPathEntityAssociations(
                 objPathMap[dbusPath] = entity;
             }
         }
-        catch (const std::exception& e)
+        catch (const std::exception&)
         {
             objPathMap[dbusPath] = entity;
         }

--- a/libpldmresponder/bios.cpp
+++ b/libpldmresponder/bios.cpp
@@ -128,8 +128,9 @@ Response Handler::getDateTime(const pldm_msg* request, size_t /*payloadLength*/)
     catch (const sdbusplus::exception_t& e)
     {
         error(
-            "Error getting time, PATH={BMC_TIME_PATH} TIME INTERACE={TIME_INTF}",
-            "BMC_TIME_PATH", bmcTimePath, "TIME_INTF", timeInterface);
+            "Error getting time, PATH={BMC_TIME_PATH} TIME INTERACE={TIME_INTF}  ERROR={ERR_EXCEP}",
+            "BMC_TIME_PATH", bmcTimePath, "TIME_INTF", timeInterface,
+            "ERR_EXCEP", e.what());
         return CmdHandler::ccOnlyResponse(request, PLDM_ERROR);
     }
 

--- a/libpldmresponder/bios_attribute.cpp
+++ b/libpldmresponder/bios_attribute.cpp
@@ -25,7 +25,7 @@ BIOSAttribute::BIOSAttribute(const Json& entry,
     {
         readOnly = entry.at("readOnly");
     }
-    catch (const std::exception& e)
+    catch (const std::exception&)
     {
         // No action required, readOnly is initialised to false
     }
@@ -39,7 +39,7 @@ BIOSAttribute::BIOSAttribute(const Json& entry,
 
         dBusMap = {objectPath, interface, propertyName, propertyType};
     }
-    catch (const std::exception& e)
+    catch (const std::exception&)
     {
         // No action required, dBusMap whill have no value
     }

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -573,8 +573,9 @@ void BIOSConfig::buildAndStoreAttrTables(const Table& stringTable)
         }
         catch (const std::exception& e)
         {
-            error("Construct Table Entry Error, AttributeName = {ATTR_NAME}",
-                  "ATTR_NAME", attr->name);
+            error(
+                "Construct Table Entry Error, AttributeName = {ATTR_NAME}  ERROR={ERR_EXCEP}",
+                "ATTR_NAME", attr->name, "ERR_EXCEP", e.what());
         }
     }
 
@@ -667,8 +668,9 @@ void BIOSConfig::load(const fs::path& filePath, ParseHandler handler)
         }
         catch (const std::exception& e)
         {
-            error("Failed to parse JSON config file : {FILE_PATH}", "FILE_PATH",
-                  filePath.c_str());
+            error(
+                "Failed to parse JSON config file : {FILE_PATH} ERROR={ERR_EXCEP}",
+                "FILE_PATH", filePath.c_str(), "ERR_EXCEP", e.what());
         }
     }
 }
@@ -959,8 +961,9 @@ void BIOSConfig::processBiosAttrChangeNotification(
     }
     catch (const std::invalid_argument& e)
     {
-        error("Could not find handle for BIOS string, ATTRIBUTE={ATTR_NAME}",
-              "ATTR_NAME", attrName.c_str());
+        error(
+            "Could not find handle for BIOS string, ATTRIBUTE={ATTR_NAME} ERROR={ERR_EXCEP}",
+            "ATTR_NAME", attrName.c_str(), "ERR_EXCEP", e.what());
         return;
     }
 

--- a/libpldmresponder/bios_enum_attribute.cpp
+++ b/libpldmresponder/bios_enum_attribute.cpp
@@ -144,7 +144,7 @@ uint8_t BIOSEnumAttribute::getAttrValueIndex()
         auto currentValue = iter->second;
         return getValueIndex(currentValue, possibleValues);
     }
-    catch (const std::exception& e)
+    catch (const std::exception&)
     {
         return defaultValueIndex;
     }
@@ -156,7 +156,7 @@ uint8_t BIOSEnumAttribute::getAttrValueIndex(const PropertyValue& propValue)
     {
         return getValueIndex(std::get<std::string>(propValue), possibleValues);
     }
-    catch (const std::exception& e)
+    catch (const std::exception&)
     {
         return getValueIndex(defaultValue, possibleValues);
     }

--- a/libpldmresponder/bios_integer_attribute.cpp
+++ b/libpldmresponder/bios_integer_attribute.cpp
@@ -211,8 +211,9 @@ uint64_t BIOSIntegerAttribute::getAttrValue()
     }
     catch (const std::exception& e)
     {
-        error("Get Integer Attribute Value Error: AttributeName = {ATTR_NAME}",
-              "ATTR_NAME", name);
+        error(
+            "Get Integer Attribute Value Error: AttributeName = {ATTR_NAME} ERROR={ERR_EXCEP}",
+            "ATTR_NAME", name, "ERR_EXCEP", e.what());
         return integerInfo.defaultValue;
     }
 }

--- a/libpldmresponder/bios_string_attribute.cpp
+++ b/libpldmresponder/bios_string_attribute.cpp
@@ -89,8 +89,9 @@ std::string BIOSStringAttribute::getAttrValue()
     }
     catch (const std::exception& e)
     {
-        error("Get String Attribute Value Error: AttributeName = {ATTR_NAME}",
-              "ATTR_NAME", name);
+        error(
+            "Get String Attribute Value Error: AttributeName = {ATTR_NAME}  ERROR={ERR_EXCEP}",
+            "ATTR_NAME", name, "ERR_EXCEP", e.what());
         return stringInfo.defString;
     }
 }

--- a/libpldmresponder/bios_table.cpp
+++ b/libpldmresponder/bios_table.cpp
@@ -24,7 +24,7 @@ bool BIOSTable::isEmpty() const noexcept
     {
         empty = fs::is_empty(filePath);
     }
-    catch (const fs::filesystem_error& e)
+    catch (const fs::filesystem_error&)
     {
         return true;
     }

--- a/libpldmresponder/event_parser.cpp
+++ b/libpldmresponder/event_parser.cpp
@@ -147,8 +147,9 @@ int StateSensorHandler::eventAction(StateSensorEntry entry,
         }
         catch (const std::out_of_range& e)
         {
-            error("Invalid event state {EVENT_STATE}", "EVENT_STATE",
-                  static_cast<unsigned>(state));
+            error("Invalid event state {EVENT_STATE}  ERROR={ERR_EXCEP}",
+                  "EVENT_STATE", static_cast<unsigned>(state), "ERR_EXCEP",
+                  e.what());
             return PLDM_ERROR_INVALID_DATA;
         }
 
@@ -166,7 +167,7 @@ int StateSensorHandler::eventAction(StateSensorEntry entry,
             return PLDM_ERROR;
         }
     }
-    catch (const std::out_of_range& e)
+    catch (const std::out_of_range&)
     {
         // There is no BMC action for this PLDM event
         return PLDM_SUCCESS;

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -44,7 +44,7 @@ pldm_entity FruImpl::getEntityByObjectPath(const dbus::ObjectValueTree& objects,
             entity.entity_instance_num = 1;
             break;
         }
-        catch (const std::exception& e)
+        catch (const std::exception&)
         {
             continue;
         }
@@ -166,7 +166,8 @@ void FruImpl::buildFRUTable()
     catch (const std::exception& e)
     {
         info(
-            "Look up of inventory objects failed and PLDM FRU table creation failed");
+            "Look up of inventory objects failed and PLDM FRU table creation failed ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         return;
     }
 
@@ -323,7 +324,7 @@ uint32_t FruImpl::populateRecords(
                               std::back_inserter(tlvs));
                 }
             }
-            catch (const std::out_of_range& e)
+            catch (const std::out_of_range&)
             {
                 continue;
             }
@@ -1136,7 +1137,7 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                     pdr->container_id = e.value("container", 0);
                 }
             }
-            catch (const std::exception& ex)
+            catch (const std::exception&)
             {
                 pdr->entity_type = e.value("type", 0);
                 pdr->entity_instance = e.value("instance", 0);
@@ -1200,8 +1201,9 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 catch (const std::exception& e)
                 {
                     error(
-                        "D-Bus object path does not exist, effecter ID: {EFFECTER_ID}",
-                        "EFFECTER_ID", static_cast<uint16_t>(pdr->effecter_id));
+                        "D-Bus object path does not exist, effecter ID: {EFFECTER_ID} ERROR={ERR_EXCEP}",
+                        "EFFECTER_ID", static_cast<uint16_t>(pdr->effecter_id),
+                        "ERR_EXCEP", e.what());
                 }
                 dbusMappings.emplace_back(std::move(dbusMapping));
                 dbusValMaps.emplace_back(std::move(dbusIdToValMap));
@@ -1306,7 +1308,7 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                     pdr->container_id = e.value("container", 0);
                 }
             }
-            catch (const std::exception& ex)
+            catch (const std::exception&)
             {
                 pdr->entity_type = e.value("type", 0);
                 pdr->entity_instance = e.value("instance", 0);
@@ -1379,8 +1381,9 @@ std::vector<uint32_t> FruImpl::setStatePDRParams(
                 catch (const std::exception& e)
                 {
                     error(
-                        "D-Bus object path does not exist, sensor ID: {SENSOR_ID}",
-                        "SENSOR_ID", static_cast<uint16_t>(pdr->sensor_id));
+                        "D-Bus object path does not exist, sensor ID: {SENSOR_ID} ERROR={ERR_EXCEP}",
+                        "SENSOR_ID", static_cast<uint16_t>(pdr->sensor_id),
+                        "ERR_EXCEP", e.what());
                 }
                 dbusMappings.emplace_back(std::move(dbusMapping));
                 dbusValMaps.emplace_back(std::move(dbusIdToValMap));

--- a/libpldmresponder/fru_parser.cpp
+++ b/libpldmresponder/fru_parser.cpp
@@ -67,7 +67,8 @@ void FruParser::setupDefaultDBusLookup(const fs::path& masterJsonPath)
         }
         catch (const std::exception& e)
         {
-            error("FRU DBus lookup map format error");
+            error("FRU DBus lookup map format error ERROR={ERR_EXCEP}",
+                  "ERR_EXCEP", e.what());
             throw InternalFailure();
         }
     }
@@ -169,7 +170,7 @@ void FruParser::setupFruRecordMap(const std::string& dirPath)
                 recordMap.emplace(dbusIntfName, recordInfos);
             }
         }
-        catch (const std::exception& e)
+        catch (const std::exception&)
         {
             continue;
         }

--- a/libpldmresponder/pdr_numeric_effecter.hpp
+++ b/libpldmresponder/pdr_numeric_effecter.hpp
@@ -83,7 +83,7 @@ void generateNumericEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
                 }
             }
         }
-        catch (const std::exception& ex)
+        catch (const std::exception&)
         {
             pdr->entity_type = e.value("type", 0);
             pdr->entity_instance = e.value("instance", 0);

--- a/libpldmresponder/pdr_state_effecter.hpp
+++ b/libpldmresponder/pdr_state_effecter.hpp
@@ -100,7 +100,7 @@ void generateStateEffecterPDR(const DBusInterface& dBusIntf, const Json& json,
                 }
             }
         }
-        catch (const std::exception& ex)
+        catch (const std::exception&)
         {
             pdr->entity_type = e.value("type", 0);
             pdr->entity_instance = e.value("instance", 0);

--- a/libpldmresponder/pdr_state_sensor.hpp
+++ b/libpldmresponder/pdr_state_sensor.hpp
@@ -149,7 +149,7 @@ void generateStateSensorPDR(const DBusInterface& dBusIntf, const Json& json,
                 }
             }
         }
-        catch (const std::exception& ex)
+        catch (const std::exception&)
         {
             pdr->entity_type = e.value("type", 0);
             pdr->entity_instance = e.value("instance", 0);

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -441,6 +441,8 @@ Response Handler::platformEventMessage(const pldm_msg* request,
         }
         catch (const std::out_of_range& e)
         {
+            error("Error in handling plateform event msg ERROR={ERR}", "ERR",
+                  e.what());
             return CmdHandler::ccOnlyResponse(request, PLDM_ERROR_INVALID_DATA);
         }
     }
@@ -517,7 +519,7 @@ int Handler::sensorEvent(const pldm_msg* request, size_t payloadLength,
             std::tie(entityInfo, compositeSensorStates, stateSetIds) =
                 hostPDRHandler->lookupSensorInfo(sensorEntry);
         }
-        catch (const std::out_of_range& e)
+        catch (const std::out_of_range&)
         {
             // If there is no mapping for tid, sensorId combination, try
             // PLDM_TID_RESERVED, sensorId for terminus that is yet to
@@ -529,7 +531,7 @@ int Handler::sensorEvent(const pldm_msg* request, size_t payloadLength,
                     hostPDRHandler->lookupSensorInfo(sensorEntry);
             }
             // If there is no mapping for events return PLDM_SUCCESS
-            catch (const std::out_of_range& e)
+            catch (const std::out_of_range&)
             {
                 return PLDM_SUCCESS;
             }

--- a/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
+++ b/oem/ibm/libpldmresponder/collect_slot_vpd.cpp
@@ -78,6 +78,8 @@ void SlotHandler::processSlotOperations(const std::string& slotObjectPath,
     }
     catch (const std::bad_optional_access& e)
     {
+        error("Failed to get the adapter dbus object ERROR={ERR}", "ERR",
+              e.what());
         return;
     }
 

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -277,8 +277,8 @@ Response Handler::readFileIntoMemory(const pldm_msg* request,
     catch (const std::exception& e)
     {
         error(
-            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
-            "FILE_HNDL", fileHandle);
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}  ERROR={ERR_EXCEP}",
+            "FILE_HNDL", fileHandle, "ERR_EXCEP", e.what());
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -372,8 +372,8 @@ Response Handler::writeFileFromMemory(const pldm_msg* request,
     catch (const std::exception& e)
     {
         error(
-            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
-            "FILE_HNDL", fileHandle);
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL} ERROR={ERR_EXCEP}",
+            "FILE_HNDL", fileHandle, "ERR_EXCEP", e.what());
         encode_rw_file_memory_resp(request->hdr.instance_id,
                                    PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
@@ -500,8 +500,8 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
     catch (const std::exception& e)
     {
         error(
-            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
-            "FILE_HNDL", fileHandle);
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL} ERROR={ERR_EXCEP}",
+            "FILE_HNDL", fileHandle, "ERR_EXCEP", e.what());
 
         encode_read_file_resp(request->hdr.instance_id,
                               PLDM_INVALID_FILE_HANDLE, length, responsePtr);
@@ -584,8 +584,8 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
     catch (const std::exception& e)
     {
         error(
-            "File handle does not exist in the file table, HANDLE={FILE_HNDL}",
-            "FILE_HNDL", fileHandle);
+            "File handle does not exist in the file table, HANDLE={FILE_HNDL}  ERROR={ERR_EXCEP}",
+            "FILE_HNDL", fileHandle, "ERR_EXCEP", e.what());
         encode_write_file_resp(request->hdr.instance_id,
                                PLDM_INVALID_FILE_HANDLE, 0, responsePtr);
         return response;
@@ -671,7 +671,8 @@ Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        error("unknown file type, TYPE={LEN}", "LEN", fileType);
+        error("unknown file type, TYPE={LEN}  ERROR={ERR_EXCEP}", "LEN",
+              fileType, "ERR_EXCEP", e.what());
         encode_rw_file_by_type_memory_resp(request->hdr.instance_id, cmd,
                                            PLDM_INVALID_FILE_TYPE, 0,
                                            responsePtr);
@@ -736,7 +737,8 @@ Response Handler::writeFileByType(const pldm_msg* request, size_t payloadLength)
     }
     catch (const InternalFailure& e)
     {
-        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
+        error("unknown file type, TYPE={FILE_TYP}  ERROR={ERR_EXCEP}",
+              "FILE_TYP", fileType, "ERR_EXCEP", e.what());
         encode_rw_file_by_type_resp(request->hdr.instance_id,
                                     PLDM_WRITE_FILE_BY_TYPE,
                                     PLDM_INVALID_FILE_TYPE, 0, responsePtr);
@@ -785,7 +787,8 @@ Response Handler::readFileByType(const pldm_msg* request, size_t payloadLength)
     }
     catch (const InternalFailure& e)
     {
-        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
+        error("unknown file type, TYPE={FILE_TYP}  ERROR={ERR_EXCEP}",
+              "FILE_TYP", fileType, "ERR_EXCEP", e.what());
         encode_rw_file_by_type_resp(request->hdr.instance_id,
                                     PLDM_READ_FILE_BY_TYPE,
                                     PLDM_INVALID_FILE_TYPE, 0, responsePtr);
@@ -831,6 +834,8 @@ Response Handler::fileAck(const pldm_msg* request, size_t payloadLength)
 
     catch (const InternalFailure& e)
     {
+        error("unknown file type, TYPE={TYPE} ERROR={ERR}", "TYPE", fileType,
+              "ERR", e.what());
         encode_file_ack_resp(request->hdr.instance_id, PLDM_INVALID_FILE_TYPE,
                              responsePtr);
         return response;
@@ -905,7 +910,8 @@ Response Handler::newFileAvailable(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
+        error("unknown file type, TYPE={FILE_TYP} ERROR={ERR_EXCEP}",
+              "FILE_TYP", fileType, "ERR_EXCEP", e.what());
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 
@@ -949,7 +955,8 @@ Response Handler::fileAckWithMetaData(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
+        error("unknown file type, TYPE={FILE_TYP} ERROR={ERR_EXCEP}",
+              "FILE_TYP", fileType, "ERR_EXCEP", e.what());
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 
@@ -995,7 +1002,8 @@ Response Handler::newFileAvailableWithMetaData(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        error("unknown file type, TYPE={FILE_TYP}", "FILE_TYP", fileType);
+        error("unknown file type, TYPE={FILE_TYP} ERROR={ERR_EXCEP}",
+              "FILE_TYP", fileType, "ERR_EXCEP", e.what());
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -106,6 +106,9 @@ int CodeUpdate::setNextBootSide(const std::string& nextSide)
     catch (const std::exception& e)
     {
         // Alternate side may not be present due to a failed code update
+        error(
+            "Alternate side may not be present due to a failed code update. ERROR = {ERR}",
+            "ERR", e.what());
         return PLDM_PLATFORM_INVALID_STATE_VALUE;
     }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -710,9 +710,9 @@ std::filesystem::path pldm::responder::oem_ibm_platform::Handler::getConfigDir()
         catch (const std::exception& e)
         {
             error(
-                "Error getting Names property , PATH={OBJ_PATH} Compatible interface = {INTF}",
+                "Error getting Names property, PATH={OBJ_PATH} Compatible interface = {INTF} ERROR={ERR_EXCEP}",
                 "OBJ_PATH", objectPath.c_str(), "INTF",
-                ibmCompatible[0].c_str());
+                ibmCompatible[0].c_str(), "ERR_EXCEP", e.what());
         }
     }
     return fs::path();
@@ -1256,7 +1256,7 @@ bool pldm::responder::oem_ibm_platform::Handler::watchDogRunning()
         isWatchDogRunning = pldm::utils::DBusHandler().getDbusProperty<bool>(
             watchDogObjectPath, watchDogEnablePropName, watchDogInterface);
     }
-    catch (const std::exception& e)
+    catch (const std::exception&)
     {
         return false;
     }
@@ -1336,7 +1336,8 @@ int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
     }
     catch (const std::exception& e)
     {
-        error("Error getting the current BMC state");
+        error("Error getting the current BMC state ERROR={ERR_EXCEP}",
+              "ERR_EXCEP", e.what());
         return PLDM_ERROR;
     }
     return PLDM_SUCCESS;
@@ -1410,7 +1411,11 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtPowerOn()
             setBootTypesBiosAttr(restartCause);
         }
         catch (const std::exception& e)
-        {}
+        {
+            error(
+                "Failed to set the D-bus property for the Host restart reason ERROR={ERR}",
+                "ERR", e.what());
+        }
     }
 }
 

--- a/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
@@ -44,7 +44,7 @@ int sendBiosAttributeUpdateEvent(
             return PLDM_SUCCESS;
         }
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception::exception&)
     {
         /* Execption is expected to happen in the case when state manager is
          * started after pldm, this is expected to happen in reboot case where

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -427,7 +427,7 @@ bool checkIfIBMCableCard(const std::string& objPath)
             return true;
         }
     }
-    catch (const sdbusplus::exception::SdBusError& e)
+    catch (const sdbusplus::exception::SdBusError&)
     {
         return false;
     }
@@ -456,8 +456,8 @@ void findPortObjects(const std::string& cardObjPath,
     }
     catch (const std::exception& e)
     {
-        error("no ports under card {CARD_OBJ_PATH}", "CARD_OBJ_PATH",
-              cardObjPath.c_str());
+        error("no ports under card {CARD_OBJ_PATH} ERROR = { ERR_EXCEP }",
+              "CARD_OBJ_PATH", cardObjPath.c_str(), "ERR_EXCEP", e.what());
     }
 }
 
@@ -495,7 +495,10 @@ bool checkFruPresence(const char* objPath)
         isPresent = std::get<bool>(propVal);
     }
     catch (const sdbusplus::exception::SdBusError& e)
-    {}
+    {
+        error("D-Bus method call to get the FRU presence failed ERROR={ERR}",
+              "ERR", e.what());
+    }
     return isPresent;
 }
 
@@ -538,8 +541,9 @@ std::string getObjectPathByLocationCode(const std::string& locationCode,
     }
     catch (const std::exception& e)
     {
-        error("Look up of inventory objects failed for location {LOC_CODE}",
-              "LOC_CODE", locationCode);
+        error(
+            "Look up of inventory objects failed for location {LOC_CODE} ERROR={ERR_EXCEP}",
+            "LOC_CODE", locationCode, "ERR_EXCEP", e.what());
         return path;
     }
 
@@ -594,8 +598,9 @@ void findSlotObjects(const std::string& boardObjPath,
     }
     catch (const std::exception& e)
     {
-        error("no cec slots under motherboard {BOARD_OBJ_PATH}",
-              "BOARD_OBJ_PATH", boardObjPath.c_str());
+        error(
+            "No cec slots found under motherboard {BOARD_OBJ_PATH} ERROR={ERR_EXCEP}",
+            "BOARD_OBJ_PATH", boardObjPath.c_str(), "ERR_EXCEP", e.what());
     }
 }
 

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -132,7 +132,12 @@ void DbusToFileHandler::processNewResourceDump(
     }
     catch (const sdbusplus::exception::exception& e)
     {
-        error("Error in getting current resource dump status");
+        error(
+            "Error {ERR_EXCEP} found in getting current resource dump status while initiating a new resource dump with objPath={DUMP_OBJ_PATH} and intf={DUMP_PROG_INTF}",
+            "ERR_EXCEP", e.what(), "DUMP_OBJ_PATH",
+            resDumpCurrentObjPath.str.c_str(), "DUMP_PROG_INTF",
+            resDumpProgressIntf);
+
         return;
     }
 

--- a/pldmd/dbus_impl_requester.cpp
+++ b/pldmd/dbus_impl_requester.cpp
@@ -24,7 +24,7 @@ uint8_t Requester::getInstanceId(uint8_t eid)
     {
         id = ids[eid].next();
     }
-    catch (const std::runtime_error& e)
+    catch (const std::runtime_error&)
     {
         throw TooManyResources();
     }

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -135,7 +135,8 @@ static std::optional<Response>
             header.command = hdrFields.command;
             if (PLDM_SUCCESS != pack_pldm_header(&header, responseHdr))
             {
-                error("Failed adding response header");
+                error("Failed adding response header ERROR={ERR_EXCEP}",
+                      "ERR_EXCEP", e.what());
                 return std::nullopt;
             }
             response.insert(response.end(), completion_code);

--- a/pldmtool/oem/ibm/pldm_oem_ibm.cpp
+++ b/pldmtool/oem/ibm/pldm_oem_ibm.cpp
@@ -8,8 +8,13 @@
 
 #include <endian.h>
 
+#include <phosphor-logging/lg2.hpp>
+
 #include <iostream>
 #include <string>
+
+PHOSPHOR_LOG2_USING;
+
 namespace pldmtool
 {
 
@@ -71,8 +76,8 @@ class GetAlertStatus : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc << ",cc=" << (int)completionCode << "\n";
+            error("Response Message Error: rc={RC} cc={CC}", "RC", rc, "CC",
+                  static_cast<int>(completionCode));
             return;
         }
 
@@ -121,7 +126,7 @@ class GetFileTable : public CommandInterface
                                             0, request);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "PLDM: Request Message Error, rc =" << rc << std::endl;
+            error("PLDM: Request Message Error, rc ={RC}", "RC", rc);
             return;
         }
 
@@ -129,7 +134,7 @@ class GetFileTable : public CommandInterface
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            std::cerr << "PLDM: Communication Error, rc =" << rc << std::endl;
+            error("PLDM: Communication Error, rc ={RC}", "RC", rc);
             return;
         }
 
@@ -148,8 +153,8 @@ class GetFileTable : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << ", rc=" << rc << ", cc=" << (int)cc << std::endl;
+            error("Response Message Error: rc={RC} cc={CC}", "RC", rc, "CC",
+                  static_cast<int>(cc));
             return;
         }
 

--- a/pldmtool/pldm_base_cmd.cpp
+++ b/pldmtool/pldm_base_cmd.cpp
@@ -13,6 +13,8 @@
 
 #include <string>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldmtool
 {
 
@@ -111,8 +113,8 @@ class GetPLDMTypes : public CommandInterface
                                         types.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
             return;
         }
 
@@ -182,8 +184,8 @@ class GetPLDMVersion : public CommandInterface
                                           &version);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
             return;
         }
         char buffer[16] = {0};
@@ -232,8 +234,8 @@ class GetTID : public CommandInterface
         auto rc = decode_get_tid_resp(responsePtr, payloadLength, &cc, &tid);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error:rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error:rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
             return;
         }
         ordered_json data;
@@ -280,8 +282,8 @@ class GetPLDMCommands : public CommandInterface
                                            cmdTypes.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
             return;
         }
         printPldmCommands(cmdTypes, pldmType);

--- a/pldmtool/pldm_bios_cmd.cpp
+++ b/pldmtool/pldm_bios_cmd.cpp
@@ -12,6 +12,8 @@
 #include <map>
 #include <optional>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldmtool
 {
 
@@ -73,8 +75,8 @@ class GetDateTime : public CommandInterface
                                             &month, &year);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
             return;
         }
 
@@ -131,7 +133,7 @@ class SetDateTime : public CommandInterface
         if (!uintToDate(tmData, &year, &month, &day, &hours, &minutes,
                         &seconds))
         {
-            lg2::error("decode date Error: tmData={KEY0}", "KEY0", tmData);
+            error("decode date Error: tmData={KEY0}", "KEY0", tmData);
 
             return {PLDM_ERROR_INVALID_DATA, requestMsg};
         }
@@ -151,8 +153,8 @@ class SetDateTime : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)completionCode);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)completionCode);
 
             return;
         }
@@ -210,16 +212,15 @@ class GetBIOSTableHandler : public CommandInterface
                                             tableType, request);
         if (rc != PLDM_SUCCESS)
         {
-            lg2::error(
-                "Encode GetBIOSTable Error, tableType= {KEY0}, rc = {KEY1}",
-                "KEY0", pldmBIOSTableMap.at(tableType), "KEY1", rc);
+            error("Encode GetBIOSTable Error, tableType= {KEY0}, rc = {KEY1}",
+                  "KEY0", pldmBIOSTableMap.at(tableType), "KEY1", rc);
             return std::nullopt;
         }
         std::vector<uint8_t> responseMsg;
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
+            error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return std::nullopt;
         }
 
@@ -236,7 +237,7 @@ class GetBIOSTableHandler : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error(
+            error(
                 "GetBIOSTable Response Error: tableType={KEY0}, rc ={KEY1}, cc={KEY2}",
                 "KEY0", pldmBIOSTableMap.at(tableType), "KEY1", rc, "KEY2",
                 (int)cc);
@@ -378,7 +379,7 @@ class GetBIOSTableHandler : public CommandInterface
             }
             else
             {
-                lg2::info("Get AttributeType failed.");
+                info("Get AttributeType failed.");
             }
         }
         switch (attrType)
@@ -453,7 +454,7 @@ class GetBIOSTableHandler : public CommandInterface
             case PLDM_BIOS_PASSWORD:
             case PLDM_BIOS_PASSWORD_READ_ONLY:
             {
-                lg2::info("Password attribute: Not Supported");
+                info("Password attribute: Not Supported");
                 break;
             }
         }
@@ -518,7 +519,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!stringTable)
         {
-            lg2::error("GetBIOSStringTable Error");
+            error("GetBIOSStringTable Error");
             return;
         }
         ordered_json stringdata;
@@ -538,7 +539,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!stringTable)
         {
-            lg2::error("GetBIOSAttributeTable Error");
+            error("GetBIOSAttributeTable Error");
             return;
         }
         ordered_json output;
@@ -564,7 +565,7 @@ class GetBIOSTable : public GetBIOSTableHandler
             }
             else
             {
-                lg2::error("Get AttributeType failed.");
+                error("Get AttributeType failed.");
             }
 
             switch (attrType)
@@ -657,7 +658,7 @@ class GetBIOSTable : public GetBIOSTableHandler
                 }
                 case PLDM_BIOS_PASSWORD:
                 case PLDM_BIOS_PASSWORD_READ_ONLY:
-                    lg2::alert("Password attribute: Not Supported");
+                    alert("Password attribute: Not Supported");
             }
             output.emplace_back(std::move(attrdata));
         }
@@ -669,7 +670,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!attrValTable)
         {
-            lg2::error("GetBIOSAttributeValueTable Error");
+            error("GetBIOSAttributeValueTable Error");
             return;
         }
         ordered_json output;
@@ -714,14 +715,14 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
 
         if (!stringTable || !attrTable)
         {
-            lg2::info("StringTable/AttrTable Unavaliable");
+            info("StringTable/AttrTable Unavaliable");
             return;
         }
 
         auto handle = findAttrHandleByName(attrName, *attrTable, *stringTable);
         if (!handle)
         {
-            lg2::error("Can not find the attribute {KEY0}", "KEY0", attrName);
+            error("Could not find the attribute {KEY0}", "KEY0", attrName);
             return;
         }
 
@@ -734,7 +735,7 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
             instanceId, 0, PLDM_GET_FIRSTPART, *handle, request);
         if (rc != PLDM_SUCCESS)
         {
-            lg2::error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
+            error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
 
@@ -742,7 +743,7 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
+            error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
 
@@ -758,8 +759,8 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
             &attributeData);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
 
             return;
         }
@@ -809,7 +810,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
 
         if (!stringTable || !attrTable)
         {
-            lg2::info("StringTable/AttrTable Unavaliable");
+            info("StringTable/AttrTable Unavaliable");
             return;
         }
 
@@ -817,7 +818,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                                              *stringTable);
         if (attrEntry == nullptr)
         {
-            lg2::info("Could not find attribute :{KEY0}", "KEY0", attrName);
+            info("Could not find attribute :{KEY0}", "KEY0", attrName);
             return;
         }
 
@@ -848,7 +849,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                     attrValue.c_str());
                 if (stringEntry == nullptr)
                 {
-                    lg2::info("Set Attribute Error: It's not a possible value");
+                    info("Set Attribute Error: It's not a possible value");
 
                     return;
                 }
@@ -863,7 +864,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                 }
                 if (i == pvNum)
                 {
-                    lg2::info("Set Attribute Error: It's not a possible value");
+                    info("Set Attribute Error: It's not a possible value");
                     return;
                 }
 
@@ -934,14 +935,14 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
 
         if (rc != PLDM_SUCCESS)
         {
-            lg2::error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
+            error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
         std::vector<uint8_t> responseMsg;
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
+            error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
         uint8_t cc = 0;
@@ -954,8 +955,8 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
             responsePtr, payloadLength, &cc, &nextTransferHandle);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
             return;
         }
 

--- a/pldmtool/pldm_cmd_helper.cpp
+++ b/pldmtool/pldm_cmd_helper.cpp
@@ -11,6 +11,8 @@
 
 #include <exception>
 
+PHOSPHOR_LOG2_USING;
+
 using namespace pldm::utils;
 
 namespace pldmtool
@@ -32,7 +34,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == sockFd)
     {
         returnCode = -errno;
-        lg2::error("Failed to create the socket : RC = {KEY0}", "KEY0", sockFd);
+        error("Failed to create the socket : RC = {KEY0}", "KEY0", sockFd);
         return returnCode;
     }
     Logger(pldmVerbose, "Success in creating the socket : RC = ", sockFd);
@@ -49,8 +51,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        lg2::error("Failed to connect to socket : RC = {KEY0}", "KEY0",
-                   returnCode);
+        error("Failed to connect to socket : RC = {KEY0}", "KEY0", returnCode);
 
         return returnCode;
     }
@@ -61,8 +62,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        lg2::error("Failed to send message type as pldm to mctp : RC = {KEY0}",
-                   "KEY0", returnCode);
+        error("Failed to send message type as pldm to mctp : RC = {KEY0}",
+              "KEY0", returnCode);
         return returnCode;
     }
     Logger(
@@ -73,7 +74,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        lg2::error("Write to socket failure : RC = {KEY0}", "KEY0", returnCode);
+        error("Write to socket failure : RC = {KEY0}", "KEY0", returnCode);
         return returnCode;
     }
     Logger(pldmVerbose, "Write to socket successful : RC = ", result);
@@ -82,16 +83,14 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     ssize_t peekedLength = recv(socketFd(), nullptr, 0, MSG_TRUNC | MSG_PEEK);
     if (0 == peekedLength)
     {
-        lg2::error("Socket is closed : peekedLength = {KEY0}", "KEY0",
-                   peekedLength);
+        error("Socket is closed : peekedLength = {KEY0}", "KEY0", peekedLength);
 
         return returnCode;
     }
     else if (peekedLength <= -1)
     {
         returnCode = -errno;
-        lg2::error("recv() system call failed : RC = {KEY0}", "KEY0",
-                   returnCode);
+        error("recv() system call failed : RC = {KEY0}", "KEY0", returnCode);
         return returnCode;
     }
     else
@@ -116,9 +115,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
             }
             else if (recvDataLength != peekedLength)
             {
-                lg2::error(
-                    "Failure to read response length packet: length = {KEY0}",
-                    "KEY0", recvDataLength);
+                error("Failure to read response length packet: length = {KEY0}",
+                      "KEY0", recvDataLength);
                 return returnCode;
             }
         } while (1);
@@ -128,8 +126,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == returnCode)
     {
         returnCode = -errno;
-        lg2::error("Failed to shutdown the socket : RC ={KEY0}", "KEY0",
-                   returnCode);
+        error("Failed to shutdown the socket : RC ={KEY0}", "KEY0", returnCode);
         return returnCode;
     }
 
@@ -154,7 +151,7 @@ void CommandInterface::exec()
     }
     catch (const std::exception& e)
     {
-        lg2::error(
+        error(
             "GetInstanceId D-Bus call failed, MCTP id = {KEY0}, error = {KEY1}",
             "KEY0", (unsigned)mctp_eid, "KEY1", e.what());
         return;
@@ -162,7 +159,7 @@ void CommandInterface::exec()
     auto [rc, requestMsg] = createRequestMsg();
     if (rc != PLDM_SUCCESS)
     {
-        lg2::error(
+        error(
             "Failed to encode request message for {KEY0} : {KEY1}, rc = {KEY1}",
             "KEY0", pldmType, "KEY1", commandName, "KEY1", rc);
         return;
@@ -173,7 +170,7 @@ void CommandInterface::exec()
 
     if (rc != PLDM_SUCCESS)
     {
-        lg2::error("pldmSendRecv: Failed to receive RC = {KEY0}", "KEY0", rc);
+        error("pldmSendRecv: Failed to receive RC = {KEY0}", "KEY0", rc);
         return;
     }
 
@@ -208,7 +205,7 @@ int CommandInterface::pldmSendRecv(std::vector<uint8_t>& requestMsg,
         int fd = pldm_open();
         if (-1 == fd)
         {
-            lg2::error("failed to init mctp ");
+            error("failed to init mctp ");
 
             return -1;
         }

--- a/pldmtool/pldm_fru_cmd.cpp
+++ b/pldmtool/pldm_fru_cmd.cpp
@@ -13,6 +13,8 @@
 #include <functional>
 #include <tuple>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldmtool
 {
 
@@ -65,8 +67,8 @@ class GetFruRecordTableMetadata : public CommandInterface
             &total_record_set_identifiers, &total_table_records, &checksum);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
 
             return;
         }
@@ -277,7 +279,7 @@ class FRUTablePrint
         {
             return std::string(typeMap.at(type)) + "(" + typeString + ")";
         }
-        catch (const std::out_of_range& e)
+        catch (const std::out_of_range&)
         {
             return typeString;
         }
@@ -385,8 +387,8 @@ class GetFRURecordByOption : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
             return;
         }
 
@@ -437,8 +439,8 @@ class GetFruRecordTable : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)cc);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)cc);
 
             return;
         }

--- a/pldmtool/pldm_fw_update_cmd.cpp
+++ b/pldmtool/pldm_fw_update_cmd.cpp
@@ -7,6 +7,8 @@
 
 #include <phosphor-logging/lg2.hpp>
 
+PHOSPHOR_LOG2_USING;
+
 namespace pldmtool
 {
 
@@ -94,8 +96,8 @@ class GetStatus : public CommandInterface
             &reasonCode, &updateOptionFlagsEnabled);
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)completionCode);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)completionCode);
             return;
         }
 
@@ -179,8 +181,8 @@ class GetFwParams : public CommandInterface
             &pendingCompImageSetVersion, &compParameterTable);
         if (rc != PLDM_SUCCESS || fwParams.completion_code != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)fwParams.completion_code);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)fwParams.completion_code);
 
             return;
         }
@@ -269,7 +271,7 @@ class GetFwParams : public CommandInterface
                 &pendingCompVerStr);
             if (rc)
             {
-                lg2::error(
+                error(
                     "Decoding component parameter table entry failed, RC={KEY0}",
                     "KEY0", rc);
                 return;

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -13,6 +13,8 @@
 #include "oem/ibm/oem_ibm_state_set.hpp"
 #endif
 
+PHOSPHOR_LOG2_USING;
+
 using namespace pldm::utils;
 
 namespace pldmtool
@@ -121,7 +123,7 @@ class GetPDR : public CommandInterface
                                                   prevRecordHandle);
                 if (!result.second)
                 {
-                    lg2::error(
+                    error(
                         "Record handle {KEY0} has multiple references: {KEY1}, {KEY2}",
                         "KEY0", recordHandle, "KEY1", result.first->second,
                         "KEY2", prevRecordHandle);
@@ -174,8 +176,8 @@ class GetPDR : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)completionCode);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)completionCode);
             return;
         }
 
@@ -560,7 +562,7 @@ class GetPDR : public CommandInterface
         {
             return entityName + entityType.at(entityNumber);
         }
-        catch (const std::out_of_range& e)
+        catch (const std::out_of_range&)
         {
             auto OemString =
                 std::to_string(static_cast<unsigned>(entityNumber));
@@ -587,7 +589,7 @@ class GetPDR : public CommandInterface
         {
             return stateSet.at(id) + "(" + typeString + ")";
         }
-        catch (const std::out_of_range& e)
+        catch (const std::out_of_range&)
         {
             return typeString;
         }
@@ -642,7 +644,7 @@ class GetPDR : public CommandInterface
         {
             return pdrType.at(type);
         }
-        catch (const std::out_of_range& e)
+        catch (const std::out_of_range&)
         {
             return typeString;
         }
@@ -732,7 +734,7 @@ class GetPDR : public CommandInterface
             reinterpret_cast<pldm_pdr_fru_record_set*>(data);
         if (!pdr)
         {
-            lg2::error("Failed to get the FRU record set PDR");
+            error("Failed to get the FRU record set PDR");
             return;
         }
 
@@ -760,7 +762,7 @@ class GetPDR : public CommandInterface
             reinterpret_cast<pldm_pdr_entity_association*>(data);
         if (!pdr)
         {
-            lg2::error("Failed to get the PDR eneity association");
+            error("Failed to get the PDR eneity association");
             return;
         }
 
@@ -772,7 +774,7 @@ class GetPDR : public CommandInterface
         }
         else
         {
-            lg2::info("Get associationType failed.");
+            info("Get associationType failed.");
         }
         output["containerEntityType"] =
             getEntityName(pdr->container.entity_type);
@@ -805,7 +807,7 @@ class GetPDR : public CommandInterface
             (struct pldm_numeric_effecter_value_pdr*)data;
         if (!pdr)
         {
-            lg2::error("Failed to get numeric effecter PDR");
+            error("Failed to get numeric effecter PDR");
             return;
         }
 
@@ -1000,7 +1002,7 @@ class GetPDR : public CommandInterface
     {
         if (data == NULL)
         {
-            lg2::error("Failed to get PDR message");
+            error("Failed to get PDR message");
             return;
         }
 
@@ -1020,8 +1022,8 @@ class GetPDR : public CommandInterface
             // is not supported
             if (!strToPdrType.contains(pdrRecType))
             {
-                lg2::error("PDR type {KEY0} is not supported or invalid",
-                           "KEY0", pdrRecType);
+                error("PDR type {KEY0} is not supported or invalid", "KEY0",
+                      pdrRecType);
 
                 // PDR type not supported, setting next record handle to 0
                 // to avoid looping through all PDR records
@@ -1114,18 +1116,16 @@ class SetStateEffecter : public CommandInterface
         if (effecterCount > maxEffecterCount ||
             effecterCount < minEffecterCount)
         {
-            lg2::error(
-                "Request Message Error: effecterCount size {KEY0} is invalid",
-                "KEY0", effecterCount);
+            error("Request Message Error: effecterCount size {KEY0} is invalid",
+                  "KEY0", effecterCount);
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
 
         if (effecterData.size() > maxEffecterDataSize)
         {
-            lg2::error(
-                "Request Message Error: effecterData size {KEY0} is invalid",
-                "KEY0", effecterData.size());
+            error("Request Message Error: effecterData size {KEY0} is invalid",
+                  "KEY0", effecterData.size());
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
@@ -1133,9 +1133,8 @@ class SetStateEffecter : public CommandInterface
         auto stateField = parseEffecterData(effecterData, effecterCount);
         if (!stateField)
         {
-            lg2::error(
-                "Failed to parse effecter data, effecterCount size {KEY0}",
-                "KEY0", effecterCount);
+            error("Failed to parse effecter data, effecterCount size {KEY0}",
+                  "KEY0", effecterCount);
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
@@ -1153,8 +1152,8 @@ class SetStateEffecter : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)completionCode);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)completionCode);
 
             return;
         }
@@ -1235,8 +1234,8 @@ class SetNumericEffecterValue : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)completionCode);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)completionCode);
 
             return;
         }
@@ -1302,8 +1301,8 @@ class GetStateSensorReadings : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
-                       rc, "KEY1", (int)completionCode);
+            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
+                  "KEY1", (int)completionCode);
 
             return;
         }
@@ -1397,10 +1396,8 @@ class GetNumericEffecterValue : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            std::cerr << "Response Message Error: "
-                      << "rc=" << rc
-                      << ",cc=" << static_cast<int>(completionCode)
-                      << std::endl;
+            error("Response Message Error: rc={RC} cc={CC}", "RC", rc, "CC",
+                  static_cast<int>(completionCode));
             return;
         }
 
@@ -1461,8 +1458,8 @@ class GetNumericEffecterValue : public CommandInterface
             }
             default:
             {
-                std::cerr << "Unknown Effecter data Size :"
-                          << static_cast<int>(effecterDataSize) << std::endl;
+                error("Unknown Effecter data Size :{SIZE}", "SIZE",
+                      effecterDataSize);
                 break;
             }
         }

--- a/requester/mctp_endpoint_discovery.cpp
+++ b/requester/mctp_endpoint_discovery.cpp
@@ -35,6 +35,9 @@ MctpDiscovery::MctpDiscovery(sdbusplus::bus_t& bus,
     }
     catch (const std::exception& e)
     {
+        error(
+            "D-bus method call to get the managed objects under MCTP Control failed ERROR={ERR}",
+            "ERR", e.what());
         return;
     }
 

--- a/softoff/softoff.cpp
+++ b/softoff/softoff.cpp
@@ -99,7 +99,9 @@ int SoftPowerOff::getHostState()
     }
     catch (const std::exception& e)
     {
-        error("PLDM host soft off: Can't get current host state.");
+        error(
+            "PLDM host soft off: Can't get current host state. ERROR={ERR_EXCEP}",
+            "ERR_EXCEP", e.what());
         hasError = true;
         return PLDM_ERROR;
     }


### PR DESCRIPTION
Correcting catch blocks in PLDM repo to print all the
exceptions precisely so that pldm trace can be more
useful to debug the issues easily.

Trace sample:
Oct 20 02:14:22 p10bmc pldmd[742]: PLDM: Communication Error, rc =1