### PR TITLE
oem-ibm: Change the "Notify" method to "NotifyDump" method

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,148 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-26T19:13:37Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "oem/ibm/configurations/fileTable.json": [
+      {
+        "hashed_secret": "c5466ef14c63f778e12ce011da1b27761f48c012",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp": [
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 71,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "76115425ed87da96eced3ae323aab27391989146",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tools/fw-update/metadata-example.json": [
+      {
+        "hashed_secret": "e3b0ba22a16e71ad12dfcd790d2b4eb36c4a1768",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8b80cf295c271c85bec5d0200b00fbd8396fbbb0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c50e03f885dcc3fcc2100e69f22fe40d871a6262",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "660c1ed72dac60bcc44db5732a2abf247a071f69",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -921,6 +921,54 @@ Response Handler::newFileAvailable(const pldm_msg* request,
     return response;
 }
 
+Response Handler::newFileAvailableWithMetaData(const pldm_msg* request,
+                                               size_t payloadLength)
+{
+    Response response(sizeof(pldm_msg_hdr) +
+                      PLDM_NEW_FILE_AVAILABLE_WITH_META_DATA_RESP_BYTES);
+
+    if (payloadLength != PLDM_NEW_FILE_AVAILABLE_WITH_META_DATA_REQ_BYTES)
+    {
+        return CmdHandler::ccOnlyResponse(request, PLDM_ERROR_INVALID_LENGTH);
+    }
+    uint16_t fileType{};
+    uint32_t fileHandle{};
+    uint64_t length{};
+    uint32_t fileMetaData1{};
+    uint32_t fileMetaData2{};
+    uint32_t fileMetaData3{};
+    uint32_t fileMetaData4{};
+
+    auto rc = decode_new_file_with_metadata_req(
+        request, payloadLength, &fileType, &fileHandle, &length, &fileMetaData1,
+        &fileMetaData2, &fileMetaData3, &fileMetaData4);
+
+    if (rc != PLDM_SUCCESS)
+    {
+        return CmdHandler::ccOnlyResponse(request, rc);
+    }
+
+    std::unique_ptr<FileHandler> handler{};
+    try
+    {
+        handler = getHandlerByType(fileType, fileHandle);
+    }
+    catch (const InternalFailure& e)
+    {
+        error("unknown file type, '{TYPE}' error - {ERROR}", "TYPE", fileType,
+              "ERROR", e);
+        return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
+    }
+
+    rc = handler->newFileAvailableWithMetaData(
+        length, fileMetaData1, fileMetaData2, fileMetaData3, fileMetaData4);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_new_file_with_metadata_resp(request->hdr.instance_id, rc,
+                                       responsePtr);
+
+    return response;
+}
+
 } // namespace oem_ibm
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -234,6 +234,11 @@ class Handler : public CmdHandler
             [this](pldm_tid_t, const pldm_msg* request, size_t payloadLength) {
             return this->newFileAvailable(request, payloadLength);
         });
