### PR TITLE
oem-ibm: Disabling Active Memory Mirroring for Bonnell

### DIFF
--- a/oem/ibm/configurations/bios/ibm,bonnell/enum_attrs.json
+++ b/oem/ibm/configurations/bios/ibm,bonnell/enum_attrs.json
@@ -273,21 +273,6 @@
             "displayName": "Secure Version Lockin Enabled"
         },
         {
-            "attribute_name": "hb_memory_mirror_mode",
-            "possible_values": ["Disabled", "Enabled"],
-            "default_values": ["Disabled"],
-            "helpText": "Specifies if the memory mirroring is enabled, requires a reboot for a change to be applied.",
-            "displayName": "Memory Mirror Mode (pending)"
-        },
-        {
-            "attribute_name": "hb_memory_mirror_mode_current",
-            "possible_values": ["Disabled", "Enabled"],
-            "default_values": ["Disabled"],
-            "helpText": "Specifies if the memory mirroring is enabled for the current IPL. Do not set this attribute directly; set hb_memory_mirror_mode instead.",
-            "displayName": "Memory Mirror Mode (current)",
-            "readOnly": true
-        },
-        {
             "attribute_name": "hb_tpm_required",
             "possible_values": ["Required", "Not Required"],
             "default_values": ["Required"],


### PR DESCRIPTION

Active memory mirroring is not supported in Bonnell. To remove that support
we are removing the bios attribute completely so that user will not have any access
to use the AMM setting.
Removed the bios attribute hb_memory_mirror_mode and hb_memory_mirror_mode_current

Fixes: 588132

Tested:
Poweron/poweroff and reset reload case, verified
   /redfish/v1/Registries/BiosAttributeRegistry/BiosAttributeRegistry