### PR TITLE
1050: Fixing Read lid size corruption issue (#525)

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -42,7 +42,7 @@ class FileHandler
      *                                  tasks
      *  @return PLDM status code
      */
-    virtual int readIntoMemory(uint32_t offset, uint32_t& length,
+    virtual int readIntoMemory(uint32_t offset, uint32_t length,
                                uint64_t address,
                                oem_platform::Handler* oemPlatformHandler) = 0;
 

--- a/oem/ibm/libpldmresponder/file_io_type_cert.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.cpp
@@ -53,7 +53,7 @@ int CertHandler::writeFromMemory(uint32_t offset, uint32_t length,
     return rc;
 }
 
-int CertHandler::readIntoMemory(uint32_t offset, uint32_t& length,
+int CertHandler::readIntoMemory(uint32_t offset, uint32_t length,
                                 uint64_t address,
                                 oem_platform::Handler* /*oemPlatformHandler*/)
 {

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -32,7 +32,7 @@ class CertHandler : public FileHandler
     virtual int writeFromMemory(uint32_t offset, uint32_t length,
                                 uint64_t address,
                                 oem_platform::Handler* /*oemPlatformHandler*/);
-    virtual int readIntoMemory(uint32_t offset, uint32_t& length,
+    virtual int readIntoMemory(uint32_t offset, uint32_t length,
                                uint64_t address,
                                oem_platform::Handler* /*oemPlatformHandler*/);
     virtual int read(uint32_t offset, uint32_t& length, Response& response,

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -501,7 +501,7 @@ int DumpHandler::fileAck(uint8_t fileStatus)
     return PLDM_ERROR;
 }
 
-int DumpHandler::readIntoMemory(uint32_t offset, uint32_t& length,
+int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
                                 uint64_t address,
                                 oem_platform::Handler* /*oemPlatformHandler*/)
 {

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -25,7 +25,7 @@ class DumpHandler : public FileHandler
                                 uint64_t address,
                                 oem_platform::Handler* /*oemPlatformHandler*/);
 
-    virtual int readIntoMemory(uint32_t offset, uint32_t& length,
+    virtual int readIntoMemory(uint32_t offset, uint32_t length,
                                uint64_t address,
                                oem_platform::Handler* /*oemPlatformHandler*/);
 

--- a/oem/ibm/libpldmresponder/file_io_type_lic.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.hpp
@@ -27,7 +27,7 @@ class LicenseHandler : public FileHandler
                                 uint64_t address,
                                 oem_platform::Handler* /*oemPlatformHandler*/);
 
-    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t& /*length*/,
+    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
                                uint64_t /*address*/,
                                oem_platform::Handler* /*oemPlatformHandler*/)
     {

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -239,7 +239,7 @@ class LidHandler : public FileHandler
         return rc;
     }
 
-    virtual int readIntoMemory(uint32_t offset, uint32_t& length,
+    virtual int readIntoMemory(uint32_t offset, uint32_t length,
                                uint64_t address,
                                oem_platform::Handler* oemPlatformHandler)
     {

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -1110,8 +1110,7 @@ int PCIeInfoHandler::newFileAvailable(uint64_t)
 }
 
 int PCIeInfoHandler::readIntoMemory(
-    uint32_t, uint32_t&, uint64_t,
-    oem_platform::Handler* /*oemPlatformHandler*/)
+    uint32_t, uint32_t, uint64_t, oem_platform::Handler* /*oemPlatformHandler*/)
 {
     return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
 }

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -186,7 +186,7 @@ class PCIeInfoHandler : public FileHandler
                                 uint64_t address,
                                 oem_platform::Handler* /*oemPlatformHandler*/);
 
-    virtual int readIntoMemory(uint32_t offset, uint32_t& length,
+    virtual int readIntoMemory(uint32_t offset, uint32_t length,
                                uint64_t address,
                                oem_platform::Handler* /*oemPlatformHandler*/);
 

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -93,7 +93,7 @@ Entry::Level getEntryLevelFromPEL(const std::string& pelFileName)
 }
 } // namespace detail
 
-int PelHandler::readIntoMemory(uint32_t offset, uint32_t& length,
+int PelHandler::readIntoMemory(uint32_t offset, uint32_t length,
                                uint64_t address,
                                oem_platform::Handler* /*oemPlatformHandler*/)
 {

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -23,7 +23,7 @@ class PelHandler : public FileHandler
                                 uint64_t address,
                                 oem_platform::Handler* /*oemPlatformHandler*/);
 
-    virtual int readIntoMemory(uint32_t offset, uint32_t& length,
+    virtual int readIntoMemory(uint32_t offset, uint32_t length,
                                uint64_t address,
                                oem_platform::Handler* /*oemPlatformHandler*/);
 

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -30,7 +30,7 @@ class ProgressCodeHandler : public FileHandler
     int write(const char* buffer, uint32_t offset, uint32_t& length,
               oem_platform::Handler* oemPlatformHandler) override;
 
-    int readIntoMemory(uint32_t /*offset*/, uint32_t& /*length*/,
+    int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
                        uint64_t /*address*/,
                        oem_platform::Handler* /*oemPlatformHandler*/) override
     {

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
@@ -26,7 +26,7 @@ class keywordHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
-    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t& /*length*/,
+    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
                                uint64_t /*address*/,
                                oem_platform::Handler* /*oemPlatformHandler*/)
     {


### PR DESCRIPTION
#### Fixing Read lid size corruption issue (#525)
```
When HOST read/write data to BMC using DMA then BMC checks the length
of the data to be read/write and divide into chunks if data length is
more than DMA max size.
This change will fix the issue in PLDM when it send data transfer
status to the HOST and sending left over length as response which is
wrong and now PLDM sends correct response with length.

Signed-off-by: Kamalkumar Patel <kamalkumar.patel@ibm.com>
```