### PR TITLE
Adding support for asynchronous file transfer

### DIFF
--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -2,6 +2,7 @@
 
 #include "types.hpp"
 
+#include <fcntl.h>
 #include <libpldm/base.h>
 #include <libpldm/bios.h>
 #include <libpldm/entity.h>
@@ -47,35 +48,6 @@ using inventoryManager =
 constexpr auto dbusProperties = "org.freedesktop.DBus.Properties";
 constexpr auto mapperService = ObjectMapper::default_service;
 constexpr auto inventoryPath = "/xyz/openbmc_project/inventory";
-/** @struct CustomFD
- *
- *  RAII wrapper for file descriptor.
- */
-struct CustomFD
-{
-    CustomFD(const CustomFD&) = delete;
-    CustomFD& operator=(const CustomFD&) = delete;
-    CustomFD(CustomFD&&) = delete;
-    CustomFD& operator=(CustomFD&&) = delete;
-
-    CustomFD(int fd) : fd(fd) {}
-
-    ~CustomFD()
-    {
-        if (fd >= 0)
-        {
-            close(fd);
-        }
-    }
-
-    int operator()() const
-    {
-        return fd;
-    }
-
-  private:
-    int fd = -1;
-};
 
 /** @brief Calculate the pad for PLDM data
  *

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/utils.hpp"
+#include "file_io_by_type.hpp"
 #include "oem/ibm/requester/dbus_to_file_handler.hpp"
 #include "oem_ibm_handler.hpp"
 #include "pldmd/handler.hpp"
@@ -11,6 +12,7 @@
 #include <libpldm/oem/ibm/file_io.h>
 #include <libpldm/oem/ibm/host.h>
 #include <stdint.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -33,6 +35,14 @@ namespace dma
 constexpr uint32_t minSize = 16;
 
 constexpr size_t maxSize = DMA_MAXSIZE;
+constexpr auto xdmaDev = "/dev/aspeed-xdma";
+
+struct FileMetaData
+{
+    uint32_t length;
+    uint32_t offset;
+    uint64_t address;
+};
 
 namespace fs = std::filesystem;
 
@@ -47,30 +57,292 @@ namespace fs = std::filesystem;
  */
 class DMA
 {
+    /** @brief DMA constructor is private to avoid object creation
+     *  without lengh.
+     */
+    DMA() {}
+
   public:
+    /** @brief DMA constructor
+     *
+     *  @param[in] length - using length allocating shared memory to transfer
+     * data.
+     */
+    DMA(uint32_t length)
+    {
+        isTxComplete = false;
+        memAddr = nullptr;
+        xdmaFd = -1;
+        sourceFd = -1;
+        iotPtr = nullptr;
+        iotPtrbc = nullptr;
+        timer = nullptr;
+        m_length = length;
+        static const size_t pageSize = getpagesize();
+        uint32_t numPages = m_length / pageSize;
+        pageAlignedLength = numPages * pageSize;
+        if (m_length > pageAlignedLength)
+        {
+            pageAlignedLength += pageSize;
+        }
+    }
+
+    /** @brief DMA destructor
+     */
+    ~DMA()
+    {
+        if (iotPtr != nullptr)
+        {
+            iotPtrbc = iotPtr.release();
+        }
+
+        if (iotPtrbc != nullptr)
+        {
+            delete iotPtrbc;
+            iotPtrbc = nullptr;
+        }
+
+        if (timer != nullptr)
+        {
+            auto time = timer.release();
+            delete time;
+        }
+
+        if (xdmaFd > 0)
+        {
+            close(xdmaFd);
+            xdmaFd = -1;
+        }
+        if (sourceFd > 0)
+        {
+            close(sourceFd);
+            sourceFd = -1;
+        }
+    }
+    /** @brief Method to fetch the shared memory file descriptor for data
+     * transfer
+     *
+     *  @return returns shared memory file descriptor
+     */
+    int getNewXdmaFd()
+    {
+        try
+        {
+            xdmaFd = open(xdmaDev, O_RDWR | O_NONBLOCK);
+        }
+        catch (...)
+        {
+            xdmaFd = -1;
+        }
+        return xdmaFd;
+    }
+    /** @brief Method to fetch the existing shared memory file descriptor for
+     *  data transfer
+     *  @return returns existing shared memory file descriptor
+     */
+    int getXdmaFd()
+    {
+        if (xdmaFd > 0)
+        {
+            return xdmaFd;
+        }
+        return getNewXdmaFd();
+    }
+
+    /** @brief function will keep one copy of fd for exception case so it
+     *  can close it.
+     *  @param[in] fd - source path file descriptor
+     */
+    inline void setDMASourceFd(int fd)
+    {
+        sourceFd = fd;
+    }
+
+    /** @brief function will keep one copy of shared memory fd for exception
+     *  case so it can close it.
+     *
+     *  @param[in] fd - xdma shared memory path file descriptor
+     */
+    inline void setXDMASourceFd(int fd)
+    {
+        xdmaFd = fd;
+    }
+
+    /** @brief function will return pagealignedlength to allocate memory for
+     *  data transfer.
+     */
+    inline int32_t getpageAlignedLength()
+    {
+        return pageAlignedLength;
+    }
+
+    /** @brief function will return shared memory address
+     *  from XDMA drive path
+     */
+    void* getXDMAsharedlocation()
+    {
+        if (xdmaFd < 0)
+        {
+            error(
+                "Failed to get memory location due to invalid file descriptor during DMA.");
+            return nullptr;
+        }
+
+        memAddr = mmap(nullptr, pageAlignedLength, PROT_WRITE | PROT_READ,
+                       MAP_SHARED, xdmaFd, 0);
+        if (MAP_FAILED == memAddr)
+        {
+            error("Failed to get memory location with err num '{ERRNO}'",
+                  "ERRNO", errno);
+            return nullptr;
+        }
+
+        return memAddr;
+    }
+
+    /** @brief Method to update file related metadata
+     *
+     *  @param[in] data - contain file related info like length, address,
+     * offset.
+     */
+    inline void setFileMetaData(FileMetaData& data)
+    {
+        fileMetaData.address = data.address;
+        fileMetaData.offset = data.offset;
+        fileMetaData.length = data.length;
+    }
+
+    /** @brief Method to get file related metadata
+     */
+    inline FileMetaData& getFileMetaData()
+    {
+        return fileMetaData;
+    }
+
+    /** @brief Method to initialize IO instance for event loop
+     *
+     *  @param[in] ioptr -  pointer to manage eventloop
+     */
+    inline void insertIOInstance(std::unique_ptr<IO>&& ioptr)
+    {
+        iotPtr = std::move(ioptr);
+    }
+
+    /** @brief Method to delete cyclic dependecy while deleting object
+     *  DMA interface and IO event loop has cyclic dependecy
+     */
+    void deleteIOInstance()
+    {
+        if (timer != nullptr)
+        {
+            auto time = timer.release();
+            delete time;
+        }
+        if (iotPtr != nullptr)
+        {
+            iotPtrbc = iotPtr.release();
+        }
+    }
+
+    /** @brief Method to set value for response received
+     *
+     *  @param[in] bresponse - transfer status
+     */
+    inline void setTransferStatus(bool bresponse)
+    {
+        isTxComplete = bresponse;
+    }
+
+    /** @brief Method to get to know tranfer success/fail.
+     *
+     *  @return returns true if transfer success else false on timeout.
+     */
+    inline bool getTransferStatus()
+    {
+        return isTxComplete;
+    }
+
+    /** @brief Method to initialize timer for each tranfer object
+     *
+     *  @param[in] event - sdeventplus event for IO object
+     *  @param[in] callback - callback function pointer
+     *
+     *  @return returns true if timer creation success else false
+     */
+    bool initTimer(
+        sdeventplus::Event& event,
+        fu2::unique_function<void(Timer&, Timer::TimePoint)>&& callback);
+
     /** @brief API to transfer data between BMC and host using DMA
      *
-     * @param[in] path     - pathname of the file to transfer data from or to
-     * @param[in] offset   - offset in the file
-     * @param[in] length   - length of the data to transfer
-     * @param[in] address  - DMA address on the host
-     * @param[in] upstream - indicates direction of the transfer; true indicates
-     *                       transfer to the host
+     *  @param[in] path     - pathname of the file to transfer data
+     *  @param[in] offset   - offset in the file
+     *  @param[in] length   - length of the data to transfer
+     *  @param[in] address  - DMA address on the host
+     *  @param[in] upstream - indicates direction of the transfer; true
+     *  indicates transfer to the host
      *
-     * @return returns 0 on success, negative errno on failure
+     *  @return returns 0 on success, negative errno on failure
      */
     int transferDataHost(int fd, uint32_t offset, uint32_t length,
                          uint64_t address, bool upstream);
 
     /** @brief API to transfer data on to unix socket from host using DMA
      *
-     * @param[in] path     - pathname of the file to transfer data from or to
-     * @param[in] length   - length of the data to transfer
-     * @param[in] address  - DMA address on the host
+     *  @param[in] path - pathname of the file to transfer data
+     *  @param[in] length  - length of the data to transfer
+     *  @param[in] address  - DMA address on the host
      *
-     * @return returns 0 on success, negative errno on failure
+     *  @return returns 0 on success, negative errno on failure
      */
     int transferHostDataToSocket(int fd, uint32_t length, uint64_t address);
+
+    int openSourcefile(fs::path path, int flag)
+    {
+        sourceFd = open(path.c_str(), flag);
+        if (sourceFd == -1)
+        {
+            error("File does not exist at {PATH}", "PATH", path.string());
+        }
+        return sourceFd;
+    }
+
+    inline int getsourceFileDesc()
+    {
+        return sourceFd;
+    }
+
+  private:
+    /* flag to track data transfer completion */
+    bool isTxComplete;
+
+    /* Mapped DMA address to perform transfer operation */
+    void* memAddr;
+
+    /* File descriptor of DMA address */
+    int xdmaFd;
+
+    /* File descriptor of file which needs to be transfer */
+    int sourceFd;
+
+    /* Page alignment length to map DMA memory size during transfer */
+    uint32_t pageAlignedLength;
+
+    /* Pointer to create event loop obejct */
+    std::unique_ptr<IO> iotPtr;
+
+    /* Pointer to hold event loop obeject to track object memory to avoid memory
+     * leak */
+    IO* iotPtrbc;
+
+    /* Pointer to create timer obejct for event loop object */
+    std::unique_ptr<Timer> timer;
+
+    /* Length to calculate page alignment length based on pagesize  */
+    uint32_t m_length;
+
+    /* Contain file related info like length, address, offset. */
+    FileMetaData fileMetaData;
 };
 
 /** @brief Transfer the data between BMC and host using DMA.
@@ -93,64 +365,183 @@ class DMA
  */
 
 template <class DMAInterface>
