### PR TITLE
Change LanesInUse type to size_t

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -190,7 +190,7 @@ void CustomDBus::implementPCIeDeviceInterface(const std::string& path)
     }
 }
 
-void CustomDBus::setPCIeDeviceProps(const std::string& path, int64_t lanesInuse,
+void CustomDBus::setPCIeDeviceProps(const std::string& path, size_t lanesInuse,
                                     const std::string& value)
 {
     Generations generationsInuse =

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -298,7 +298,7 @@ class CustomDBus
                            const std::string& linkState);
 
     /** @brief set pcie device properties */
-    void setPCIeDeviceProps(const std::string& path, int64_t lanesInuse,
+    void setPCIeDeviceProps(const std::string& path, size_t lanesInuse,
                             const std::string& value);
 
     /** @brief set cable attributes */

--- a/host-bmc/dbus/pcie_device.cpp
+++ b/host-bmc/dbus/pcie_device.cpp
@@ -17,13 +17,13 @@ auto PCIeDevice::generationInUse(Generations value) -> Generations
         PCIeDevice::generationInUse(value);
 }
 
-int64_t PCIeDevice::lanesInUse() const
+size_t PCIeDevice::lanesInUse() const
 {
     return sdbusplus::xyz::openbmc_project::Inventory::Item::server::
         PCIeDevice::lanesInUse();
 }
 
-int64_t PCIeDevice::lanesInUse(int64_t value)
+int64_t PCIeDevice::lanesInUse(size_t value)
 {
     return sdbusplus::xyz::openbmc_project::Inventory::Item::server::
         PCIeDevice::lanesInUse(value);

--- a/host-bmc/dbus/pcie_device.hpp
+++ b/host-bmc/dbus/pcie_device.hpp
@@ -36,10 +36,10 @@ class PCIeDevice : public ItemDevice
     }
 
     /** Get lanes in use */
-    int64_t lanesInUse() const override;
+    size_t lanesInUse() const override;
 
     /** Set lanes in use */
-    int64_t lanesInUse(int64_t value) override;
+    size_t lanesInUse(size_t value) override;
 
     /** Get Generation in use */
     Generations generationInUse() const override;

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -379,8 +379,13 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                         link_speed[linkSpeed], itemPCIeDevice, "string");
 
             // set link width
-            setProperty(slotAndAdapter.second, "LanesInUse", linkWidth,
-                        itemPCIeDevice, "int64_t");
+            auto& bus = pldm::utils::DBusHandler::getBus();
+            auto service = pldm::utils::DBusHandler().getService(slotAndAdapter.second.c_str(),
+                                      itemPCIeDevice);
+            auto method = bus.new_method_call(
+                service.c_str(), slotAndAdapter.second.c_str(), "org.freedesktop.DBus.Properties", "Set");
+            method.append(itemPCIeDevice, "LanesInUse",
+                      linkWidth);
             std::filesystem::path adapter(slotAndAdapter.second);
 
             error(
@@ -427,6 +432,12 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                 // set link width
                 setProperty(slotAndAdapter.second, "LanesInUse", linkWidth,
                             itemPCIeDevice, "int64_t");
+                auto& bus = pldm::utils::DBusHandler::getBus();
+                auto service = pldm::utils::DBusHandler().getService(slotAndAdapter.second.c_str(),
+                                          itemPCIeDevice);
+                auto method = bus.new_method_call(
+                    service.c_str(), slotAndAdapter.second.c_str(), "org.freedesktop.DBus.Properties", "Set");
+                method.append(itemPCIeDevice, "LanesInUse", linkWidth);
             }
 
             std::filesystem::path adapter(slotAndAdapter.second);

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -53,7 +53,7 @@ static std::map<uint8_t, std::string> link_speed{
     {0xFF, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Unknown"}};
 
 static std::map<uint8_t, int64_t> link_width{{0x01, 1}, {0x02, 2},  {0x04, 4},
-                                             {0x08, 8}, {0x10, 16}, {0xFF, -1},
+                                             {0x08, 8}, {0x10, 16}, {0xFF, UINT_MAX},
                                              {0x00, 0}};
 
 struct SlotLocCode_t


### PR DESCRIPTION
Change LanesInUse to type size_t from int64_t. This change is made as per changes made to upstream at -

[1] https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/53650