### PR TITLE
Reverting pldmtool traces

### DIFF
--- a/pldmtool/oem/ibm/pldm_oem_ibm.cpp
+++ b/pldmtool/oem/ibm/pldm_oem_ibm.cpp
@@ -8,13 +8,8 @@
 
 #include <endian.h>
 
-#include <phosphor-logging/lg2.hpp>
-
 #include <iostream>
 #include <string>
-
-PHOSPHOR_LOG2_USING;
-
 namespace pldmtool
 {
 
@@ -76,8 +71,8 @@ class GetAlertStatus : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc={RC} cc={CC}", "RC", rc, "CC",
-                  static_cast<int>(completionCode));
+            std::cerr << "Response Message Error: "
+                      << "rc=" << rc << ",cc=" << (int)completionCode << "\n";
             return;
         }
 
@@ -126,7 +121,7 @@ class GetFileTable : public CommandInterface
                                             0, request);
         if (rc != PLDM_SUCCESS)
         {
-            error("PLDM: Request Message Error, rc ={RC}", "RC", rc);
+            std::cerr << "PLDM: Request Message Error, rc =" << rc << std::endl;
             return;
         }
 
@@ -134,7 +129,7 @@ class GetFileTable : public CommandInterface
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            error("PLDM: Communication Error, rc ={RC}", "RC", rc);
+            std::cerr << "PLDM: Communication Error, rc =" << rc << std::endl;
             return;
         }
 
@@ -153,8 +148,8 @@ class GetFileTable : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc={RC} cc={CC}", "RC", rc, "CC",
-                  static_cast<int>(cc));
+            std::cerr << "Response Message Error: "
+                      << ", rc=" << rc << ", cc=" << (int)cc << std::endl;
             return;
         }
 

--- a/pldmtool/pldm_base_cmd.cpp
+++ b/pldmtool/pldm_base_cmd.cpp
@@ -13,8 +13,6 @@
 
 #include <string>
 
-PHOSPHOR_LOG2_USING;
-
 namespace pldmtool
 {
 
@@ -113,8 +111,8 @@ class GetPLDMTypes : public CommandInterface
                                         types.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 
@@ -184,8 +182,8 @@ class GetPLDMVersion : public CommandInterface
                                           &version);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         char buffer[16] = {0};
@@ -234,8 +232,8 @@ class GetTID : public CommandInterface
         auto rc = decode_get_tid_resp(responsePtr, payloadLength, &cc, &tid);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error:rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error:rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         ordered_json data;
@@ -282,8 +280,8 @@ class GetPLDMCommands : public CommandInterface
                                            cmdTypes.data());
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
         printPldmCommands(cmdTypes, pldmType);

--- a/pldmtool/pldm_bios_cmd.cpp
+++ b/pldmtool/pldm_bios_cmd.cpp
@@ -12,8 +12,6 @@
 #include <map>
 #include <optional>
 
-PHOSPHOR_LOG2_USING;
-
 namespace pldmtool
 {
 
@@ -75,8 +73,8 @@ class GetDateTime : public CommandInterface
                                             &month, &year);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 
@@ -133,7 +131,7 @@ class SetDateTime : public CommandInterface
         if (!uintToDate(tmData, &year, &month, &day, &hours, &minutes,
                         &seconds))
         {
-            error("decode date Error: tmData={KEY0}", "KEY0", tmData);
+            lg2::error("decode date Error: tmData={KEY0}", "KEY0", tmData);
 
             return {PLDM_ERROR_INVALID_DATA, requestMsg};
         }
@@ -153,8 +151,8 @@ class SetDateTime : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)completionCode);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
 
             return;
         }
@@ -212,15 +210,16 @@ class GetBIOSTableHandler : public CommandInterface
                                             tableType, request);
         if (rc != PLDM_SUCCESS)
         {
-            error("Encode GetBIOSTable Error, tableType= {KEY0}, rc = {KEY1}",
-                  "KEY0", pldmBIOSTableMap.at(tableType), "KEY1", rc);
+            lg2::error(
+                "Encode GetBIOSTable Error, tableType= {KEY0}, rc = {KEY1}",
+                "KEY0", pldmBIOSTableMap.at(tableType), "KEY1", rc);
             return std::nullopt;
         }
         std::vector<uint8_t> responseMsg;
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
+            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return std::nullopt;
         }
 