-Response transferAll(DMAInterface* intf, uint8_t command, fs::path& path,
-                     uint32_t offset, uint32_t length, uint64_t address,
-                     bool upstream, uint8_t instanceId)
+void transferAll(std::shared_ptr<DMAInterface> intf, int32_t fd,
+                 uint32_t offset, uint32_t length, uint64_t address,
+                 bool upstream, SharedAIORespData& sharedAIORespDataobj,
+                 sdeventplus::Event& event)
 {
-    uint32_t origLength = length;
-    Response response(sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_RESP_BYTES, 0);
-    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
-
-    int flags{};
-    if (upstream)
+    uint8_t command = sharedAIORespDataobj.command;
+    uint8_t instance_id = sharedAIORespDataobj.instance_id;
+    if (nullptr == intf)
     {
-        flags = O_RDONLY;
-    }
-    else if (fs::exists(path))
-    {
-        flags = O_RDWR;
-    }
-    else
-    {
-        flags = O_WRONLY;
-    }
-    int file = open(path.string().c_str(), flags);
-    if (file == -1)
-    {
-        error("File at path '{PATH}' does not exist", "PATH", path.string());
-        encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
+        Response response(sizeof(pldm_msg_hdr) + command, 0);
+        auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+        encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
                                    responsePtr);
-        return response;
+        error("Xdma interface is NULL");
+        if (sharedAIORespDataobj.respInterface != nullptr)
+        {
+            sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+        }
+        if (fd > 0)
+            close(fd);
+        return;
     }
-    pldm::utils::CustomFD fd(file);
+    // intf->setDMASourceFd(file);
+    uint32_t origLength = length;
+    static auto& bus = pldm::utils::DBusHandler::getBus();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+    std::weak_ptr<dma::DMA> wInterface = intf;
 
