### PR TITLE
host-bmc: Update set host effecter PEL severity

### DIFF
--- a/host-bmc/dbus_to_host_effecters.cpp
+++ b/host-bmc/dbus_to_host_effecters.cpp
@@ -289,7 +289,7 @@ int HostEffecterParser::sendSetStateEffecterStates(
                 "EFFECTER_ID", effecterId, "RC", rc);
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                pldm::PelSeverity::ERROR);
+                pldm::PelSeverity::INFORMATIONAL);
         }
         if (completionCode)
         {
@@ -299,7 +299,7 @@ int HostEffecterParser::sendSetStateEffecterStates(
                 static_cast<unsigned>(completionCode));
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                pldm::PelSeverity::ERROR);
+                pldm::PelSeverity::INFORMATIONAL);
         }
         else
         {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1010,7 +1010,7 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
                     "RC", static_cast<unsigned>(rc));
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                    pldm::PelSeverity::ERROR);
+                    pldm::PelSeverity::INFORMATIONAL);
             }
             if (completionCode)
             {
@@ -1018,7 +1018,7 @@ void pldm::responder::oem_ibm_platform::Handler::setHostEffecterState(
                       static_cast<unsigned>(completionCode));
                 pldm::utils::reportError(
                     "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
-                    pldm::PelSeverity::ERROR);
+                    pldm::PelSeverity::INFORMATIONAL);
             }
         };
         rc = handler->registerRequest(


### PR DESCRIPTION
This commit updates the severity of PEL
'xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed' from ERROR to INFORMATIONAL.

Test: Triggered set numericEffecter at runtime and verified the severity of PEL logged as INFORMATIONAL.