### PR TITLE
pldm: Support password prompt for graphical SMS menu

### DIFF
--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -81,6 +81,7 @@ if get_option('oem-ibm').enabled()
     '../oem/ibm/host-bmc/host_lamp_test.cpp',
     '../oem/ibm/libpldmresponder/bios_oem_ibm.cpp',
     '../oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp',
+    '../oem/ibm/libpldmresponder/file_io_type_smsmenu.cpp',
   ]
   libpam = cpp.find_library('pam', required: true)
   libpldmresponder_deps += [libpam]

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -12,6 +12,7 @@
 #include "file_io_type_pcie.hpp"
 #include "file_io_type_pel.hpp"
 #include "file_io_type_progress_src.hpp"
+#include "file_io_type_smsmenu.hpp"
 #include "file_io_type_vpd.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -128,8 +129,10 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
     return transferFileData(fd(), upstream, offset, length, address);
 }
 
-std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
-                                              uint32_t fileHandle)
+std::unique_ptr<FileHandler> getHandlerByType(
+    uint16_t fileType, uint32_t fileHandle,
+    dbus_api::Requester* dbusImplReqester,
+    pldm::requester::Handler<pldm::requester::Request>* handler)
 {
     switch (fileType)
     {
@@ -192,6 +195,12 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
         case PLDM_FILE_TYPE_CHAP_DATA:
         {
             return std::make_unique<ChapHandler>(fileHandle, fileType);
+        }
+        case PLDM_FILE_TYPE_USER_PASSWORD_AUTHENTICATION:
+        case PLDM_FILE_TYPE_USER_PASSWORD_CHANGE:
+        {
+            return std::make_unique<SmsMenuHandler>(fileHandle, fileType,
+                                                    dbusImplReqester, handler);
         }
         default:
         {

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -63,10 +63,22 @@ class FileHandler
      *  @param[in/out] length - length to be written
      *  @param[in] oemPlatformHandler - oem handler for PLDM platform related
      *                                  tasks
+     *  @param[out] metaDataObj - file ack meta data status and values
      *  @return PLDM status code
      */
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* oemPlatformHandler) = 0;
+                      oem_platform::Handler* oemPlatformHandler,
+                      struct fileack_status_metadata& metaDataObj) = 0;
+
+    /** @brief Execute the post actions after sending back the write command
+     *  response to the host
+     *  @param[in] fileType - type of the file
+     *  @param[in] fileHandle - file handle
+     *  @param[in] metaDataObj - file ack meta data status and values
+     */
+    virtual void
+        postWriteAction(const uint16_t fileType, const uint32_t fileHandle,
+                        const struct fileack_status_metadata& metaDataObj) = 0;
 
     virtual int fileAck(uint8_t fileStatus) = 0;
 
@@ -161,9 +173,13 @@ class FileHandler
  *
  *  @param[in] fileType - type of file
  *  @param[in] fileHandle - file handle
+ *  @param[in] dbusImplReqester - pldm dbus api requester
+ *  @param[in] handler - pldm request handler
  */
 
-std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
-                                              uint32_t fileHandle);
+std::unique_ptr<FileHandler> getHandlerByType(
+    uint16_t fileType, uint32_t fileHandle,
+    dbus_api::Requester* dbusImplReqester,
+    pldm::requester::Handler<pldm::requester::Request>* handler);
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_cert.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.cpp
@@ -94,7 +94,8 @@ int CertHandler::read(uint32_t offset, uint32_t& length, Response& response,
 }
 
 int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