-    while (length > dma::maxSize)
-    {
-        auto rc = intf->transferDataHost(fd(), offset, dma::maxSize, address,
-                                         upstream);
+    dma::FileMetaData data;
+    data.length = length;
+    data.offset = offset;
+    data.address = address;
+    intf->setFileMetaData(data);
+    auto timerCb = [=](Timer& /*source*/, Timer::TimePoint /*time*/) {
+        if (!intf->getTransferStatus())
+        {
+            error(
+                "EventLoop Timeout..!! Terminating data tranfer file operation where transferred data length:{TXDATA} Remaining length:{REMAIN_DATA}",
+                "TXDATA", origLength, "REMAIN_DATA", data.length);
+            Response response(sizeof(pldm_msg_hdr) + command, 0);
+            auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+            encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                       responsePtr);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            intf->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(intf)).reset();
+        }
+        return;
+    };
+
+    auto callback = [=](IO&, int, uint32_t revents) {
+        if (!(revents & (EPOLLIN | EPOLLOUT)))
+        {
+            return;
+        }
+        auto weakPtr = wInterface.lock();
+        dma::FileMetaData& data = weakPtr->getFileMetaData();
+        int file = weakPtr->getsourceFileDesc();
+        Response response(sizeof(pldm_msg_hdr) + command, 0);
+        auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+        int rc = 0;
+
+        while (data.length > dma::maxSize)
+        {
+            rc = weakPtr->transferDataHost(file, data.offset, dma::maxSize,
+                                           data.address, upstream);
+
+            data.length -= dma::maxSize;
+            data.offset += dma::maxSize;
+            data.address += dma::maxSize;
+            if (rc < 0)
+            {
+                encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                           responsePtr);
+                error(
+                    "Failed to transfer muliple chunks of data to remote terminus due to RC: '{RC}'.",
+                    "RC", rc);
+                if (sharedAIORespDataobj.respInterface != nullptr)
+                {
+                    sharedAIORespDataobj.respInterface->sendPLDMRespMsg(
+                        response);
+                }
+                weakPtr->deleteIOInstance();
+                (static_cast<std::shared_ptr<dma::DMA>>(wInterface)).reset();
+                return;
+            }
+        }
+        rc = weakPtr->transferDataHost(file, data.offset, data.length,
+                                       data.address, upstream);
         if (rc < 0)
         {
-            encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
+            encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
                                        responsePtr);
-            return response;
+            error(
+                "Failed to transfer single chunks of data to remote terminus due to RC: '{RC}'.",
+                "RC", rc);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            weakPtr->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(wInterface)).reset();
+            return;
         }
+        if (static_cast<int>(data.length) == rc)
+        {
+            weakPtr->setTransferStatus(true);
+            encode_rw_file_memory_resp(instance_id, command, PLDM_SUCCESS,
+                                       origLength, responsePtr);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            weakPtr->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(wInterface)).reset();
+            return;
+        }
+    };
 
-        offset += dma::maxSize;
-        length -= dma::maxSize;
-        address += dma::maxSize;
-    }
-
-    auto rc = intf->transferDataHost(fd(), offset, length, address, upstream);
-    if (rc < 0)
+    try
     {
-        encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
-                                   responsePtr);
-        return response;
-    }
+        int xdmaFd = intf->getNewXdmaFd();
+        if (xdmaFd < 0)
+        {
+            error(
+                "Failed to get the XDMA file descriptor while initialising event loop.");
+            Response response(sizeof(pldm_msg_hdr) + command, 0);
+            auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
 
-    encode_rw_file_memory_resp(instanceId, command, PLDM_SUCCESS, origLength,
-                               responsePtr);
-    return response;
+            encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                       responsePtr);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            intf->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(intf)).reset();
+            return;
+        }
+        if (intf->initTimer(event, std::move(timerCb)) == false)
+        {
+            error(
+                "Failed to start the event timer while initialising event loop.");
+            Response response(sizeof(pldm_msg_hdr) + command, 0);
+            auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+            encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                       responsePtr);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            intf->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(intf)).reset();
+            return;
+        }
+        intf->insertIOInstance(std::move(std::make_unique<IO>(
+            event, xdmaFd, EPOLLIN | EPOLLOUT, std::move(callback))));
+    }
+    catch (const std::runtime_error& e)
+    {
+        Response response(sizeof(pldm_msg_hdr) + command, 0);
+        auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+        error("Failed to start the event loop with error: {ERROR} ", "ERROR",
+              e);
+        encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                   responsePtr);
+        if (sharedAIORespDataobj.respInterface != nullptr)
+        {
+            sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+        }
+        intf->deleteIOInstance();
+        (static_cast<std::shared_ptr<dma::DMA>>(intf)).reset();
+    }
+    return;
 }
 
 } // namespace dma
@@ -169,10 +560,12 @@ class Handler : public CmdHandler
   public:
     Handler(oem_platform::Handler* oemPlatformHandler, int hostSockFd,
             uint8_t hostEid, pldm::InstanceIdDb* instanceIdDb,
-            pldm::requester::Handler<pldm::requester::Request>* handler) :
+            pldm::requester::Handler<pldm::requester::Request>* handler,
+            pldm::response_api::AltResponse* respInterface) :
         oemPlatformHandler(oemPlatformHandler),
         hostSockFd(hostSockFd), hostEid(hostEid), instanceIdDb(instanceIdDb),
-        handler(handler)
+        handler(handler),
+        sharedAIORespDataobj({0, 0, nullptr, 0, respInterface})
     {
         handlers.emplace(
             PLDM_READ_FILE_INTO_MEMORY,
@@ -245,7 +638,6 @@ class Handler : public CmdHandler
             [this](pldm_tid_t, const pldm_msg* request, size_t payloadLength) {
             return this->fileAckWithMetaData(request, payloadLength);
         });
-
         resDumpMatcher = std::make_unique<sdbusplus::bus::match_t>(
             pldm::utils::DBusHandler::getBus(),
             sdbusplus::bus::match::rules::interfacesAdded() +
@@ -492,6 +884,7 @@ class Handler : public CmdHandler
     pldm::requester::Handler<pldm::requester::Request>* handler;
     std::vector<std::unique_ptr<pldm::requester::oem_ibm::DbusToFileHandler>>
         dbusToFileHandlers;
+    SharedAIORespData sharedAIORespDataobj;
 };
 
 } // namespace oem_ibm

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -1,6 +1,5 @@
-#include "file_io_by_type.hpp"
-
 #include "common/utils.hpp"