+        handlers.emplace(
+            PLDM_NEW_FILE_AVAILABLE_WITH_META_DATA,
+            [this](pldm_tid_t, const pldm_msg* request, size_t payloadLength) {
+            return this->newFileAvailableWithMetaData(request, payloadLength);
+        });
 
         resDumpMatcher = std::make_unique<sdbusplus::bus::match_t>(
             pldm::utils::DBusHandler::getBus(),
@@ -413,6 +418,16 @@ class Handler : public CmdHandler
      *  @return PLDM response message
      */
     Response newFileAvailable(const pldm_msg* request, size_t payloadLength);
+
+    /** @brief Handler for newFileAvailableWithMetaData command
+     *
+     *  @param[in] request - PLDM request msg
+     *  @param[in] payloadLength - length of the message payload
+     *
+     *   @return PLDM response messsage
+     */
+    Response newFileAvailableWithMetaData(const pldm_msg* request,
+                                          size_t payloadLength);
 
   private:
     oem_platform::Handler* oemPlatformHandler;

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -79,6 +79,23 @@ class FileHandler
      */
     virtual int newFileAvailable(uint64_t length) = 0;
 
+    /** @brief method to process a new file available metadata notification from
+     * the host
+     *
+     * @param[in] length - size of the file content to be transferred
+     * @param[in] metaDataValue1 - value of meta data sent by host
+     * @param[in] metaDataValue2 - value of meta data sent by host
+     * @param[in] metaDataValue3 - value of meta data sent by host
+     * @param[in] metaDataValue4 - value of meta data sent by host
+     *
+     * @return PLDM status code
+     */
+    virtual int newFileAvailableWithMetaData(uint64_t length,
+                                             uint32_t metaDataValue1,
+                                             uint32_t metaDataValue2,
+                                             uint32_t metaDataValue3,
+                                             uint32_t metaDataValue4) = 0;
+
     /** @brief Method to read an oem file type's content into the PLDM response.
      *  @param[in] filePath - file to read from
      *  @param[in] offset - offset to read

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -1,5 +1,6 @@
 #include "file_io_type_dump.hpp"
 
+#include "com/ibm/Dump/Notify/server.hpp"
 #include "common/utils.hpp"
 #include "utils.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
@@ -12,7 +13,6 @@
 
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/server.hpp>
-#include <xyz/openbmc_project/Dump/NewDump/server.hpp>
 
 #include <exception>
 #include <filesystem>
@@ -111,24 +111,26 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
 
 int DumpHandler::newFileAvailable(uint64_t length)
 {
-    static constexpr auto dumpInterface = "xyz.openbmc_project.Dump.NewDump";
+    static constexpr auto dumpInterface = "com.ibm.Dump.Notify";
     auto& bus = pldm::utils::DBusHandler::getBus();
 
     auto notifyObjPath = dumpObjPath;
+    auto notifyDumpType =
+        sdbusplus::common::com::ibm::dump::Notify::DumpType::System;
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
     {
         // Setting the Notify path for resource dump
-        notifyObjPath = resDumpObjPath;
+        notifyDumpType =
+            sdbusplus::common::com::ibm::dump::Notify::DumpType::Resource;
     }
 
     try
     {
         auto service = pldm::utils::DBusHandler().getService(notifyObjPath,
                                                              dumpInterface);
-        using namespace sdbusplus::xyz::openbmc_project::Dump::server;
         auto method = bus.new_method_call(service.c_str(), notifyObjPath,
-                                          dumpInterface, "Notify");
-        method.append(fileHandle, length);
+                                          dumpInterface, "NotifyDump");
+        method.append(fileHandle, length, notifyDumpType, 0);
         bus.call_noreply(method, dbusTimeout);
     }
     catch (const std::exception& e)
@@ -345,5 +347,45 @@ int DumpHandler::read(uint32_t offset, uint32_t& length, Response& response,
     return readFile(resDumpDirPath, offset, length, response);
 }
 
+int DumpHandler::newFileAvailableWithMetaData(uint64_t length,
+                                              uint32_t metaDataValue1,
+                                              uint32_t /*metaDataValue2*/,
+                                              uint32_t /*metaDataValue3*/,
+                                              uint32_t /*metaDataValue4*/)
+{
+    static constexpr auto dumpInterface = "com.ibm.Dump.Notify";
+    auto& bus = pldm::utils::DBusHandler::getBus();
+
+    auto notifyObjPath = dumpObjPath;
+    auto notifyDumpType =
+        sdbusplus::common::com::ibm::dump::Notify::DumpType::System;
+    if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
+    {
+        // Setting the Notify path for resource dump
+        notifyDumpType =
+            sdbusplus::common::com::ibm::dump::Notify::DumpType::Resource;
+    }
+
+    try
+    {
+        auto service = pldm::utils::DBusHandler().getService(notifyObjPath,
+                                                             dumpInterface);
+        auto method = bus.new_method_call(service.c_str(), notifyObjPath,
+                                          dumpInterface, "NotifyDump");
+        method.append(fileHandle, length, notifyDumpType, metaDataValue1);
+        bus.call(method, dbusTimeout);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        error(
+            "failed to make a d-bus call to notify a new dump request using newFileAvailableWithMetaData, error - {ERROR}",
+            "ERROR", e);
+        pldm::utils::reportError(
+            "xyz.openbmc_project.PLDM.Error.newFileAvailableWithMetaData.NewDumpNotifyFail");
+        return PLDM_ERROR;
+    }
+
+    return PLDM_SUCCESS;
+}
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -40,6 +40,12 @@ class DumpHandler : public FileHandler
 
     virtual int fileAck(uint8_t fileStatus);
 
+    virtual int newFileAvailableWithMetaData(uint64_t length,
+                                             uint32_t metaDataValue1,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/);
+
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
 

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -306,6 +306,15 @@ class LidHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief LidHandler destructor
      */
     ~LidHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -48,6 +48,15 @@ class PelHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief PelHandler destructor
      */
     ~PelHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -53,6 +53,15 @@ class ProgressCodeHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief method to set the dbus Raw value Property with
      * the obtained progress code from the host.
      *


### PR DESCRIPTION
The "NotifyDump" method was newly introduced in the PDI with additional parameters [1]. This commit changes the Notify method to the new "NotifyDump" method.
Added support for newFileAvailableWithMetaData command which uses the new "NotifyDump" method.

[1]: https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/com/ibm/Dump/Notify.interface.yaml

Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>