@@ -237,7 +236,7 @@ class GetBIOSTableHandler : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error(
+            lg2::error(
                 "GetBIOSTable Response Error: tableType={KEY0}, rc ={KEY1}, cc={KEY2}",
                 "KEY0", pldmBIOSTableMap.at(tableType), "KEY1", rc, "KEY2",
                 (int)cc);
@@ -379,7 +378,7 @@ class GetBIOSTableHandler : public CommandInterface
             }
             else
             {
-                info("Get AttributeType failed.");
+                lg2::info("Get AttributeType failed.");
             }
         }
         switch (attrType)
@@ -454,7 +453,7 @@ class GetBIOSTableHandler : public CommandInterface
             case PLDM_BIOS_PASSWORD:
             case PLDM_BIOS_PASSWORD_READ_ONLY:
             {
-                info("Password attribute: Not Supported");
+                lg2::info("Password attribute: Not Supported");
                 break;
             }
         }
@@ -519,7 +518,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!stringTable)
         {
-            error("GetBIOSStringTable Error");
+            lg2::error("GetBIOSStringTable Error");
             return;
         }
         ordered_json stringdata;
@@ -539,7 +538,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!stringTable)
         {
-            error("GetBIOSAttributeTable Error");
+            lg2::error("GetBIOSAttributeTable Error");
             return;
         }
         ordered_json output;
@@ -565,7 +564,7 @@ class GetBIOSTable : public GetBIOSTableHandler
             }
             else
             {
-                error("Get AttributeType failed.");
+                lg2::error("Get AttributeType failed.");
             }
 
             switch (attrType)
@@ -658,7 +657,7 @@ class GetBIOSTable : public GetBIOSTableHandler
                 }
                 case PLDM_BIOS_PASSWORD:
                 case PLDM_BIOS_PASSWORD_READ_ONLY:
-                    alert("Password attribute: Not Supported");
+                    lg2::alert("Password attribute: Not Supported");
             }
             output.emplace_back(std::move(attrdata));
         }
@@ -670,7 +669,7 @@ class GetBIOSTable : public GetBIOSTableHandler
     {
         if (!attrValTable)
         {
-            error("GetBIOSAttributeValueTable Error");
+            lg2::error("GetBIOSAttributeValueTable Error");
             return;
         }
         ordered_json output;
@@ -715,14 +714,14 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
 
         if (!stringTable || !attrTable)
         {
-            info("StringTable/AttrTable Unavaliable");
+            lg2::info("StringTable/AttrTable Unavaliable");
             return;
         }
 
         auto handle = findAttrHandleByName(attrName, *attrTable, *stringTable);
         if (!handle)
         {
-            error("Could not find the attribute {KEY0}", "KEY0", attrName);
+            lg2::error("Can not find the attribute {KEY0}", "KEY0", attrName);
             return;
         }
 
@@ -735,7 +734,7 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
             instanceId, 0, PLDM_GET_FIRSTPART, *handle, request);
         if (rc != PLDM_SUCCESS)
         {
-            error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
+            lg2::error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
 
@@ -743,7 +742,7 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
+            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
 
@@ -759,8 +758,8 @@ class GetBIOSAttributeCurrentValueByHandle : public GetBIOSTableHandler
             &attributeData);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
 
             return;
         }
@@ -810,7 +809,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
 
         if (!stringTable || !attrTable)
         {
-            info("StringTable/AttrTable Unavaliable");
+            lg2::info("StringTable/AttrTable Unavaliable");
             return;
         }
 
@@ -818,7 +817,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                                              *stringTable);
         if (attrEntry == nullptr)
         {
-            info("Could not find attribute :{KEY0}", "KEY0", attrName);
+            lg2::info("Could not find attribute :{KEY0}", "KEY0", attrName);
             return;
         }
 
@@ -849,7 +848,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                     attrValue.c_str());
                 if (stringEntry == nullptr)
                 {
-                    info("Set Attribute Error: It's not a possible value");
+                    lg2::info("Set Attribute Error: It's not a possible value");
 
                     return;
                 }
@@ -864,7 +863,7 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
                 }
                 if (i == pvNum)
                 {
-                    info("Set Attribute Error: It's not a possible value");
+                    lg2::info("Set Attribute Error: It's not a possible value");
                     return;
                 }
 
