### PR TITLE
pldm: Fix for multipath splitter Dbus modelling of logical slots

### DIFF
--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -175,8 +175,21 @@ void updateEntityAssociation(
         fs::path path{"/xyz/openbmc_project/inventory"};
         std::deque<std::string> paths{};
         pldm_entity node_entity = pldm_entity_extract(entity);
-        auto node = pldm_entity_association_tree_find(entityTree, &node_entity,
-                                                      false);
+        uint16_t remoteContainerId =
+            pldm_entity_node_get_remote_container_id(entity);
+        /* If the logical bit is set in the host containerId, cosider this as
+         * host entity and find in host node by setting the is_remote to true)
+         */
+        info(
+            "Update Entity Association , type = {ENTITY_TYP}, num = {ENTITY_NUM}, container = {CONT}, Remote Container ID = {RID}, is remote = {REMOTE}",
+            "ENTITY_TYP", static_cast<int>(node_entity.entity_type),
+            "ENTITY_NUM", static_cast<int>(node_entity.entity_instance_num),
+            "CONT", static_cast<int>(node_entity.entity_container_id), "RID",
+            remoteContainerId, "REMOTE", (bool)(remoteContainerId & 0x8000));
+
+        auto node = pldm_entity_association_tree_find(
+            entityTree, &node_entity, (remoteContainerId & 0x8000));
+
         if (!node)
         {
             continue;


### PR DESCRIPTION
Find the Entity node in the entity association tree using is_remote as true

Host sends Splitter/mex PDRs during the PDR exchange. In case of splitter number of PDRs is more so there will be multiple respository changed events from Host. Splitter has 24 slots attached to it and CEC chassis has 12 slots. One of the repository change event is received for Slots to logical slots association in splitter.
While updating this association to the entity association tree, we search the node using the entity type and instance id, one of the CEC slot matches the requests and returns the CEC slot for the request of splitter slot node. and we end up creating logical slots under CEC motherboard.
To solve the issue we are using entity type, instance number and container id for entities for which has logical remote container id(host entity).

Tested:
     1. Multiple Poweroff/Poweron on the system with mex/splitter attached.
     2. Reset Reload
     3. Jenkin's multiple ipl test