### PR TITLE
pldm: Building bios table lazily

### DIFF
--- a/host-bmc/dbus/serialize.cpp
+++ b/host-bmc/dbus/serialize.cpp
@@ -87,16 +87,7 @@ void Serialize::serialize(const std::string& path, const std::string& intf,
 
     std::ofstream os(filePath.c_str(), std::ios::binary);
     cereal::BinaryOutputArchive oarchive(os);
-    oarchive(savedObjs, savedKeyVal);
-}
-
-void Serialize::serializeKeyVal(const std::string& key,
-                                dbus::PropertyValue value)
-{
-    std::ofstream os(filePath.c_str(), std::ios::binary);
-    cereal::BinaryOutputArchive oarchive(os);
-    savedKeyVal[key] = value;
-    oarchive(savedObjs, savedKeyVal);
+    oarchive(savedObjs);
 }
 
 bool Serialize::deserialize()
@@ -111,10 +102,9 @@ bool Serialize::deserialize()
     try
     {
         savedObjs.clear();
-        savedKeyVal.clear();
         std::ifstream is(filePath.c_str(), std::ios::in | std::ios::binary);
         cereal::BinaryInputArchive iarchive(is);
-        iarchive(savedObjs, savedKeyVal);
+        iarchive(savedObjs);
 
         return true;
     }
@@ -168,7 +158,7 @@ void Serialize::reSerialize(const std::vector<uint16_t> types)
 
     std::ofstream os(filePath.c_str(), std::ios::binary);
     cereal::BinaryOutputArchive oarchive(os);
-    oarchive(this->savedObjs, this->savedKeyVal);
+    oarchive(this->savedObjs);
 }
 
 } // namespace serialize

--- a/host-bmc/dbus/serialize.hpp
+++ b/host-bmc/dbus/serialize.hpp
@@ -45,24 +45,11 @@ class Serialize
                    const std::string& type = "",
                    dbus::PropertyValue value = {});
 
-    /** @brief Save the map of Key Value
-     *
-     *  @param[in] key
-     *  @param[in] Property value
-     *  @return void
-     */
-    void serializeKeyVal(const std::string& key, dbus::PropertyValue value);
-
     bool deserialize();
 
     dbus::SavedObjs getSavedObjs()
     {
         return savedObjs;
-    }
-
-    std::map<std::string, pldm::dbus::PropertyValue> getSavedKeyVals()
-    {
-        return savedKeyVal;
     }
 
     void setObjectPathMaps(const ObjectPathMaps& maps);
@@ -78,7 +65,6 @@ class Serialize
     fs::path filePath{PERSISTENT_FILE};
     std::set<uint16_t> storeEntityTypes;
     std::map<ObjectPath, pldm_entity> entityPathMaps;
-    std::map<std::string, pldm::dbus::PropertyValue> savedKeyVal;
 };
 
 } // namespace serialize