-                       oem_platform::Handler* /*oemPlatformHandler*/)
+                       oem_platform::Handler* /*oemPlatformHandler*/,
+                       struct fileack_status_metadata& /*metaDataObj*/)
 {
     auto it = certMap.find(certType);
     if (it == certMap.end())

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -39,7 +39,8 @@ class CertHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int fileAck(uint8_t /*fileStatus*/)
     {
@@ -59,6 +60,10 @@ class CertHandler : public FileHandler
                                              uint32_t /*metaDataValue2*/,
                                              uint32_t /*metaDataValue3*/,
                                              uint32_t /*metaDataValue4*/);
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
 
     /** @brief CertHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_chap.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_chap.hpp
@@ -40,7 +40,8 @@ class ChapHandler : public FileHandler
 
     virtual int write(const char* /*buffer*/, uint32_t /*offset*/,
                       uint32_t& /*length*/,
-                      oem_platform::Handler* /*oemPlatformHandler*/)
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/)
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
@@ -69,6 +70,10 @@ class ChapHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
 
     /** @brief ChapHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -329,7 +329,8 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
 }
 
 int DumpHandler::write(const char* buffer, uint32_t, uint32_t& length,
-                       oem_platform::Handler* /*oemPlatformHandler*/)
+                       oem_platform::Handler* /*oemPlatformHandler*/,
+                       struct fileack_status_metadata& /*metaDataObj*/)
 {
     info(
         "Enter DumpHandler::write length = {LEN} DumpHandler::fd ={FILE_DESCRIPTION}",

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -33,7 +33,8 @@ class DumpHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int newFileAvailable(uint64_t length);
 
@@ -50,6 +51,10 @@ class DumpHandler : public FileHandler
                                              uint32_t /*metaDataValue2*/,
                                              uint32_t /*metaDataValue3*/,
                                              uint32_t /*metaDataValue4*/);
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
 
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);