+#include "file_io.hpp"
 #include "file_io_type_cert.hpp"
 #include "file_io_type_dump.hpp"
 #include "file_io_type_lid.hpp"
@@ -13,6 +12,7 @@
 #include <libpldm/base.h>
 #include <libpldm/oem/ibm/file_io.h>
 #include <stdint.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 
 #include <phosphor-logging/lg2.hpp>
@@ -30,50 +30,330 @@ namespace pldm
 namespace responder
 {
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+using namespace sdeventplus;
+using namespace sdeventplus::source;
 
-int FileHandler::transferFileData(int32_t fd, bool upstream, uint32_t offset,
-                                  uint32_t& length, uint64_t address)
+void FileHandler::dmaResponseToRemoteTerminus(
+    const SharedAIORespData& sharedAIORespDataobj,
+    const pldm_completion_codes rStatus, uint32_t length)
 {
-    dma::DMA xdmaInterface;
-    while (length > dma::maxSize)
+    Response response(sizeof(pldm_msg_hdr) + sharedAIORespDataobj.command, 0);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_rw_file_by_type_memory_resp(sharedAIORespDataobj.instance_id,
+                                       sharedAIORespDataobj.command, rStatus,
+                                       length, responsePtr);
+    if (nullptr != sharedAIORespDataobj.respInterface)
     {
-        auto rc = xdmaInterface.transferDataHost(fd, offset, dma::maxSize,
-                                                 address, upstream);
-        if (rc < 0)
-        {
-            return PLDM_ERROR;
-        }
-        offset += dma::maxSize;
-        length -= dma::maxSize;
-        address += dma::maxSize;
+        sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
     }
-    auto rc = xdmaInterface.transferDataHost(fd, offset, length, address,
-                                             upstream);
-    return rc < 0 ? PLDM_ERROR : PLDM_SUCCESS;
 }
 
-int FileHandler::transferFileDataToSocket(int32_t fd, uint32_t& length,
-                                          uint64_t address)
+void FileHandler::dmaResponseToRemoteTerminus(
+    const SharedAIORespData& sharedAIORespDataobj,
+    const pldm_fileio_completion_codes rStatus, uint32_t length)
 {
-    dma::DMA xdmaInterface;
-    while (length > dma::maxSize)
+    Response response(sizeof(pldm_msg_hdr) + sharedAIORespDataobj.command, 0);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_rw_file_by_type_memory_resp(sharedAIORespDataobj.instance_id,
+                                       sharedAIORespDataobj.command, rStatus,
+                                       length, responsePtr);
+    if (nullptr != sharedAIORespDataobj.respInterface)
     {
-        auto rc = xdmaInterface.transferHostDataToSocket(fd, dma::maxSize,
-                                                         address);
-        if (rc < 0)
-        {
-            return PLDM_ERROR;
-        }
-        length -= dma::maxSize;
-        address += dma::maxSize;
+        sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
     }
-    auto rc = xdmaInterface.transferHostDataToSocket(fd, length, address);
-    return rc < 0 ? PLDM_ERROR : PLDM_SUCCESS;
 }
 
-int FileHandler::transferFileData(const fs::path& path, bool upstream,
-                                  uint32_t offset, uint32_t& length,
-                                  uint64_t address)
+void FileHandler::deleteAIOobjects(
+    const std::shared_ptr<dma::DMA>& xdmaInterface,
+    const SharedAIORespData& sharedAIORespDataobj)
+{
+    if (nullptr != xdmaInterface)
+    {
+        xdmaInterface->deleteIOInstance();
+        (static_cast<std::shared_ptr<dma::DMA>>(xdmaInterface)).reset();
+    }
+
+    if (nullptr != sharedAIORespDataobj.functionPtr)
+    {
+        (static_cast<std::shared_ptr<FileHandler>>(
+             sharedAIORespDataobj.functionPtr))
+            .reset();
+    }
+}
+
+void FileHandler::transferFileData(int fd, bool upstream, uint32_t offset,
+                                   uint32_t& length, uint64_t address,
+                                   SharedAIORespData& sharedAIORespDataobj,
+                                   sdeventplus::Event& event)
+{
+    std::shared_ptr<dma::DMA> xdmaInterface =
+        std::make_shared<dma::DMA>(length);
+    if (nullptr == xdmaInterface)
+    {
+        error("Failed to initializing DMA interface during for fileType:{TYPE}",
+              "TYPE", sharedAIORespDataobj.fileType);
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+        deleteAIOobjects(nullptr, sharedAIORespDataobj);
+        close(fd);
+        return;
+    }
+    xdmaInterface->setDMASourceFd(fd);
+    uint32_t origLength = length;
+    uint8_t command = sharedAIORespDataobj.command;
+    static auto& bus = pldm::utils::DBusHandler::getBus();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+    dma::FileMetaData data{length, offset, address};
+    xdmaInterface->setFileMetaData(data);
+    std::weak_ptr<dma::DMA> wxInterface = xdmaInterface;
+    auto timerCb = [=, this](Timer& /*source*/, Timer::TimePoint /*time*/) {
+        if (!xdmaInterface->getTransferStatus())
+        {
+            error(
+                "EventLoop Timeout..!! Terminating FileHandler data tranfer operation for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+        }
+        return;
+    };
+
+    auto callback = [=, this](IO&, int, uint32_t revents) {
+        if (!(revents & (EPOLLIN | EPOLLOUT)))
+        {
+            return;
+        }
+        auto wInterface = wxInterface.lock();
+        dma::FileMetaData& data = wInterface->getFileMetaData();
+        int rc = 0;
+        while (data.length > dma::maxSize)
+        {
+            rc = wInterface->transferDataHost(fd, data.offset, dma::maxSize,
+                                              data.address, upstream);
+            data.length -= dma::maxSize;
+            data.offset += dma::maxSize;
+            data.address += dma::maxSize;
+            if (rc < 0)
+            {
+                error(
+                    "Failed to transfer muliple chunks of data to host fileType:{TYPE}",
+                    "TYPE", sharedAIORespDataobj.fileType);
+                dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR,
+                                            0);
+                deleteAIOobjects(wInterface, sharedAIORespDataobj);
+                return;
+            }
+        }
+        rc = wInterface->transferDataHost(fd, data.offset, data.length,
+                                          data.address, upstream);
+        if (rc < 0)
+        {
+            error(
+                "transferFileData : Failed to transfer single chunks of data to host for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            deleteAIOobjects(wInterface, sharedAIORespDataobj);
+            return;
+        }
+        if (static_cast<int>(data.length) == rc)
+        {
+            wInterface->setTransferStatus(true);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_SUCCESS,
+                                        origLength);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY,
+                    data.length);
+            }
+            deleteAIOobjects(wInterface, sharedAIORespDataobj);
+            return;
+        }
+    };
+    try
+    {
+        int xdmaFd = xdmaInterface->getNewXdmaFd();
+        if (xdmaFd < 0)
+        {
+            error("Failed to get the XDMA file descriptor for fileType:{TYPE}",
+                  "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+            return;
+        }
+        if (xdmaInterface->initTimer(event, std::move(timerCb)) == false)
+        {
+            error("Failed to start the event timer for fileType:{TYPE}", "TYPE",
+                  sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+            return;
+        }
+        xdmaInterface->insertIOInstance(std::move(std::make_unique<IO>(
+            event, xdmaFd, EPOLLIN | EPOLLOUT, std::move(callback))));
+    }
+    catch (const std::runtime_error& e)
+    {
+        error("Failed to start the event loop for fileType:{TYPE} : {ERROR}",
+              "TYPE", sharedAIORespDataobj.fileType, "ERROR", e);
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+        deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+    }
+}
+
+void FileHandler::transferFileDataToSocket(
+    int32_t fd, uint32_t& length, uint64_t address,
+    SharedAIORespData& sharedAIORespDataobj, sdeventplus::Event& event)
+{
+    std::shared_ptr<dma::DMA> xdmaInterface =
+        std::make_shared<dma::DMA>(length);
+    uint8_t command = sharedAIORespDataobj.command;
+    if (nullptr == xdmaInterface)
+    {
+        error(
+            "XDMA interface initialization failed while transfering data via socket for fileType:{TYPE}",
+            "TYPE", sharedAIORespDataobj.fileType);
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+        if (sharedAIORespDataobj.functionPtr != nullptr)
+        {
+            sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+        }
+        deleteAIOobjects(nullptr, sharedAIORespDataobj);
+        return;
+    }
+    uint32_t origLength = length;
+    static auto& bus = pldm::utils::DBusHandler::getBus();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+    dma::FileMetaData data{length, 0, address};
+    xdmaInterface->setFileMetaData(data);
+    std::weak_ptr<dma::DMA> wxInterface = xdmaInterface;
+    std::weak_ptr<FileHandler> wxfunctionPtr = sharedAIORespDataobj.functionPtr;
+    auto timerCb = [=, this](Timer& /*source*/, Timer::TimePoint /*time*/) {
+        if (!xdmaInterface->getTransferStatus())
+        {
+            error(
+                "EventLoop Timeout...Terminating tranfer operation while transfering data via socket for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+            }
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+        }
+        return;
+    };
+    auto callback = [=, this](IO&, int, uint32_t revents) {
+        if (!(revents & (EPOLLIN | EPOLLOUT)))
+        {
+            return;
+        }
+        auto wInterface = wxInterface.lock();
+        dma::FileMetaData& data = wInterface->getFileMetaData();
+        int rc = 0;
+        while (data.length > dma::maxSize)
+        {
+            rc = wInterface->transferHostDataToSocket(fd, dma::maxSize,
+                                                      data.address);
+            data.length -= dma::maxSize;
+            data.address += dma::maxSize;
+            if (rc < 0)
+            {
+                error(
+                    "Failed to transfer muliple chunks of data to host while transfering data via socket for fileType:{TYPE}",
+                    "TYPE", sharedAIORespDataobj.fileType);
+                dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR,
+                                            0);
+                if (sharedAIORespDataobj.functionPtr != nullptr)
+                {
+                    sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                        command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+                }
+                deleteAIOobjects(wInterface, sharedAIORespDataobj);
+                return;
+            }
+        }
+        rc = wInterface->transferHostDataToSocket(fd, data.length,
+                                                  data.address);
+        if (rc < 0)
+        {
+            error(
+                "Failed to transfer single chunks of data to host while transfering data via socket for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+            }
+            deleteAIOobjects(wInterface, sharedAIORespDataobj);
+            return;
+        }
+        if (static_cast<int>(data.length) == rc)
+        {
+            wInterface->setTransferStatus(true);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_SUCCESS,
+                                        origLength);
+            deleteAIOobjects(wInterface, sharedAIORespDataobj);
+            return;
+        }
+    };
+    try
+    {
+        int xdmaFd = xdmaInterface->getNewXdmaFd();
+        if (xdmaFd < 0)
+        {
+            error(
+                "Failed to open shared memory location while transfering data via socket for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+            }
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+            return;
+        }
+        if (xdmaInterface->initTimer(event, std::move(timerCb)) == false)
+        {
+            error(
+                "Failed to start the event timer while transfering data via socket for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+            }
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+            return;
+        }
+        xdmaInterface->insertIOInstance(std::move(std::make_unique<IO>(
+            event, xdmaFd, EPOLLIN | EPOLLOUT, std::move(callback))));
+    }
+    catch (const std::runtime_error& e)
+    {
+        error(
+            "Failed to start the event loop while transfering data via socket for fileType:{TYPE} : {ERROR}",
+            "TYPE", sharedAIORespDataobj.fileType, "ERROR", e);
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+        if (sharedAIORespDataobj.functionPtr != nullptr)
+        {
+            sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+        }
+        deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+    }
+    return;
+}
+
+void FileHandler::transferFileData(const fs::path& path, bool upstream,
+                                   uint32_t offset, uint32_t& length,
+                                   uint64_t address,
+                                   SharedAIORespData& sharedAIORespDataobj,
+                                   sdeventplus::Event& event)
 {
     bool fileExists = false;
     if (upstream)
@@ -82,7 +362,9 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
         if (!fileExists)
         {
             error("File '{PATH}' does not exist.", "PATH", path);
-            return PLDM_INVALID_FILE_HANDLE;
+            FileHandler::dmaResponseToRemoteTerminus(
+                sharedAIORespDataobj, PLDM_INVALID_FILE_HANDLE, length);
+            FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
         }
 
         size_t fileSize = fs::file_size(path);
@@ -91,7 +373,9 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
             error(
                 "Offset '{OFFSET}' exceeds file size '{SIZE}' for file handle {FILE_HANDLE}",
                 "OFFSET", offset, "SIZE", fileSize, "FILE_HANDLE", fileHandle);
-            return PLDM_DATA_OUT_OF_RANGE;
+            FileHandler::dmaResponseToRemoteTerminus(
+                sharedAIORespDataobj, PLDM_DATA_OUT_OF_RANGE, length);
+            FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
         }
         if (offset + length > fileSize)
         {
@@ -116,11 +400,13 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
     if (file == -1)
     {
         error("File '{PATH}' does not exist.", "PATH", path);
-        return PLDM_ERROR;
+        return;
+        FileHandler::dmaResponseToRemoteTerminus(sharedAIORespDataobj,
+                                                 PLDM_ERROR, 0);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
-    utils::CustomFD fd(file);
-
-    return transferFileData(fd(), upstream, offset, length, address);
+    transferFileData(file, upstream, offset, length, address,
+                     sharedAIORespDataobj, event);
 }
 
 std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
@@ -174,6 +460,71 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
         case PLDM_FILE_TYPE_CABLE_INFO:
         {
             return std::make_unique<PCIeInfoHandler>(fileHandle, fileType);
+        }
+        default:
+        {
+            throw InternalFailure();
+            break;
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<FileHandler> getSharedHandlerByType(uint16_t fileType,
+                                                    uint32_t fileHandle)
+{
+    switch (fileType)
+    {
+        case PLDM_FILE_TYPE_PEL:
+        {
+            return std::make_shared<PelHandler>(fileHandle);
+        }
+        case PLDM_FILE_TYPE_LID_PERM:
+        {
+            return std::make_shared<LidHandler>(fileHandle, true);
+        }
+        case PLDM_FILE_TYPE_LID_TEMP:
+        {
+            return std::make_shared<LidHandler>(fileHandle, false);
+        }
+        case PLDM_FILE_TYPE_LID_MARKER:
+        {
+            return std::make_shared<LidHandler>(fileHandle, false,
+                                                PLDM_FILE_TYPE_LID_MARKER);
+        }
+        case PLDM_FILE_TYPE_LID_RUNNING:
+        {
+            return std::make_shared<LidHandler>(fileHandle, false,
+                                                PLDM_FILE_TYPE_LID_RUNNING);
+        }
+        case PLDM_FILE_TYPE_DUMP:
+        case PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS:
+        case PLDM_FILE_TYPE_RESOURCE_DUMP:
+        case PLDM_FILE_TYPE_BMC_DUMP:
+        case PLDM_FILE_TYPE_SBE_DUMP:
+            // case PLDM_FILE_TYPE_HOSTBOOT_DUMP:
+            // case PLDM_FILE_TYPE_HARDWARE_DUMP:
+            {
+                return std::make_shared<DumpHandler>(fileHandle, fileType);
+            }
+        case PLDM_FILE_TYPE_CERT_SIGNING_REQUEST:
+        case PLDM_FILE_TYPE_SIGNED_CERT:
+        case PLDM_FILE_TYPE_ROOT_CERT:
+        {
+            return std::make_shared<CertHandler>(fileHandle, fileType);
+        }
+        case PLDM_FILE_TYPE_PROGRESS_SRC:
+        {
+            return std::make_shared<ProgressCodeHandler>(fileHandle);
+        }
+        case PLDM_FILE_TYPE_PCIE_TOPOLOGY:
+        case PLDM_FILE_TYPE_CABLE_INFO:
+        {
+            return std::make_shared<PCIeInfoHandler>(fileHandle, fileType);
+        }
+        case PLDM_FILE_TYPE_PSPD_VPD_PDD_KEYWORD:
+        {
+            return std::make_shared<keywordHandler>(fileHandle, fileType);
         }
         default:
         {

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -28,12 +28,16 @@ class CertHandler : public FileHandler
         FileHandler(fileHandle), certType(fileType)
     {}
 
-    virtual int writeFromMemory(uint32_t offset, uint32_t length,
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
+    virtual void readIntoMemory(uint32_t offset, uint32_t length,
                                 uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/);
-    virtual int readIntoMemory(uint32_t offset, uint32_t length,
-                               uint64_t address,
-                               oem_platform::Handler* /*oemPlatformHandler*/);
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& event);
     virtual int read(uint32_t offset, uint32_t& length, Response& response,
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
@@ -59,6 +63,8 @@ class CertHandler : public FileHandler
                                              uint32_t /*metaDataValue3*/,
                                              uint32_t /*metaDataValue4*/);
 
+    virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
+
     /** @brief CertHandler destructor
      */
     ~CertHandler() {}
@@ -67,6 +73,7 @@ class CertHandler : public FileHandler
     uint16_t certType;      //!< type of the certificate
     static CertMap certMap; //!< holds the fd and remaining read/write size for
                             //!< each certificate
+    std::string certfilePath;
     enum SignedCertStatus
     {
         PLDM_INVALID_CERT_DATA = 0X03

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -190,7 +190,7 @@ void DumpHandler::resetOffloadUri()
     }
 
     info("DumpHandler::resetOffloadUri path = {PATH} fileHandle = {FILE_HNDLE}",
-         "PATH", path.c_str(), "FILE_HNDL", fileHandle);
+         "PATH", path.c_str(), "FILE_HNDLE", fileHandle);
 
     PropertyValue offloadUriValue{""};
     DBusMapping dbusMapping{path, dumpEntry, "OffloadUri", "string"};
@@ -241,8 +241,29 @@ std::string DumpHandler::getOffloadUri(uint32_t fileHandle)
     return socketInterface;
 }
 
-int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
-                                 oem_platform::Handler* /*oemPlatformHandler*/)
+void DumpHandler::postDataTransferCallBack(bool IsWriteToMemOp,
+                                           uint32_t /*length*/)
+{
+    /// execute when DMA transfer failed.
+    if (IsWriteToMemOp)
+    {
+        error("DumpHandler::writeFromMemory: transferFileDataToSocket failed");
+        if (DumpHandler::fd >= 0)
+        {
+            close(DumpHandler::fd);
+            DumpHandler::fd = -1;
+        }
+        auto socketInterface = getOffloadUri(fileHandle);
+        std::remove(socketInterface.c_str());
+        resetOffloadUri();
+        return;
+    }
+}
+
+void DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
+                                  oem_platform::Handler* /*oemPlatformHandler*/,
+                                  SharedAIORespData& sharedAIORespDataobj,
+                                  sdeventplus::Event& event)
 {
     if (DumpHandler::fd == -1)
     {
@@ -250,18 +271,25 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
         int sock = setupUnixSocket(socketInterface);
         if (sock < 0)
         {
-            sock = -errno;
             close(DumpHandler::fd);
             error(
                 "Failed to setup Unix socket while write from memory for interface '{INTERFACE}', response code '{SOCKET_RC}'",
                 "INTERFACE", socketInterface, "SOCKET_RC", sock);
             std::remove(socketInterface.c_str());
-            return PLDM_ERROR;
+            resetOffloadUri();
+
+            FileHandler::dmaResponseToRemoteTerminus(sharedAIORespDataobj,
+                                                     PLDM_ERROR, 0);
+            FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+
+            return;
         }
 
         DumpHandler::fd = sock;
     }
-    return transferFileDataToSocket(DumpHandler::fd, length, address);
+
+    transferFileDataToSocket(DumpHandler::fd, length, address,
+                             sharedAIORespDataobj, event);
 }
 
 int DumpHandler::write(const char* buffer, uint32_t, uint32_t& length,
@@ -403,9 +431,11 @@ int DumpHandler::fileAck(uint8_t fileStatus)
     return PLDM_ERROR;
 }
 
-int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
-                                uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/)
+void DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event)
 {
     auto path = findDumpObjPath(fileHandle);
     static constexpr auto dumpFilepathInterface =
@@ -413,7 +443,10 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
     if ((dumpType == PLDM_FILE_TYPE_DUMP) ||
         (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP))
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+        return;
     }
     else if (dumpType != PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
     {
@@ -422,9 +455,9 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
             auto filePath =
                 pldm::utils::DBusHandler().getDbusProperty<std::string>(
                     path.c_str(), "Path", dumpFilepathInterface);
-            auto rc = transferFileData(fs::path(filePath), true, offset, length,
-                                       address);
-            return rc;
+            transferFileData(fs::path(filePath), true, offset, length, address,
+                             sharedAIORespDataobj, event);
+            return;
         }
         catch (const sdbusplus::exception_t& e)
         {
@@ -433,11 +466,14 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
                 "FILE_HNDLE", lg2::hex, fileHandle, "ERROR", e);
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.readIntoMemory.GetFilepathFail");
-            return PLDM_ERROR;
+            FileHandler::dmaResponseToRemoteTerminus(sharedAIORespDataobj,
+                                                     PLDM_ERROR, 0);
+            FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+            return;
         }
     }
-    return transferFileData(resDumpRequestDirPath, true, offset, length,
-                            address);
+    transferFileData(resDumpRequestDirPath, true, offset, length, address,
+                     sharedAIORespDataobj, event);
 }
 
 int DumpHandler::read(uint32_t offset, uint32_t& length, Response& response,

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -22,13 +22,17 @@ class DumpHandler : public FileHandler
         FileHandler(fileHandle), dumpType(fileType)
     {}
 
-    virtual int writeFromMemory(uint32_t offset, uint32_t length,
-                                uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
 
-    virtual int readIntoMemory(uint32_t offset, uint32_t length,
-                               uint64_t address,
-                               oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void readIntoMemory(uint32_t offset, uint32_t length,
+                                uint64_t address,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& event);
 
     virtual int read(uint32_t offset, uint32_t& length, Response& response,
                      oem_platform::Handler* /*oemPlatformHandler*/);
@@ -54,8 +58,9 @@ class DumpHandler : public FileHandler
 
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
-
     void resetOffloadUri();
+    virtual void postDataTransferCallBack(bool IsWriteToMemOp,
+                                          uint32_t /*length*/);
 
     /** @brief DumpHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -22,20 +22,26 @@ class PCIeInfoHandler : public FileHandler
      */
     PCIeInfoHandler(uint32_t fileHandle, uint16_t fileType);
 
-    virtual int writeFromMemory(uint32_t offset, uint32_t length,
-                                uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
                       oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int fileAck(uint8_t fileStatus);
 
-    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                               uint64_t /*address*/,
-                               oem_platform::Handler* /*oemPlatformHandler*/)
+    virtual void readIntoMemory(uint32_t /*offset*/, uint32_t length,
+                                uint64_t /*address*/,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& /*event*/)
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
 
     virtual int read(uint32_t /*offset*/, uint32_t& /*length*/,
@@ -67,6 +73,10 @@ class PCIeInfoHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                          uint32_t /*length*/)
+    {}
 
     /** @brief PCIeInfoHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -19,13 +19,17 @@ class PelHandler : public FileHandler
      */
     PelHandler(uint32_t fileHandle) : FileHandler(fileHandle) {}
 
-    virtual int writeFromMemory(uint32_t offset, uint32_t length,
-                                uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
 
-    virtual int readIntoMemory(uint32_t offset, uint32_t length,
-                               uint64_t address,
-                               oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void readIntoMemory(uint32_t offset, uint32_t length,
+                                uint64_t address,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& event);
 
     virtual int read(uint32_t offset, uint32_t& length, Response& response,
                      oem_platform::Handler* /*oemPlatformHandler*/);
@@ -37,7 +41,7 @@ class PelHandler : public FileHandler
     virtual int fileAck(uint8_t fileStatus);
 
     /** @brief method to store a pel file in tempfs and send
-     *  d-bus notification to pel daemon that it is ready for consumption
+     *         d-bus notification to pel daemon that it is ready for consumption
      *
      *  @param[in] pelFileName - the pel file path
      */
@@ -47,6 +51,7 @@ class PelHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+    virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
 
     virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
                                              uint32_t /*metaDataValue1*/,
@@ -69,6 +74,10 @@ class PelHandler : public FileHandler
     /** @brief PelHandler destructor
      */
     ~PelHandler() {}
+
+  private:
+    fs::path Pelpath;
+    int fd;
 };
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -20,21 +20,29 @@ class ProgressCodeHandler : public FileHandler
      */
     ProgressCodeHandler(uint32_t fileHandle) : FileHandler(fileHandle) {}
 
-    int writeFromMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                        uint64_t /*address*/,
-                        oem_platform::Handler* /*oemPlatformHandler*/) override
+    void writeFromMemory(uint32_t /*offset*/, uint32_t length,
+                         uint64_t /*address*/,
+                         oem_platform::Handler* /*oemPlatformHandler*/,
+                         SharedAIORespData& sharedAIORespDataobj,
+                         sdeventplus::Event& /*event*/) override
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
 
     int write(const char* buffer, uint32_t offset, uint32_t& length,
               oem_platform::Handler* oemPlatformHandler) override;
 
-    int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                       uint64_t /*address*/,
-                       oem_platform::Handler* /*oemPlatformHandler*/) override
+    void readIntoMemory(uint32_t /*offset*/, uint32_t length,
+                        uint64_t /*address*/,
+                        oem_platform::Handler* /*oemPlatformHandler*/,
+                        SharedAIORespData& sharedAIORespDataobj,
+                        sdeventplus::Event& /*event*/) override
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
 
     int read(uint32_t /*offset*/, uint32_t& /*length*/, Response& /*response*/,
@@ -78,6 +86,16 @@ class ProgressCodeHandler : public FileHandler
      */
     virtual int setRawBootProperty(
         const std::tuple<uint64_t, std::vector<uint8_t>>& progressCodeBuffer);
+
+    /** @brief Method to do necessary operation according different
+     *         file type and being call when data transfer completed.
+     *
+     *  @param[in] IsWriteToMemOp - type of operation to decide what operation
+     *                              needs to be done after data transfer.
+     */
+    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                          uint32_t /*length*/)
+    {}
 
     /** @brief ProgressCodeHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
@@ -20,17 +20,25 @@ class keywordHandler : public FileHandler
     keywordHandler(uint32_t fileHandle, uint16_t fileType) :
         FileHandler(fileHandle), vpdFileType(fileType)
     {}
-    virtual int writeFromMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                                uint64_t /*address*/,
-                                oem_platform::Handler* /*oemPlatformHandler*/)
+    virtual void writeFromMemory(uint32_t /*offset*/, uint32_t length,
+                                 uint64_t /*address*/,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& /*event*/)
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
-    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                               uint64_t /*address*/,
-                               oem_platform::Handler* /*oemPlatformHandler*/)
+    virtual void readIntoMemory(uint32_t /*offset*/, uint32_t length,
+                                uint64_t /*address*/,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& /*event*/)
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
     virtual int read(uint32_t offset, uint32_t& length, Response& response,
                      oem_platform::Handler* /*oemPlatformHandler*/);
@@ -64,6 +72,16 @@ class keywordHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+    /** @brief Method to do necessary operation according different
+     *         file type and being call when data transfer completed.
+     *
+     *  @param[in] IsWriteToMemOp - type of operation to decide what operation
+     *                              needs to be done after data transfer.
+     */
+    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                          uint32_t /*length*/)
+    {}
+
     /** @brief keywordHandler destructor
      */
     ~keywordHandler() {}

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unistd.h>
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -10,6 +12,40 @@ namespace responder
 {
 namespace utils
 {
+
+/** @struct CustomFD
+ *
+ *  CustomFD class is created for special purpose using RAII and it wil be
+ * useful during AIO file transfer operation.
+ */
+struct CustomFD
+{
+    CustomFD(const CustomFD&) = delete;
+    CustomFD& operator=(const CustomFD&) = delete;
+    CustomFD(CustomFD&&) = delete;
+    CustomFD& operator=(CustomFD&&) = delete;
+
+    CustomFD(int fd, bool closeOnOutScope = true) :
+        fd(fd), closeOnOutScope(closeOnOutScope)
+    {}
+
+    ~CustomFD()
+    {
+        if (fd >= 0 && closeOnOutScope)
+        {
+            close(fd);
+        }
+    }
+
+    int operator()() const
+    {
+        return fd;
+    }
+
+  private:
+    int fd = -1;
+    bool closeOnOutScope;
+};
 
 /** @brief Setup UNIX socket
  *  This function creates listening socket in non-blocking mode and allows only

--- a/pldmd/pldm_resp_interface.hpp
+++ b/pldmd/pldm_resp_interface.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "common/flight_recorder.hpp"
+#include "common/transport.hpp"
+#include "common/utils.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <vector>
+using namespace pldm;
+using namespace pldm::utils;
+using namespace pldm::flightrecorder;
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm
+{
+namespace response_api
+{
+
+/** @class AltResponse
+ *
+ *  @brief This class performs the necessary operation in pldm for
+ *         responding remote pldm. This class is mostly designed in special case
+ *         when pldm need to send reply to host after FILE IO operation
+ *         completed.
+ */
+class AltResponse
+{
+  public:
+    /** @brief Response constructor
+     */
+    AltResponse() = delete;
+    AltResponse(const AltResponse&) = delete;
+    AltResponse(PldmTransport* pldmTransport, pldm_tid_t& TID,
+                bool verbose = false) :
+        pldmTransport(pldmTransport),
+        TID(TID), verbose(verbose)
+    {}
+
+    /** @brief method to send response to remote pldm using Response interface
+     *  @param response - response of each request
+     *  @returns returns 0 if success else error number
+     */
+    int sendPLDMRespMsg(auto response)
+    {
+        FlightRecorder::GetInstance().saveRecord(response, true);
+        if (verbose)
+        {
+            printBuffer(Tx, response);
+        }
+
+        int rc =
+            (*pldmTransport).sendMsg(TID, response.data(), response.size());
+        if (rc < 0)
+        {
+            rc = errno;
+            warning("sendto system call failed, errno= {ERRNO}", "ERRNO", rc);
+        }
+        return rc;
+    }
+
+  private:
+    PldmTransport* pldmTransport; //!< PLDM transport object
+    pldm_tid_t TID;               //!< PLDM hostEID reference
+    bool verbose;
+};
+
+struct ResponseInterface
+{
+    std::unique_ptr<AltResponse> responseObj;
+};
+
+} // namespace response_api
+
+} // namespace pldm


### PR DESCRIPTION
The transfer files between BMC and Remote terminus as synchronous
    manner. Previously if file transfer was interrupted between BMC and
    Remote terminus then PLDM is ending up in the hung state and not able
    to respond to the incoming new requests. User has to do work around to
    restart the PLDM to work again.
    This commits adds support for asynchronous file transfer using
    eventloop mechanism and non-blocking socket communication, so file
    transfer will be taken care by event loop and PLDM is free to receive
    another request from the Remote terminus. In case file transfer will be
    stuck or interrupted during asynchronous transfer then time-out occurs
    and file transfer will be aborted and same status communicated to the
    Remote terminus.