### PR TITLE
1020: pldm: Remove led Dbus obj when FRU is removed from pdr repo (#514)

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1893,6 +1893,9 @@ void HostPDRHandler::setRecordPresent(uint32_t recordHandle)
             CustomDBus::getCustomDBus().updateItemPresentStatus(path, false);
             CustomDBus::getCustomDBus().setOperationalStatus(
                 path, false, getParentChassis(path));
+            // Delete the LED object path
+            auto ledGroupPath = updateLedGroupPath(path);
+            pldm::dbus::CustomDBus::getCustomDBus().deleteObject(ledGroupPath);
             return;
         }
     }


### PR DESCRIPTION
#### pldm: Remove led Dbus obj when FRU is removed from pdr repo (#514)
```
Correct Dbus modelling of Led object when FRU is removed from
pdr repository.

Currently, if PHYP deletes a FRU or sensors and effectors
association with the FRU (from the PDR repository),
in response to that BMC marks the state of the FRU to Absent.
But leave the LocationIndicatorActive as how it was already
there before removal (it can be either true/false/null
based on how it was set previously ).

To modell hardware behaviour accurately when FRU or
the Sensors/Effecters associated with FRU are removed
from PDR repository, LED object are removed from PLDm Dbus tree.

Tested:
    - Inject Nimitz FAN error
      FAN becomes inaccessible and sensors/effecters are removed.
      Dbus query does not show any LED object path associated with it

Signed-off-by: Archana Kakani <archana.kakani@ibm.com>```