### PR TITLE
1110: Change BaseBIOStable type

### DIFF
--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -331,10 +331,10 @@ int BIOSConfig::checkAttributeValueTable(const Table& table)
                 // get possible_value
                 for (size_t i = 0; i < pvHandls.size(); i++)
                 {
-                    options.push_back(
-                        std::make_tuple("xyz.openbmc_project.BIOSConfig."
-                                        "Manager.BoundType.OneOf",
-                                        getValue(pvHandls[i], *stringTable)));
+                    options.push_back(std::make_tuple(
+                        "xyz.openbmc_project.BIOSConfig."
+                        "Manager.BoundType.OneOf",
+                        getValue(pvHandls[i], *stringTable), ""));
                 }
 
                 auto count =
@@ -383,15 +383,15 @@ int BIOSConfig::checkAttributeValueTable(const Table& table)
                 options.push_back(
                     std::make_tuple("xyz.openbmc_project.BIOSConfig.Manager."
                                     "BoundType.LowerBound",
-                                    static_cast<int64_t>(lower)));
+                                    static_cast<int64_t>(lower), ""));
                 options.push_back(
                     std::make_tuple("xyz.openbmc_project.BIOSConfig.Manager."
                                     "BoundType.UpperBound",
-                                    static_cast<int64_t>(upper)));
+                                    static_cast<int64_t>(upper), ""));
                 options.push_back(
                     std::make_tuple("xyz.openbmc_project.BIOSConfig.Manager."
                                     "BoundType.ScalarIncrement",
-                                    static_cast<int64_t>(scalar)));
+                                    static_cast<int64_t>(scalar), ""));
                 defaultValue = static_cast<int64_t>(def);
                 break;
             }
@@ -420,11 +420,11 @@ int BIOSConfig::checkAttributeValueTable(const Table& table)
                 options.push_back(
                     std::make_tuple("xyz.openbmc_project.BIOSConfig.Manager."
                                     "BoundType.MinStringLength",
-                                    static_cast<int64_t>(min)));
+                                    static_cast<int64_t>(min), ""));
                 options.push_back(
                     std::make_tuple("xyz.openbmc_project.BIOSConfig.Manager."
                                     "BoundType.MaxStringLength",
-                                    static_cast<int64_t>(max)));
+                                    static_cast<int64_t>(max), ""));
                 defaultValue = defString.data();
                 break;
             }

--- a/libpldmresponder/bios_config.hpp
+++ b/libpldmresponder/bios_config.hpp
@@ -47,7 +47,7 @@ using CurrentValue = std::variant<int64_t, std::string>;
 using DefaultValue = std::variant<int64_t, std::string>;
 using OptionString = std::string;
 using OptionValue = std::variant<int64_t, std::string>;
-using Option = std::vector<std::tuple<OptionString, OptionValue>>;
+using Option = std::vector<std::tuple<OptionString, OptionValue, std::string>>;
 using BIOSTableObj =
     std::tuple<AttributeType, ReadonlyStatus, DisplayName, Description,
                MenuPath, CurrentValue, DefaultValue, Option>;


### PR DESCRIPTION
This commit adds changes to BaseBIOStable type
as per the changes done in bios-setting-mgr app at - https://gerrit.openbmc.org/c/openbmc/bios-settings-mgr/+/63061

Currently, the upstream code is broken in pldm due to the above change.


Change-Id: Ib2882c93e81a70332e4897b196ae812b63cf6184