@@ -935,14 +934,14 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
 
         if (rc != PLDM_SUCCESS)
         {
-            error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
+            lg2::error("PLDM: Request Message Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
         std::vector<uint8_t> responseMsg;
         rc = pldmSendRecv(requestMsg, responseMsg);
         if (rc != PLDM_SUCCESS)
         {
-            error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
+            lg2::error("PLDM: Communication Error, rc ={KEY0}", "KEY0", rc);
             return;
         }
         uint8_t cc = 0;
@@ -955,8 +954,8 @@ class SetBIOSAttributeCurrentValue : public GetBIOSTableHandler
             responsePtr, payloadLength, &cc, &nextTransferHandle);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 

--- a/pldmtool/pldm_cmd_helper.cpp
+++ b/pldmtool/pldm_cmd_helper.cpp
@@ -11,8 +11,6 @@
 
 #include <exception>
 
-PHOSPHOR_LOG2_USING;
-
 using namespace pldm::utils;
 
 namespace pldmtool
@@ -34,7 +32,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == sockFd)
     {
         returnCode = -errno;
-        error("Failed to create the socket : RC = {KEY0}", "KEY0", sockFd);
+        lg2::error("Failed to create the socket : RC = {KEY0}", "KEY0", sockFd);
         return returnCode;
     }
     Logger(pldmVerbose, "Success in creating the socket : RC = ", sockFd);
@@ -51,7 +49,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        error("Failed to connect to socket : RC = {KEY0}", "KEY0", returnCode);
+        lg2::error("Failed to connect to socket : RC = {KEY0}", "KEY0",
+                   returnCode);
 
         return returnCode;
     }
@@ -62,8 +61,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        error("Failed to send message type as pldm to mctp : RC = {KEY0}",
-              "KEY0", returnCode);
+        lg2::error("Failed to send message type as pldm to mctp : RC = {KEY0}",
+                   "KEY0", returnCode);
         return returnCode;
     }
     Logger(
@@ -74,7 +73,7 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == result)
     {
         returnCode = -errno;
-        error("Write to socket failure : RC = {KEY0}", "KEY0", returnCode);
+        lg2::error("Write to socket failure : RC = {KEY0}", "KEY0", returnCode);
         return returnCode;
     }
     Logger(pldmVerbose, "Write to socket successful : RC = ", result);
@@ -83,14 +82,16 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     ssize_t peekedLength = recv(socketFd(), nullptr, 0, MSG_TRUNC | MSG_PEEK);
     if (0 == peekedLength)
     {
-        error("Socket is closed : peekedLength = {KEY0}", "KEY0", peekedLength);
+        lg2::error("Socket is closed : peekedLength = {KEY0}", "KEY0",
+                   peekedLength);
 
         return returnCode;
     }
     else if (peekedLength <= -1)
     {
         returnCode = -errno;
-        error("recv() system call failed : RC = {KEY0}", "KEY0", returnCode);
+        lg2::error("recv() system call failed : RC = {KEY0}", "KEY0",
+                   returnCode);
         return returnCode;
     }
     else
@@ -115,8 +116,9 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
             }
             else if (recvDataLength != peekedLength)
             {
-                error("Failure to read response length packet: length = {KEY0}",
-                      "KEY0", recvDataLength);
+                lg2::error(
+                    "Failure to read response length packet: length = {KEY0}",
+                    "KEY0", recvDataLength);
                 return returnCode;
             }
         } while (1);
@@ -126,7 +128,8 @@ int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
     if (-1 == returnCode)
     {
         returnCode = -errno;
-        error("Failed to shutdown the socket : RC ={KEY0}", "KEY0", returnCode);
+        lg2::error("Failed to shutdown the socket : RC ={KEY0}", "KEY0",
+                   returnCode);
         return returnCode;
     }
 