--- a/oem/ibm/libpldmresponder/file_io_type_lic.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.cpp
@@ -99,7 +99,8 @@ int LicenseHandler::writeFromMemory(
 
 int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,
                           uint32_t& length,
-                          oem_platform::Handler* /*oemPlatformHandler*/)
+                          oem_platform::Handler* /*oemPlatformHandler*/,
+                          struct fileack_status_metadata& /*metaDataObj*/)
 {
     int rc = PLDM_SUCCESS;
 

--- a/oem/ibm/libpldmresponder/file_io_type_lic.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.hpp
@@ -38,7 +38,8 @@ class LicenseHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int write(const char* buffer, uint32_t /*offset*/, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int fileAck(uint8_t /*fileStatus*/)
     {
@@ -60,6 +61,10 @@ class LicenseHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
 
     int updateBinFileAndLicObjs(const fs::path& newLicFilePath);
 

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -249,7 +249,8 @@ class LidHandler : public FileHandler
     }
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* oemPlatformHandler)
+                      oem_platform::Handler* oemPlatformHandler,
+                      struct fileack_status_metadata& /*metaDataObj*/)
     {
         int rc = PLDM_SUCCESS;
         bool codeUpdateInProgress = false;
@@ -388,6 +389,10 @@ class LidHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
 
     /** @brief LidHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -103,7 +103,8 @@ int PCIeInfoHandler::writeFromMemory(
 }
 
 int PCIeInfoHandler::write(const char* buffer, uint32_t, uint32_t& length,
-                           oem_platform::Handler* /*oemPlatformHandler*/)
+                           oem_platform::Handler* /*oemPlatformHandler*/,
+                           struct fileack_status_metadata& /*metaDataObj*/)
 {
     fs::path infoFile(fs::path(pciePath) / topologyFile);
     if (infoType == PLDM_FILE_TYPE_CABLE_INFO)

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -194,7 +194,8 @@ class PCIeInfoHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int newFileAvailable(uint64_t length);
 
@@ -211,6 +212,10 @@ class PCIeInfoHandler : public FileHandler
                                              uint32_t /*metaDataValue2*/,
                                              uint32_t /*metaDataValue3*/,
                                              uint32_t /*metaDataValue4*/);
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
 
     /** @brief method to parse the pcie topology information */
     virtual void parseTopologyData();

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -334,7 +334,8 @@ int PelHandler::storePel(std::string&& pelFileName)
 }
 
 int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/)
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/)
 {
     int rc = PLDM_SUCCESS;
 

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -32,7 +32,8 @@ class PelHandler : public FileHandler
 
     virtual int write(const char* /*buffer*/, uint32_t /*offset*/,
                       uint32_t& /*length*/,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int fileAck(uint8_t fileStatus);
 
@@ -65,6 +66,10 @@ class PelHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
 
     /** @brief PelHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
@@ -48,7 +48,8 @@ int ProgressCodeHandler::setRawBootProperty(
 
 int ProgressCodeHandler::write(const char* buffer, uint32_t /*offset*/,
                                uint32_t& length,
-                               oem_platform::Handler* /*oemPlatformHandler*/)
+                               oem_platform::Handler* /*oemPlatformHandler*/,
+                               struct fileack_status_metadata& /*metaDataObj*/)
 {
     static constexpr auto StartOffset = 40;
     static constexpr auto EndOffset = 48;

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -28,7 +28,8 @@ class ProgressCodeHandler : public FileHandler
     }
 
     int write(const char* buffer, uint32_t offset, uint32_t& length,
-              oem_platform::Handler* oemPlatformHandler) override;
+              oem_platform::Handler* /*oemPlatformHandler*/,
+              struct fileack_status_metadata& /*metaDataObj*/) override;
 
     int readIntoMemory(uint32_t /*offset*/, uint32_t& /*length*/,
                        uint64_t /*address*/,
@@ -70,6 +71,10 @@ class ProgressCodeHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
 
     /** @brief method to set the dbus Raw value Property with
      * the obtained progress code from the host.

--- a/oem/ibm/libpldmresponder/file_io_type_smsmenu.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_smsmenu.cpp
@@ -1,0 +1,180 @@
+#include "file_io_type_smsmenu.hpp"
+
+#include "libpldm/base.h"
+#include "libpldm/file_io.h"
+
+#include "pfw-sms-utils/pfw_sms_menu.hpp"
+
+#include <stdint.h>
+
+#include <iostream>
+
+namespace pldm
+{
+using namespace pldm::responder::utils;
+using namespace ibm_pfw_sms;
+
+namespace responder
+{
+
+uint32_t SmsMenuHandler::readVecContent(std::vector<char>& inputVec,
+                                        const uint32_t startIdx,
+                                        const uint32_t endIdx)
+{
+    uint32_t size = 0;
+    constexpr auto bitPos = 8;
+    std::vector<char> userPassLenArr(inputVec.begin() + startIdx,
+                                     inputVec.begin() + endIdx);
+    for (uint32_t idx = 0; idx < bitPos; idx++)
+    {
+        size |= (uint32_t)userPassLenArr[idx] << bitPos * idx;
+    }
+    return size;
+}
+
+void SmsMenuHandler::postWriteAction(
+    const uint16_t fileType, const uint32_t fileHandle,
+    const struct fileack_status_metadata& metaDataObj)
+{
+    sdbusplus::message::object_path path;
+    auto hostEid = pldm::utils::readHostEID();
+    auto hostSockFd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    dbusToFileHandlers
+        .emplace_back(
+            std::make_unique<pldm::requester::oem_ibm::DbusToFileHandler>(
+                hostSockFd, hostEid, dbusImplReqester, path, handler))
+        ->sendFileAckWithMetaDataToHost(
+            fileType, fileHandle, metaDataObj.fileStatus,
+            metaDataObj.fileMetaData1, metaDataObj.fileMetaData2,
+            metaDataObj.fileMetaData3, metaDataObj.fileMetaData4);
+}
+
+int SmsMenuHandler::write(const char* buffer, uint32_t /*offset*/,
+                          uint32_t& length,
+                          oem_platform::Handler* /*oemPlatformHandler*/,
+                          struct fileack_status_metadata& metaDataObj)
+{
+    if (!buffer)
+    {
+        error("SMS Menu buffer is empty");
+        return PLDM_ERROR;
+    }
+
+    std::vector<char> smsBuf(buffer, buffer + length);
+
+    uint32_t userNewPassLen = 0;
+    std::string newPassStr;
+
+    // Format of file type USER_PASSWORD_AUTHENTICATION
+    // <User Name Length><User Name><Password Length><Password>
+
+    // Format of file type USER_PASSWORD_CHANGE
+    // <User Name Length><User Name><Old Password Length><Old Password>
+    // <New Password Length><New Password>
+
+    // Read the size of User Name which is the content of first four bytes
+    auto userNameLen = readVecContent(smsBuf, 0, sizeof(uint32_t));
+
+    // Read the size of Password/Old Password which is the content of four bytes
+    // after User Name
+    auto userPassLen =
+        readVecContent(smsBuf, sizeof(uint32_t) + userNameLen,
+                       sizeof(uint32_t) + userNameLen + sizeof(uint32_t));
+    if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_CHANGE)
+    {
+        // Read the size of New Password which is the content of four bytes
+        // after Old Password
+        userNewPassLen = readVecContent(
+            smsBuf,
+            sizeof(uint32_t) + userNameLen + sizeof(uint32_t) + userPassLen,
+            sizeof(uint32_t) + userNameLen + sizeof(uint32_t) + userPassLen +
+                sizeof(uint32_t));
+    }
+
+    // Split the vector to retrieve the User Name
+    auto result = vecSplit(smsBuf, sizeof(uint32_t),
+                           sizeof(uint32_t) + userNameLen);
+    std::string unameStr(result.begin(), result.end());
+
+    // Split the vector to retrieve the Password/Old Password
+    result = vecSplit(smsBuf, sizeof(uint32_t) + userNameLen + sizeof(uint32_t),
+                      sizeof(uint32_t) + userNameLen + sizeof(uint32_t) +
+                          userPassLen);
+    std::string passStr(result.begin(), result.end());
+
+    if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_CHANGE)
+    {
+        // Split the vector to retrieve the New Password
+        result = vecSplit(smsBuf,
+                          sizeof(uint32_t) + userNameLen + sizeof(uint32_t) +
+                              userPassLen + sizeof(uint32_t),
+                          sizeof(uint32_t) + userNameLen + sizeof(uint32_t) +
+                              userPassLen + sizeof(uint32_t) + userNewPassLen);
+        std::string tempNewPassStr(result.begin(), result.end());
+        newPassStr = tempNewPassStr;
+    }
+
+    metaDataObj.fileStatus = 0x00;
+    metaDataObj.fileMetaData1 = 0xFFFFFFFF;
+    metaDataObj.fileMetaData2 = 0xFFFFFFFF;
+    metaDataObj.fileMetaData3 = 0xFFFFFFFF;
+    metaDataObj.fileMetaData4 = 0xFFFFFFFF;
+
+    bool authenticated = false;
+    bool passwordChangeRequired = false;
+    bool operationAllowed = false;
+    changePasswordReasonCode changePassRc{};
+
+    if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_AUTHENTICATION)
+    {
+        authenticate(unameStr, passStr, authenticated, passwordChangeRequired,
+                     operationAllowed);
+
+        metaDataObj.fileMetaData1 = (authenticated) ? PLDM_AUTHENTICATED
+                                                    : PLDM_NOT_AUTHENTICATED;
+
+        if (passwordChangeRequired)
+        {
+            metaDataObj.fileMetaData1 = PLDM_AUTHENTICATED_BUT_PASSWORD_EXPIRED;
+        }
+    }
+    else if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_CHANGE)
+    {
+        changePassRc = changePassword(unameStr, passStr, newPassStr,
+                                      operationAllowed);
+        if (changePassRc == PASSWORD_CHANGE_SUCCESSFUL)
+        {
+            metaDataObj.fileMetaData1 = PLDM_PASSWORD_CHANGED;
+        }
+        else if (changePassRc == NOT_AUTHENTICATED)
+        {
+            metaDataObj.fileMetaData1 = PLDM_PASSWORD_NOT_CHANGED;
+        }
+        else
+        {
+            metaDataObj.fileMetaData1 = PLDM_PASSWORD_INVALID;
+        }
+
+        metaDataObj.fileMetaData3 = (int)changePassRc;
+    }
+    else
+    {
+        error("SMS Menu type is wrong");
+        return PLDM_ERROR;
+    }
+
+    if (operationAllowed)
+    {
+        metaDataObj.fileMetaData2 = PLDM_ADMIN_OP_ALLOWED;
+    }
+
+    info("SMS PAM authenticated:{USR_AUTH} passwordChangeRequired:{USR_PASS_CR}"
+         " operationAllowed:{OPA}",
+         "USR_AUTH", authenticated, "USR_PASS_CR", passwordChangeRequired,
+         "OPA", operationAllowed);
+
+    return PLDM_SUCCESS;
+}
+
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_smsmenu.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_smsmenu.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "file_io_by_type.hpp"
+
+namespace pldm
+{
+namespace responder
+{
+
+/** @class SmsMenuHandler
+ *
+ *  @brief Inherits and implements FileHandler. This class is used
+ *  to support password prompt for the graphical SMS(System Management Services)
+ *  menus provided by PFW(Platform Firmware).Supported operations are
+ *  user password authentication and user password change.
+ */
+class SmsMenuHandler : public FileHandler
+{
+  public:
+    /** @brief Handler constructor
+     */
+    SmsMenuHandler(
+        uint32_t fileHandle, uint16_t fileType,
+        dbus_api::Requester* dbusImplReqester,
+        pldm::requester::Handler<pldm::requester::Request>* handler) :
+        FileHandler(fileHandle),
+        smsMenuType(fileType), dbusImplReqester(dbusImplReqester),
+        handler(handler)
+    {}
+
+    virtual int writeFromMemory(uint32_t /*offset*/, uint32_t /*length*/,
+                                uint64_t /*address*/,
+                                oem_platform::Handler* /*oemPlatformHandler*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t& /*length*/,
+                               uint64_t /*address*/,
+                               oem_platform::Handler* /*oemPlatformHandler*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int read(uint32_t /*offset*/, uint32_t& /*length*/,
+                     Response& /*response*/,
+                     oem_platform::Handler* /*oemPlatformHandler*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int write(const char* buffer, uint32_t /*offset*/, uint32_t& length,
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& metaDataObj);
+
+    virtual int fileAck(uint8_t /*fileStatus*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int newFileAvailable(uint64_t /*length*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual void
+        postWriteAction(const uint16_t fileType, const uint32_t fileHandle,
+                        const struct fileack_status_metadata& metaDataObj);
+
+    /** @brief Reads the contents of the input vector and returns the value back
+     *  @param[in] inputVec - input vector
+     *  @param[in] startIdx - start index
+     *  @param[in] endIdx - end index
+     *  @return  the value contained in the input vector
+     */
+    uint32_t readVecContent(std::vector<char>& inputVec,
+                            const uint32_t startIdx, const uint32_t endIdx);
+
+    /** @brief SmsMenuHandler destructor
+     */
+    ~SmsMenuHandler() {}
+
+  private:
+    uint16_t smsMenuType; //!< type of the SMS menu selection
+
+    // pldm::requester::Handler<pldm::requester::Request>* handler;
+    std::vector<std::unique_ptr<pldm::requester::oem_ibm::DbusToFileHandler>>
+        dbusToFileHandlers;
+    /** @brief pldm dbus api requester */
+    dbus_api::Requester* dbusImplReqester;
+    /** @brief PLDM request handler */
+    pldm::requester::Handler<pldm::requester::Request>* handler;
+};
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
@@ -36,7 +36,8 @@ class keywordHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
     virtual int write(const char* /*buffer*/, uint32_t /*offset*/,
                       uint32_t& /*length*/,
-                      oem_platform::Handler* /*oemPlatformHandler*/)
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/)
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
@@ -64,6 +65,9 @@ class keywordHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/){};
     /** @brief keywordHandler destructor
      */
     ~keywordHandler() {}

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -604,6 +604,20 @@ void findSlotObjects(const std::string& boardObjPath,
     }
 }
 