--- a/libpldmresponder/bios.cpp
+++ b/libpldmresponder/bios.cpp
@@ -75,9 +75,6 @@ Handler::Handler(int fd, uint8_t eid, dbus_api::Requester* requester,
     biosConfig(BIOS_JSONS_DIR, BIOS_TABLES_DIR, &dbusHandler, fd, eid,
                requester, handler, oemBiosHandler)
 {
-    biosConfig.removeTables();
-    biosConfig.buildTables();
-
     handlers.emplace(PLDM_SET_DATE_TIME,
                      [this](const pldm_msg* request, size_t payloadLength) {
         return this->setDateTime(request, payloadLength);
@@ -224,6 +221,11 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
 
 Response Handler::getBIOSTable(const pldm_msg* request, size_t payloadLength)
 {
+    if (!biosConfig.initializeAttributesAndTables())
+    {
+        return ccOnlyResponse(request, PLDM_ERROR_NOT_READY);
+    }
+
     uint32_t transferHandle{};
     uint8_t transferOpFlag{};
     uint8_t tableType{};
@@ -259,6 +261,11 @@ Response Handler::getBIOSTable(const pldm_msg* request, size_t payloadLength)
 
 Response Handler::setBIOSTable(const pldm_msg* request, size_t payloadLength)
 {
+    if (!biosConfig.initializeAttributesAndTables())
+    {
+        return ccOnlyResponse(request, PLDM_ERROR_NOT_READY);
+    }
+
     uint32_t transferHandle{};
     uint8_t transferOpFlag{};
     uint8_t tableType{};
@@ -294,6 +301,11 @@ Response Handler::setBIOSTable(const pldm_msg* request, size_t payloadLength)
 Response Handler::getBIOSAttributeCurrentValueByHandle(const pldm_msg* request,
                                                        size_t payloadLength)
 {
+    if (!biosConfig.initializeAttributesAndTables())
+    {
+        return ccOnlyResponse(request, PLDM_ERROR_NOT_READY);
+    }
+
     uint32_t transferHandle;
     uint8_t transferOpFlag;
     uint16_t attributeHandle;
@@ -339,6 +351,11 @@ Response Handler::getBIOSAttributeCurrentValueByHandle(const pldm_msg* request,
 Response Handler::setBIOSAttributeCurrentValue(const pldm_msg* request,
                                                size_t payloadLength)
 {
+    if (!biosConfig.initializeAttributesAndTables())
+    {
+        return ccOnlyResponse(request, PLDM_ERROR_NOT_READY);
+    }
+
     uint32_t transferHandle;
     uint8_t transferOpFlag;
     variable_field attributeField;

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -51,17 +51,32 @@ BIOSConfig::BIOSConfig(
     tableDir(tableDir), dbusHandler(dbusHandler), fd(fd), eid(eid),
     requester(requester), handler(handler), oemBiosHandler(oemBiosHandler)
 {
+    fs::create_directories(tableDir);
+    listenPendingAttributes();
+    initializeAttributesAndTables();
+}
+
+bool BIOSConfig::initializeAttributesAndTables()
+{
+    if (!sysType.empty())
+    {
+        return true;
+    }
+
     if (oemBiosHandler)
     {
         auto systemType = oemBiosHandler->getPlatformName();
         if (systemType.has_value())
         {
             sysType = systemType.value();
+            constructAttributes();
+            removeTables();
+            buildTables();
+            return true;
         }
     }
-    fs::create_directories(tableDir);
-    constructAttributes();
-    listenPendingAttributes();
+    error("SystemType not found");
+    return false;
 }
 
 void BIOSConfig::buildTables()
@@ -1045,6 +1060,39 @@ uint16_t BIOSConfig::findAttrHandle(const std::string& attrName)
 void BIOSConfig::constructPendingAttribute(
     const PendingAttributes& pendingAttributes)
 {
+    if (!initializeAttributesAndTables())
+    {
+        error("Base Bios table is not ready");
+
+        for (auto& attribute : pendingAttributes)
+        {
+            auto& [attributeType, attributeValue] = attribute.second;
+            auto type = BIOSConfigManager::convertAttributeTypeFromString(
+                attributeType);
+
+            if (type == BIOSConfigManager::AttributeType::String)
+            {
+                error(
+                    "Persisting attribute = {ATTR_NAME} and Value = {ATTR_VALUE}",
+                    "ATTR_NAME", attribute.first, "ATTR_VALUE",
+                    std::get<std::string>(attributeValue));
+            }
+            else if (type == BIOSConfigManager::AttributeType::Integer)
+            {
+                error(
+                    "Persisting attribute = {ATTR_NAME} and Value = {ATTR_VALUE}",
+                    "ATTR_NAME", attribute.first, "ATTR_VALUE",
+                    std::get<int64_t>(attributeValue));
+            }
+            else
+            {
+                error("Persisting attribute = {ATTR_NAME}", "ATTR_NAME",
+                      attribute.first);
+            }
+        }
+        return;
+    }
+
     std::vector<uint16_t> listOfHandles{};
 
     for (auto& attribute : pendingAttributes)

--- a/libpldmresponder/bios_config.hpp
+++ b/libpldmresponder/bios_config.hpp
@@ -105,6 +105,10 @@ class BIOSConfig
     /** @brief Build bios tables(string,attribute,attribute value table)*/
     void buildTables();
 
+    /** @brief Construct attributes and tables based on the system type(platform
+     * name) */
+    bool initializeAttributesAndTables();
+
     /** @brief Get BIOS table of specified type
      *  @param[in] tableType - The table type
      *  @return The bios table, std::nullopt if the table is unaviliable

--- a/oem/ibm/libpldmresponder/bios_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/bios_oem_ibm.cpp
@@ -1,7 +1,5 @@
 #include "bios_oem_ibm.hpp"
 
-#include "host-bmc/dbus/serialize.hpp"
-
 namespace pldm
 {
 namespace responder
@@ -47,7 +45,7 @@ std::optional<std::string>
                              .getDbusProperty<std::vector<std::string>>(
                                  objectPath.c_str(), namesProperty,
                                  ibmCompatible[0].c_str());
-            writeFile(value[0]);
+            info("SystemType is : {SYSTEM_TYPE}", "SYSTEM_TYPE", value[0]);
             return value[0];
         }
         catch (const sdbusplus::exception_t& e)
@@ -59,7 +57,7 @@ std::optional<std::string>
         }
     }
 
-    return readFile();
+    return std::nullopt;
 }
 
 /** @brief callback function invoked when interfaces get added from
@@ -98,36 +96,13 @@ void pldm::responder::oem::ibm::bios::Handler::ibmCompatibleAddedCallback(
     if (!names.empty())
     {
         systemType = names.front();
-        writeFile(systemType);
+        info("Updated SystemType: {SYSTEM_TYPE}", "SYSTEM_TYPE", systemType);
     }
 
     if (!systemType.empty())
     {
         ibmCompatibleMatchConfig.reset();
     }
-}
-
-void pldm::responder::oem::ibm::bios::Handler::writeFile(std::string systemType)
-{
-    info("SystemType written in the file : {SYSTEM_TYPE}", "SYSTEM_TYPE",
-         systemType);
-    pldm::serialize::Serialize::getSerialize().serializeKeyVal("SystemType",
-                                                               systemType);
-}
-
-std::optional<std::string> pldm::responder::oem::ibm::bios::Handler::readFile()
-{
-    std::map<std::string, pldm::dbus::PropertyValue> persistedData =
-        pldm::serialize::Serialize::getSerialize().getSavedKeyVals();
-
-    if (persistedData.contains("SystemType"))
-    {
-        info("SystemType read from the file: {SYSTEM_TYPE}", "SYSTEM_TYPE",
-             std::get<std::string>(persistedData["SystemType"]));
-        return std::get<std::string>(persistedData["SystemType"]);
-    }
-    error("Error in reading SystemType from the file");
-    return std::nullopt;
 }
 
 } // namespace oem::ibm::bios

--- a/oem/ibm/libpldmresponder/bios_oem_ibm.hpp
+++ b/oem/ibm/libpldmresponder/bios_oem_ibm.hpp
@@ -53,18 +53,6 @@ class Handler : public oem_bios::Handler
      *  @param[in] msg - Data associated with subscribed signal
      */
     void ibmCompatibleAddedCallback(sdbusplus::message::message& msg);
-
-    /** @brief Method to get the persisted system type information
-     *
-     *  @return - the system type information
-     */
-    std::optional<std::string> readFile();
-
-    /** @brief Method to persist system type information
-     *  @param[in] systemType - the system type
-     *  @return - void
-     */
-    void writeFile(std::string systemType);
 };
 
 } // namespace oem::ibm::bios


### PR DESCRIPTION
Building bios table after receiving the System Type from entity manager.

During startup PLDM checks for the system type if system type is known it will build bios tables or else wait for the callback from entity manager to update the system type. Any BIOS command or pending bios attribute update is the trigger to build the bios table.

Tested: Power on/off and Reset reload test.  Jenkin's multiple IPL test.