### PR TITLE
oem-ibm: Multipath Splitter support

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -156,7 +156,7 @@ void CustomDBus::setSlotProperties(const std::string& path,
         pcieSlot.at(path)->linkStatus(linkStatus);
     }
 }
-void CustomDBus::setlinkreset(
+void CustomDBus::setLinkReset(
     const std::string& path, bool value,
     pldm::host_effecters::HostEffecterParser* hostEffecterParser,
     uint8_t mctpEid)

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -312,7 +312,7 @@ class CustomDBus
     void setSlotType(const std::string& path, const std::string& slotType);
 
     /** set reset link value*/
-    void setlinkreset(
+    void setLinkReset(
         const std::string& path, bool value,
         pldm::host_effecters::HostEffecterParser* hostEffecterParser,
         uint8_t instanceId);

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1827,7 +1827,7 @@ void HostPDRHandler::createDbusObjects()
             case PLDM_ENTITY_SLOT:
                 CustomDBus::getCustomDBus().implementPCIeSlotInterface(
                     entity.first);
-                CustomDBus::getCustomDBus().setlinkreset(
+                CustomDBus::getCustomDBus().setLinkReset(
                     entity.first, false, hostEffecterParser, mctp_eid);
                 break;
             case PLDM_ENTITY_CONNECTOR:
@@ -1856,6 +1856,8 @@ void HostPDRHandler::createDbusObjects()
                 CustomDBus::getCustomDBus().setSlotType(
                     entity.first,
                     "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OEM");
+                CustomDBus::getCustomDBus().setLinkReset(
+                    entity.first, false, hostEffecterParser, mctp_eid);
                 break;
             default:
                 break;
@@ -1961,9 +1963,9 @@ void HostPDRHandler::setRecordPresent(uint32_t recordHandle)
         {
             error(
                 "Removing Host FRU [ {PATH} ] with entityid [ {ENTITY_TYP}, {ENTITY_NUM}, {ENTITY_ID} ]",
-                "ENTITY_TYP", (unsigned)recordEntity.entity_type, "ENTITY_NUM",
-                (unsigned)recordEntity.entity_instance_num, "ENTITY_ID",
-                (unsigned)recordEntity.entity_container_id);
+                "PATH", path, "ENTITY_TYP", (unsigned)recordEntity.entity_type,
+                "ENTITY_NUM", (unsigned)recordEntity.entity_instance_num,
+                "ENTITY_ID", (unsigned)recordEntity.entity_container_id);
             // if the record has the same entity id, mark that dbus object as
             // not present
             CustomDBus::getCustomDBus().updateItemPresentStatus(path, false);

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -206,10 +206,11 @@ void PCIeInfoHandler::getMexObjects()
     // get the in memory cached copy of mex objects
     auto savedObjs = pldm::serialize::Serialize::getSerialize().getSavedObjs();
 
-    // Find the PCIE slots & PCIeAdapters & Connecters & their location codes
-    std::set<uint16_t> neededEntityTypes = {PLDM_ENTITY_SLOT, PLDM_ENTITY_CARD,
-                                            PLDM_ENTITY_CONNECTOR,
-                                            PLDM_ENTITY_SYSTEM_CHASSIS};
+    // Find the PCIE slots & PCIE logical slots & PCIeAdapters & Connecters &
+    // their location codes
+    std::set<uint16_t> neededEntityTypes = {
+        PLDM_ENTITY_SLOT, PLDM_ENTITY_CARD, PLDM_ENTITY_CONNECTOR,
+        PLDM_ENTITY_SYSTEM_CHASSIS, (0x8000 | PLDM_ENTITY_SLOT)};
     std::set<std::string> neededProperties = {"locationCode"};
 
     for (const auto& [entityType, objects] : savedObjs)
@@ -257,7 +258,9 @@ std::string PCIeInfoHandler::getMexObjectFromLocationCode(
 {
     for (const auto& [objectPath, obj] : mexObjectMap)
     {
-        if (std::get<0>(obj) == entityType &&
+        // Added the check for logical entity type
+        if (((std::get<0>(obj) == entityType) ||
+             (std::get<0>(obj) == (0x8000 | entityType))) &&
             (std::get<1>(obj) == "locationCode"))
         {
             if ((std::get<2>(obj)).has_value() &&


### PR DESCRIPTION
Added below changes to support multipath splitter

1. Add LinkReset to Logical slots
2. Fetch Logical slot entities from saved object paths.
3. Updated code to fetch the location code of logical slots too.

Tested:
1. Inventory LEDs page on GUI.
2. Identifying LEDs on Inventory Page works well.
3. Topology Page (Populates links properly)
4. Link Reset on few links
5. Verified Dbus details like Location code of Logical slots and Dbus Modelling of Topology data.