### PR TITLE
pldm: Creating /var/lib/pldm before updating system type

### DIFF
--- a/host-bmc/dbus/serialize.cpp
+++ b/host-bmc/dbus/serialize.cpp
@@ -93,6 +93,12 @@ void Serialize::serialize(const std::string& path, const std::string& intf,
 void Serialize::serializeKeyVal(const std::string& key,
                                 dbus::PropertyValue value)
 {
+    auto dir = filePath.parent_path();
+    if (!fs::exists(dir))
+    {
+        fs::create_directories(dir);
+    }
+
     std::ofstream os(filePath.c_str(), std::ios::binary);
     cereal::BinaryOutputArchive oarchive(os);
     savedKeyVal[key] = value;


### PR DESCRIPTION
System type is written to persist file during start up. Creating pldm folder under /var/lib before updating the system type to persist file.

PLDM was coredumping on manufacturing system as pldm folder did not exist in /var/lib while writting the system type to persist file.

Fixes: 597047

Tested:
Below steps:
    1. Remove /var/lib/pldm
    2. Restart pldmd
    3. BMC reached ready state.