@@ -151,7 +154,7 @@ void CommandInterface::exec()
     }
     catch (const std::exception& e)
     {
-        error(
+        lg2::error(
             "GetInstanceId D-Bus call failed, MCTP id = {KEY0}, error = {KEY1}",
             "KEY0", (unsigned)mctp_eid, "KEY1", e.what());
         return;
@@ -159,7 +162,7 @@ void CommandInterface::exec()
     auto [rc, requestMsg] = createRequestMsg();
     if (rc != PLDM_SUCCESS)
     {
-        error(
+        lg2::error(
             "Failed to encode request message for {KEY0} : {KEY1}, rc = {KEY1}",
             "KEY0", pldmType, "KEY1", commandName, "KEY1", rc);
         return;
@@ -170,7 +173,7 @@ void CommandInterface::exec()
 
     if (rc != PLDM_SUCCESS)
     {
-        error("pldmSendRecv: Failed to receive RC = {KEY0}", "KEY0", rc);
+        lg2::error("pldmSendRecv: Failed to receive RC = {KEY0}", "KEY0", rc);
         return;
     }
 
@@ -205,7 +208,7 @@ int CommandInterface::pldmSendRecv(std::vector<uint8_t>& requestMsg,
         int fd = pldm_open();
         if (-1 == fd)
         {
-            error("failed to init mctp ");
+            lg2::error("failed to init mctp ");
 
             return -1;
         }

--- a/pldmtool/pldm_fru_cmd.cpp
+++ b/pldmtool/pldm_fru_cmd.cpp
@@ -13,8 +13,6 @@
 #include <functional>
 #include <tuple>
 
-PHOSPHOR_LOG2_USING;
-
 namespace pldmtool
 {
 
@@ -67,8 +65,8 @@ class GetFruRecordTableMetadata : public CommandInterface
             &total_record_set_identifiers, &total_table_records, &checksum);
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
 
             return;
         }
@@ -387,8 +385,8 @@ class GetFRURecordByOption : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
             return;
         }
 
@@ -439,8 +437,8 @@ class GetFruRecordTable : public CommandInterface
 
         if (rc != PLDM_SUCCESS || cc != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)cc);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)cc);
 
             return;
         }

--- a/pldmtool/pldm_fw_update_cmd.cpp
+++ b/pldmtool/pldm_fw_update_cmd.cpp
@@ -7,8 +7,6 @@
 
 #include <phosphor-logging/lg2.hpp>
 
-PHOSPHOR_LOG2_USING;
-
 namespace pldmtool
 {
 
@@ -96,8 +94,8 @@ class GetStatus : public CommandInterface
             &reasonCode, &updateOptionFlagsEnabled);
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)completionCode);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
             return;
         }
 
@@ -181,8 +179,8 @@ class GetFwParams : public CommandInterface
             &pendingCompImageSetVersion, &compParameterTable);
         if (rc != PLDM_SUCCESS || fwParams.completion_code != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)fwParams.completion_code);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)fwParams.completion_code);
 
             return;
         }
@@ -271,7 +269,7 @@ class GetFwParams : public CommandInterface
                 &pendingCompVerStr);
             if (rc)
             {
-                error(
+                lg2::error(
                     "Decoding component parameter table entry failed, RC={KEY0}",
                     "KEY0", rc);
                 return;

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -13,8 +13,6 @@
 #include "oem/ibm/oem_ibm_state_set.hpp"
 #endif
 
-PHOSPHOR_LOG2_USING;
-
 using namespace pldm::utils;
 
 namespace pldmtool
@@ -123,7 +121,7 @@ class GetPDR : public CommandInterface
                                                   prevRecordHandle);
                 if (!result.second)
                 {
-                    error(
+                    lg2::error(
                         "Record handle {KEY0} has multiple references: {KEY1}, {KEY2}",
                         "KEY0", recordHandle, "KEY1", result.first->second,
                         "KEY2", prevRecordHandle);
@@ -176,8 +174,8 @@ class GetPDR : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)completionCode);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
             return;
         }
 
@@ -734,7 +732,7 @@ class GetPDR : public CommandInterface
             reinterpret_cast<pldm_pdr_fru_record_set*>(data);
         if (!pdr)
         {
-            error("Failed to get the FRU record set PDR");
+            lg2::error("Failed to get the FRU record set PDR");
             return;
         }
 
@@ -762,7 +760,7 @@ class GetPDR : public CommandInterface
             reinterpret_cast<pldm_pdr_entity_association*>(data);
         if (!pdr)
         {
-            error("Failed to get the PDR eneity association");
+            lg2::error("Failed to get the PDR eneity association");
             return;
         }
 
@@ -774,7 +772,7 @@ class GetPDR : public CommandInterface
         }
         else
         {
-            info("Get associationType failed.");
+            lg2::info("Get associationType failed.");
         }
         output["containerEntityType"] =
             getEntityName(pdr->container.entity_type);
