### PR TITLE
1030: host-bmc: Update set host effecter PEL severity (#534)

### DIFF
--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -290,7 +290,7 @@ int HostEffecterParser::sendSetStateEffecterStates(
                 << effecterId << " , rc " << rc << "\n";
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                pldm::PelSeverity::ERROR);
+                pldm::PelSeverity::INFORMATIONAL);
         }
         if (completionCode)
         {
@@ -300,7 +300,7 @@ int HostEffecterParser::sendSetStateEffecterStates(
                       << "\n";
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                pldm::PelSeverity::ERROR);
+                pldm::PelSeverity::INFORMATIONAL);
         }
         else
         {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -933,7 +933,7 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
                         << " rc " << rc << "\n";
                     pldm::utils::reportError(
                         "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                        pldm::PelSeverity::ERROR);
+                        pldm::PelSeverity::INFORMATIONAL);
                 }
                 if (completionCode)
                 {
@@ -943,7 +943,7 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
                         << "\n";
                     pldm::utils::reportError(
                         "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                        pldm::PelSeverity::ERROR);
+                        pldm::PelSeverity::INFORMATIONAL);
                 }
             };
         rc = handler->registerRequest(


### PR DESCRIPTION
#### host-bmc: Update set host effecter PEL severity (#534)
```
This commit updates the severity of PEL
'xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed' from ERROR to
INFORMATIONAL.

Test: Triggered set numericEffecter at runtime and verified the severity of PEL logged as INFORMATIONAL.

Signed-off-by: Riya Dixit <riyadixitagra@gmail.com>```