### PR TITLE
host-bmc: Update set host effecter PEL severity

### DIFF
--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -290,7 +290,7 @@ int HostEffecterParser::sendSetStateEffecterStates(
                 "EFFECTER_ID", effecterId, "RC", rc);
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                pldm::PelSeverity::ERROR);
+                pldm::PelSeverity::INFORMATIONAL);
         }
         if (completionCode)
         {
@@ -300,7 +300,7 @@ int HostEffecterParser::sendSetStateEffecterStates(
                 static_cast<unsigned>(completionCode));
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                pldm::PelSeverity::ERROR);
+                pldm::PelSeverity::INFORMATIONAL);
         }
         else
         {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1156,7 +1156,7 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
                         "RESPONSE_CODE", rc);
                     pldm::utils::reportError(
                         "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                        pldm::PelSeverity::ERROR);
+                        pldm::PelSeverity::INFORMATIONAL);
                 }
                 if (completionCode)
                 {
@@ -1166,7 +1166,7 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
                         completionCode);
                     pldm::utils::reportError(
                         "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                        pldm::PelSeverity::ERROR);
+                        pldm::PelSeverity::INFORMATIONAL);
                 }
             };
             rc = handler->registerRequest(


### PR DESCRIPTION
This commit updates the severity of PEL
'xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed' from ERROR to INFORMATIONAL.

Test: Triggered set numericEffecter at runtime and verified the severity of PEL logged as INFORMATIONAL.