@@ -807,7 +805,7 @@ class GetPDR : public CommandInterface
             (struct pldm_numeric_effecter_value_pdr*)data;
         if (!pdr)
         {
-            error("Failed to get numeric effecter PDR");
+            lg2::error("Failed to get numeric effecter PDR");
             return;
         }
 
@@ -1002,7 +1000,7 @@ class GetPDR : public CommandInterface
     {
         if (data == NULL)
         {
-            error("Failed to get PDR message");
+            lg2::error("Failed to get PDR message");
             return;
         }
 
@@ -1022,8 +1020,8 @@ class GetPDR : public CommandInterface
             // is not supported
             if (!strToPdrType.contains(pdrRecType))
             {
-                error("PDR type {KEY0} is not supported or invalid", "KEY0",
-                      pdrRecType);
+                lg2::error("PDR type {KEY0} is not supported or invalid",
+                           "KEY0", pdrRecType);
 
                 // PDR type not supported, setting next record handle to 0
                 // to avoid looping through all PDR records
@@ -1116,16 +1114,18 @@ class SetStateEffecter : public CommandInterface
         if (effecterCount > maxEffecterCount ||
             effecterCount < minEffecterCount)
         {
-            error("Request Message Error: effecterCount size {KEY0} is invalid",
-                  "KEY0", effecterCount);
+            lg2::error(
+                "Request Message Error: effecterCount size {KEY0} is invalid",
+                "KEY0", effecterCount);
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
 
         if (effecterData.size() > maxEffecterDataSize)
         {
-            error("Request Message Error: effecterData size {KEY0} is invalid",
-                  "KEY0", effecterData.size());
+            lg2::error(
+                "Request Message Error: effecterData size {KEY0} is invalid",
+                "KEY0", effecterData.size());
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
@@ -1133,8 +1133,9 @@ class SetStateEffecter : public CommandInterface
         auto stateField = parseEffecterData(effecterData, effecterCount);
         if (!stateField)
         {
-            error("Failed to parse effecter data, effecterCount size {KEY0}",
-                  "KEY0", effecterCount);
+            lg2::error(
+                "Failed to parse effecter data, effecterCount size {KEY0}",
+                "KEY0", effecterCount);
             auto rc = PLDM_ERROR_INVALID_DATA;
             return {rc, requestMsg};
         }
@@ -1152,8 +1153,8 @@ class SetStateEffecter : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)completionCode);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
 
             return;
         }
@@ -1234,8 +1235,8 @@ class SetNumericEffecterValue : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)completionCode);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
 
             return;
         }
@@ -1301,8 +1302,8 @@ class GetStateSensorReadings : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0", rc,
-                  "KEY1", (int)completionCode);
+            lg2::error("Response Message Error: rc = {KEY0}, cc={KEY1}", "KEY0",
+                       rc, "KEY1", (int)completionCode);
 
             return;
         }
@@ -1396,8 +1397,8 @@ class GetNumericEffecterValue : public CommandInterface
 
         if (rc != PLDM_SUCCESS || completionCode != PLDM_SUCCESS)
         {
-            error("Response Message Error: rc={RC} cc={CC}", "RC", rc, "CC",
-                  static_cast<int>(completionCode));
+            lg2::error("Response Message Error: rc={RC} cc={CC}", "RC", rc,
+                       "CC", static_cast<int>(completionCode));
             return;
         }
 
@@ -1458,8 +1459,8 @@ class GetNumericEffecterValue : public CommandInterface
             }
             default:
             {
-                error("Unknown Effecter data Size :{SIZE}", "SIZE",
-                      effecterDataSize);
+                lg2::error("Unknown Effecter data Size :{SIZE}", "SIZE",
+                           effecterDataSize);
                 break;
             }
         }
@@ -1490,7 +1491,7 @@ class GetNumericEffecterValue : public CommandInterface
         {
             return numericEffecterOpState.at(state);
         }
-        catch (const std::out_of_range& e)
+        catch (const std::out_of_range&)
         {
             return typeString;
         }


### PR DESCRIPTION
- pldmtool is console based tool and while printing messages on console using lg2 format then it's adding extra unwanted things like line no, braces etc.

- lg2 is systemd journal specific logging mechanism so we don't require lg2 in pldmtool directory so reverting changes only for pldmtool directory.