+std::vector<char> vecSplit(const std::vector<char>& inputVec,
+                           const uint32_t startIdx, const uint32_t endIdx)
+{
+    // Start and end iterators
+    auto startItr = inputVec.begin() + startIdx;
+    auto endItr = inputVec.begin() + endIdx;
+
+    // Resultant split vector
+    std::vector<char> resultVec(endIdx - startIdx + 1);
+
+    copy(startItr, endItr, resultVec.begin());
+    return resultVec;
+}
+
 } // namespace utils
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -12,6 +12,18 @@
 
 namespace pldm
 {
+
+/** @brief Holds the file ack with meta data status and values
+ */
+struct fileack_status_metadata
+{
+    uint8_t fileStatus;
+    uint32_t fileMetaData1;
+    uint32_t fileMetaData2;
+    uint32_t fileMetaData3;
+    uint32_t fileMetaData4;
+};
+
 namespace responder
 {
 
@@ -171,6 +183,15 @@ uint32_t getLinkResetInstanceNumber(std::string& path);
 void findSlotObjects(const std::string& boardObjPath,
                      std::vector<std::string>& slotObjects);
 
+/** @brief Split the vector according to the start and end index and return
+ *  back the resultant vector
+ *  @param[in] inputVec - input vector
+ *  @param[in] startIdx - start index
+ *  @param[in] endIdx - end index
+ *  @return  the resultant split vector
+ */
+std::vector<char> vecSplit(const std::vector<char>& inputVec,
+                           const uint32_t startIdx, const uint32_t endIdx);
 } // namespace utils
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/requester/dbus_to_file_handler.hpp
+++ b/oem/ibm/requester/dbus_to_file_handler.hpp
@@ -69,6 +69,23 @@ class DbusToFileHandler
      */
     void newLicFileAvailable(const std::string& licenseStr);
 
+    /** @brief Send the file ack with metadata command request to host
+     *  @param[in] fileType - type of the file
+     *  @param[in] fileHandle - file handle
+     *  @param[in] fileStatus - file status
+     *  @param[in] fileMetaData1 - file meta data value 1
+     *  @param[in] fileMetaData2 - file meta data value 2
+     *  @param[in] fileMetaData3 - file meta data value 3
+     *  @param[in] fileMetaData4 - file meta data value 4
+     */
+    void sendFileAckWithMetaDataToHost(const uint16_t fileType,
+                                       const uint32_t fileHandle,
+                                       const uint8_t fileStatus,
+                                       const uint32_t fileMetaData1,
+                                       const uint32_t fileMetaData2,
+                                       const uint32_t fileMetaData3,
+                                       const uint32_t fileMetaData4);
+
   private:
     /** @brief Send the new file available command request to hypervisor
      *  @param[in] fileSize - size of the file

--- a/oem/ibm/test/libpldmresponder_fileio_test.cpp
+++ b/oem/ibm/test/libpldmresponder_fileio_test.cpp
@@ -7,6 +7,7 @@
 #include "libpldmresponder/file_io_type_dump.hpp"
 #include "libpldmresponder/file_io_type_lid.hpp"
 #include "libpldmresponder/file_io_type_pel.hpp"
+#include "libpldmresponder/file_io_type_smsmenu.hpp"
 #include "libpldmresponder/file_table.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -885,6 +886,15 @@ TEST(getHandlerByType, allPaths)
     handler = getHandlerByType(PLDM_FILE_TYPE_ROOT_CERT, fileHandle);
     certType = dynamic_cast<CertHandler*>(handler.get());
     ASSERT_TRUE(certType != nullptr);
+
+    handler = getHandlerByType(PLDM_FILE_TYPE_USER_PASSWORD_AUTHENTICATION,
+      ` fileHandle);
+    smsMenuType = dynamic_cast<SmsMenuHandler*>(handler.get());
+    ASSERT_TRUE(smsMenuType != nullptr);
+
+    handler = getHandlerByType(PLDM_FILE_TYPE_USER_PASSWORD_CHANGE, fileHandle);
+    smsMenuType = dynamic_cast<SmsMenuHandler*>(handler.get());
+    ASSERT_TRUE(smsMenuType != nullptr);
 
     using namespace sdbusplus::xyz::openbmc_project::Common::Error;
     ASSERT_THROW(getHandlerByType(0xFFFF, fileHandle), InternalFailure);

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -285,9 +285,10 @@ int main(int argc, char** argv)
                                                            pdrRepo.get());
     codeUpdate->setOemPlatformHandler(oemPlatformHandler.get());
     slotHandler->setOemPlatformHandler(oemPlatformHandler.get());
-    invoker.registerHandler(PLDM_OEM, std::make_unique<oem_ibm::Handler>(
-                                          oemPlatformHandler.get(), sockfd,
-                                          hostEID, &dbusImplReq, &reqHandler));
+    invoker.registerHandler(PLDM_OEM,
+                            std::make_unique<oem_ibm::Handler>(
+                                oemPlatformHandler.get(), sockfd, hostEID,
+                                &dbusImplReq, &reqHandler, event));
 
     // host lamp test
     std::unique_ptr<pldm::led::HostLampTest> hostLampTest =


### PR DESCRIPTION
This supports the following password prompts for PFW (Platform Firmware) provided graphical SMS (System Management Services (SMS) menu

In system configurations that include a graphics adapter assigned to a partition, PFW can display the SMS menus on the console allowing users to interact with PFW using a keybaord. This menu requires as they can be used to change partition configurations (e.g. Boot option, I/O device info etc.)

Supported password prompt functions:
1. The ability to prompt for a username/password and provide authentication
2. The ability to change a password when the current password is expired

Tested:
1. Providing correct username and password for authentication sendFileAckWithMetaDataToHost fmd1=0 fmd2=1 fmd3=4294967295 fmd4=4294967295 Tx: 80 3f 0f 18 00 01 00 01 00 00 00 00 00 00 01 00 00 00 ff ff ff ff ff ff ff ff
2. Wrong password authentication sendFileAckWithMetaDataToHost fmd1=2 fmd2=4294967295 fmd3=4294967295 fmd4=4294967295 Tx: 80 3f 0f 18 00 02 00 01 00 00 02 00 00 00 ff ff ff ff ff ff ff ff ff ff ff ff
3. New password with a palindrome sendFileAckWithMetaDataToHost fmd1=3 fmd2=1 fmd3=258 fmd4=4294967295 Tx: 80 3f 0f 19 00 03 00 01 00 00 03 00 00 00 01 00 00 00 02 01 00 00 ff ff ff ff
4. New password with dictionary word DbusToFileHandler::sendFileAckWithMetaDataToHost fmd1=3 fmd2=1 fmd3=264 fmd4=4294967295
5. New password with dictionary word sendFileAckWithMetaDataToHost fmd1=3 fmd2=1 fmd3=264 fmd4=4294967295 Tx: 80 3f 0f 19 00 03 00 01 00 00 03 00 00 00 01 00 00 00 08 01 00 00 ff ff ff ff

Some of the other scenarios tested are "New password contains the username", "New password is too short", "Wrong current password" etc

Change-Id: I26d8025bd0585ffc1b57bb80360a9c4df32632bf