### PR TITLE
oem-ibm: Capacity on demand licensing support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,148 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-26T19:13:37Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "oem/ibm/configurations/fileTable.json": [
+      {
+        "hashed_secret": "c5466ef14c63f778e12ce011da1b27761f48c012",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp": [
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 71,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "76115425ed87da96eced3ae323aab27391989146",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tools/fw-update/metadata-example.json": [
+      {
+        "hashed_secret": "e3b0ba22a16e71ad12dfcd790d2b4eb36c4a1768",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8b80cf295c271c85bec5d0200b00fbd8396fbbb0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c50e03f885dcc3fcc2100e69f22fe40d871a6262",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "660c1ed72dac60bcc44db5732a2abf247a071f69",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/host-bmc/custom_dbus.cpp
+++ b/host-bmc/custom_dbus.cpp
@@ -27,5 +27,69 @@ std::optional<std::string>
     return std::nullopt;
 }
 
+void CustomDBus::setOperationalStatus(const std::string& path, uint8_t status)
+{
+    if (operationalStatus.find(path) == operationalStatus.end())
+    {
+        operationalStatus.emplace(
+            path, std::make_unique<OperationalStatusIntf>(
+                      pldm::utils::DBusHandler::getBus(), path.c_str()));
+    }
+
+    if (status == PLDM_STATE_SET_OPERATIONAL_STRESS_STATUS_NORMAL)
+    {
+        operationalStatus.at(path)->functional(true);
+    }
+    else
+    {
+        operationalStatus.at(path)->functional(false);
+    }
+}
+
+bool CustomDBus::getOperationalStatus(const std::string& path) const
+{
+    if (operationalStatus.find(path) != operationalStatus.end())
+    {
+        return operationalStatus.at(path)->functional();
+    }
+
+    return false;
+}
+
+void CustomDBus::implementLicInterfaces(
+    const std::string& path, const uint32_t& authdevno, const std::string& name,
+    const std::string& serialno, const uint64_t& exptime,
+    const sdbusplus::com::ibm::License::Entry::server::LicenseEntry::Type& type,
+    const sdbusplus::com::ibm::License::Entry::server::LicenseEntry::
+        AuthorizationType& authtype)
+{
+    if (codLic.find(path) == codLic.end())
+    {
+        codLic.emplace(
+            path, std::make_unique<LicIntf>(pldm::utils::DBusHandler::getBus(),
+                                            path.c_str()));
+    }
+
+    codLic.at(path)->authDeviceNumber(authdevno);
+    codLic.at(path)->name(name);
+    codLic.at(path)->serialNumber(serialno);
+    codLic.at(path)->expirationTime(exptime);
+    codLic.at(path)->type(type);
+    codLic.at(path)->authorizationType(authtype);
+}
+
+void CustomDBus::setAvailabilityState(const std::string& path,
+                                      const bool& state)
+{
+    if (availabilityState.find(path) == availabilityState.end())
+    {
+        availabilityState.emplace(
+            path, std::make_unique<AvailabilityIntf>(
+                      pldm::utils::DBusHandler::getBus(), path.c_str()));
+    }
+
+    availabilityState.at(path)->available(state);
+}
+
 } // namespace dbus
 } // namespace pldm

--- a/host-bmc/custom_dbus.hpp
+++ b/host-bmc/custom_dbus.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
+#include "com/ibm/License/Entry/LicenseEntry/server.hpp"
 #include "common/utils.hpp"
+
+#include <libpldm/state_set.h>
 
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Inventory/Decorator/LocationCode/server.hpp>
+#include <xyz/openbmc_project/State/Decorator/Availability/server.hpp>
+#include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
 
 #include <memory>
 #include <optional>
@@ -19,6 +24,13 @@ using ObjectPath = std::string;
 using LocationIntf =
     sdbusplus::server::object_t<sdbusplus::xyz::openbmc_project::Inventory::
                                     Decorator::server::LocationCode>;
+using LicIntf = sdbusplus::server::object::object<
+    sdbusplus::com::ibm::License::Entry::server::LicenseEntry>;
+using AvailabilityIntf = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::State::Decorator::server::Availability>;
+using OperationalStatusIntf =
+    sdbusplus::server::object::object<sdbusplus::xyz::openbmc_project::State::
+                                          Decorator::server::OperationalStatus>;
 
 /** @class CustomDBus
  *  @brief This is a custom D-Bus object, used to add D-Bus interface and update
@@ -60,8 +72,65 @@ class CustomDBus
      */
     std::optional<std::string> getLocationCode(const std::string& path) const;
 
+    /** @brief Set the Functional property
+     *
+     *  @param[in] path   - The object path
+     *
+     *  @param[in] status - PLDM operational fault status
+     */
+    void setOperationalStatus(const std::string& path, uint8_t status);
+
+    /** @brief Get the Functional property
+     *
+     *  @param[in] path   - The object path
+     *
+     *  @return status    - PLDM operational fault status
+     */
+    bool getOperationalStatus(const std::string& path) const;
+
+    /** @brief Implement the license interface properties
+     *
+     *  @param[in] path      - The object path
+     *
+     *  @param[in] authdevno - License name
+     *
+     *  @param[in] name      - License name
+     *
+     *  @param[in] serialno  - License serial number
+     *
+     *  @param[in] exptime   - License expiration time
+     *
+     *  @param[in] type      - License type
+     *
+     *  @param[in] authtype  - License authorization type
+     *
+     * @note This API implements the following interface
+     *       com.ibm.License.Entry.LicenseEntry and associated
+     *       dbus properties.
+     */
+    void implementLicInterfaces(
+        const std::string& path, const uint32_t& authdevno,
+        const std::string& name, const std::string& serialno,
+        const uint64_t& exptime,
+        const sdbusplus::com::ibm::License::Entry::server::LicenseEntry::Type&
+            type,
+        const sdbusplus::com::ibm::License::Entry::server::LicenseEntry::
+            AuthorizationType& authtype);
+
+    /** @brief Set the availability state property
+     *
+     *  @param[in] path   - The object path
+     *
+     *  @param[in] state  - Availability state
+     */
+    void setAvailabilityState(const std::string& path, const bool& state);
+
   private:
     std::unordered_map<ObjectPath, std::unique_ptr<LocationIntf>> location;
+    std::map<ObjectPath, std::unique_ptr<OperationalStatusIntf>>
+        operationalStatus;
+    std::map<ObjectPath, std::unique_ptr<AvailabilityIntf>> availabilityState;
+    std::unordered_map<ObjectPath, std::unique_ptr<LicIntf>> codLic;
 };
 
 } // namespace dbus

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -55,6 +55,7 @@ if get_option('oem-ibm').allowed()
     '../oem/ibm/libpldmresponder/file_io_type_progress_src.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_vpd.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_pcie.cpp',
+    '../oem/ibm/libpldmresponder/file_io_type_lic.cpp',
   ]
 endif
 

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -933,6 +933,54 @@ Response Handler::newFileAvailable(const pldm_msg* request,
     return response;
 }
 
+Response Handler::fileAckWithMetaData(const pldm_msg* request,
+                                      size_t payloadLength)
+{
+    Response response(sizeof(pldm_msg_hdr) +
+                      PLDM_FILE_ACK_WITH_META_DATA_RESP_BYTES);
+
+    if (payloadLength != PLDM_FILE_ACK_WITH_META_DATA_REQ_BYTES)
+    {
+        return CmdHandler::ccOnlyResponse(request, PLDM_ERROR_INVALID_LENGTH);
+    }
+    uint16_t fileType{};
+    uint32_t fileHandle{};
+    uint8_t fileStatus{};
+    uint32_t fileMetaData1{};
+    uint32_t fileMetaData2{};
+    uint32_t fileMetaData3{};
+    uint32_t fileMetaData4{};
+
+    auto rc = decode_file_ack_with_meta_data_req(
+        request, payloadLength, &fileType, &fileHandle, &fileStatus,
+        &fileMetaData1, &fileMetaData2, &fileMetaData3, &fileMetaData4);
+
+    if (rc != PLDM_SUCCESS)
+    {
+        return CmdHandler::ccOnlyResponse(request, rc);
+    }
+
+    std::unique_ptr<FileHandler> handler{};
+    try
+    {
+        handler = getHandlerByType(fileType, fileHandle);
+    }
+    catch (const InternalFailure& e)
+    {
+        error(
+            "Unknown file type, '{FILE_TYPE}' in FileAckWithMetaData response and error is {ERROR}",
+            "FILE_TYPE", fileType, "ERROR", e);
+        return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
+    }
+
+    rc = handler->fileAckWithMetaData(fileStatus, fileMetaData1, fileMetaData2,
+                                      fileMetaData3, fileMetaData4);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_file_ack_with_meta_data_resp(request->hdr.instance_id, rc,
+                                        responsePtr);
+    return response;
+}
+
 } // namespace oem_ibm
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -163,6 +163,9 @@ static constexpr auto resDumpEntry = "com.ibm.Dump.Entry.Resource";
 static constexpr auto certObjPath = "/xyz/openbmc_project/certs/ca/";
 static constexpr auto certAuthority =
     "xyz.openbmc_project.PLDM.Provider.Certs.Authority.CSR";
+
+static constexpr auto codLicObjPath = "/com/ibm/license";
+static constexpr auto codLicInterface = "com.ibm.License.LicenseManager";
 class Handler : public CmdHandler
 {
   public:
@@ -314,6 +317,39 @@ class Handler : public CmdHandler
                 }
             }
         });
+        codLicenseSubs = std::make_unique<sdbusplus::bus::match::match>(
+            pldm::utils::DBusHandler::getBus(),
+            sdbusplus::bus::match::rules::propertiesChanged(codLicObjPath,
+                                                            codLicInterface),
+            [this, hostSockFd, hostEid, instanceIdDb,
+             handler](sdbusplus::message::message& msg) {
+            sdbusplus::message::object_path path;
+            std::map<dbus::Property, pldm::utils::PropertyValue> props;
+            std::string iface;
+            msg.read(iface, props);
+            std::string licenseStr;
+
+            for (auto& prop : props)
+            {
+                if (prop.first == "LicenseString")
+                {
+                    pldm::utils::PropertyValue licStrVal{prop.second};
+                    licenseStr = std::get<std::string>(licStrVal);
+                    if (licenseStr.empty())
+                    {
+                        return;
+                    }
+                    dbusToFileHandlers
+                        .emplace_back(
+                            std::make_unique<
+                                pldm::requester::oem_ibm::DbusToFileHandler>(
+                                hostSockFd, hostEid, instanceIdDb, path,
+                                handler))
+                        ->newLicFileAvailable(licenseStr);
+                    break;
+                }
+            }
+        });
     }
 
     /** @brief Handler for readFileIntoMemory command
@@ -413,6 +449,15 @@ class Handler : public CmdHandler
      */
     Response newFileAvailable(const pldm_msg* request, size_t payloadLength);
 
+    /** @brief Handler for fileAckWithMetaData command
+     *
+     *  @param[in] request - PLDM request msg
+     *  @param[in] payloadLength - length of the message payload
+     *
+     *  @return PLDM response message
+     */
+    Response fileAckWithMetaData(const pldm_msg* request, size_t payloadLength);
+
   private:
     oem_platform::Handler* oemPlatformHandler;
     int hostSockFd;
@@ -429,6 +474,9 @@ class Handler : public CmdHandler
     std::unique_ptr<sdbusplus::bus::match_t>
         vmiCertMatcher;    //!< Pointer to capture the interface added signal
                            //!< for new csr string
+    std::unique_ptr<sdbusplus::bus::match::match>
+        codLicenseSubs;    //!< Pointer to capture the property changed signal
+                           //!< for new license string
     /** @brief PLDM request handler */
     pldm::requester::Handler<pldm::requester::Request>* handler;
     std::vector<std::unique_ptr<pldm::requester::oem_ibm::DbusToFileHandler>>

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -3,6 +3,7 @@
 #include "common/utils.hpp"
 #include "file_io_type_cert.hpp"
 #include "file_io_type_dump.hpp"
+#include "file_io_type_lic.hpp"
 #include "file_io_type_lid.hpp"
 #include "file_io_type_pcie.hpp"
 #include "file_io_type_pel.hpp"
@@ -118,7 +119,7 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
         error("File '{PATH}' does not exist.", "PATH", path);
         return PLDM_ERROR;
     }
-    utils::CustomFD fd(file);
+    pldm::utils::CustomFD fd(file);
 
     return transferFileData(fd(), upstream, offset, length, address);
 }
@@ -160,6 +161,11 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
         case PLDM_FILE_TYPE_PROGRESS_SRC:
         {
             return std::make_unique<ProgressCodeHandler>(fileHandle);
+        }
+        case PLDM_FILE_TYPE_COD_LICENSE_KEY:
+        case PLDM_FILE_TYPE_COD_LICENSED_RESOURCES:
+        {
+            return std::make_unique<LicenseHandler>(fileHandle, fileType);
         }
         case PLDM_FILE_TYPE_LID_RUNNING:
         {

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -79,6 +79,22 @@ class FileHandler
      */
     virtual int newFileAvailable(uint64_t length) = 0;
 
+    /** @brief Method to process a file ack with meta data notification from the
+     *  host. The bmc can chose to do different actions based on the file type.
+     *
+     *  @param[in] fileStatus - Status of the file transfer
+     *  @param[in] metaDataValue1 - value of meta data sent by host
+     *  @param[in] metaDataValue2 - value of meta data sent by host
+     *  @param[in] metaDataValue3 - value of meta data sent by host
+     *  @param[in] metaDataValue4 - value of meta data sent by host
+     *
+     *  @return PLDM status code
+     */
+    virtual int fileAckWithMetaData(uint8_t fileStatus, uint32_t metaDataValue1,
+                                    uint32_t metaDataValue2,
+                                    uint32_t metaDataValue3,
+                                    uint32_t metaDataValue4) = 0;
+
     /** @brief Method to read an oem file type's content into the PLDM response.
      *  @param[in] filePath - file to read from
      *  @param[in] offset - offset to read

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -47,7 +47,7 @@ class CertHandler : public FileHandler
 
     virtual int newFileAvailable(uint64_t length);
 
-    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+    virtual int fileAckWithMetaData(uint8_t fileStatus,
                                     uint32_t /*metaDataValue1*/,
                                     uint32_t /*metaDataValue2*/,
                                     uint32_t /*metaDataValue3*/,

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -40,6 +40,15 @@ class DumpHandler : public FileHandler
 
     virtual int fileAck(uint8_t fileStatus);
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
 

--- a/oem/ibm/libpldmresponder/file_io_type_lic.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.cpp
@@ -1,0 +1,302 @@
+#include "file_io_type_lic.hpp"
+
+#include "libpldm/base.h"
+#include "libpldm/file_io.h"
+
+#include "common/utils.hpp"
+
+#include <stdint.h>
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <iostream>
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm
+{
+using namespace pldm::responder::utils;
+using namespace pldm::utils;
+using Json = nlohmann::json;
+const Json emptyJson{};
+const std::vector<Json> emptyJsonList{};
+
+namespace responder
+{
+static constexpr auto codFilePath = "/var/lib/ibm/cod/";
+static constexpr auto licFilePath = "/var/lib/pldm/license/";
+constexpr auto newLicenseFile = "new_license.bin";
+constexpr auto newLicenseJsonFile = "new_license.json";
+
+int LicenseHandler::updateBinFileAndLicObjs(const fs::path& newLicJsonFilePath)
+{
+    int rc = PLDM_SUCCESS;
+    fs::path newLicFilePath(fs::path(licFilePath) / newLicenseFile);
+    std::ifstream jsonFileNew(newLicJsonFilePath);
+
+    auto dataNew = Json::parse(jsonFileNew, nullptr, false);
+    if (dataNew.is_discarded())
+    {
+        error("Parsing the new license json file '{NEW_LIC_JSON}' failed",
+              "NEW_LIC_JSON", newLicJsonFilePath.c_str());
+        throw InternalFailure();
+    }
+
+    // Store the json data in a file with binary format
+    convertJsonToBinaryFile(dataNew, newLicFilePath);
+
+    // Create or update the license objects
+    rc = createOrUpdateLicenseObjs();
+    if (rc != PLDM_SUCCESS)
+    {
+        error("Create or update License Objs failed with rc as {RC}", "RC", rc);
+        return rc;
+    }
+    return PLDM_SUCCESS;
+}
+
+int LicenseHandler::writeFromMemory(
+    uint32_t offset, uint32_t length, uint64_t address,
+    oem_platform::Handler* /*oemPlatformHandler*/)
+{
+    namespace fs = std::filesystem;
+    if (!fs::exists(licFilePath))
+    {
+        fs::create_directories(licFilePath);
+        fs::permissions(licFilePath,
+                        fs::perms::others_read | fs::perms::owner_write);
+    }
+    fs::path newLicJsonFilePath(fs::path(licFilePath) / newLicenseJsonFile);
+    std::ofstream licJsonFile(newLicJsonFilePath,
+                              std::ios::out | std::ios::binary);
+    if (!licJsonFile)
+    {
+        error(
+            "License json file '{NEW_LIC_JSON}' create failed in writeFromMemory",
+            "NEW_LIC_JSON", newLicJsonFilePath.c_str());
+        return -1;
+    }
+
+    auto rc = transferFileData(newLicJsonFilePath, false, offset, length,
+                               address);
+    if (rc != PLDM_SUCCESS)
+    {
+        error(
+            "Transfer of license file data failed with rc as {RC} in writeFromMemory",
+            "RC", rc);
+        return rc;
+    }
+
+    if (length == licLength)
+    {
+        rc = updateBinFileAndLicObjs(newLicJsonFilePath);
+        if (rc != PLDM_SUCCESS)
+        {
+            error(
+                "Update Bin file and License Objs failed with rc as {RC} in writeFromMemory",
+                "RC", rc);
+            return rc;
+        }
+    }
+
+    return PLDM_SUCCESS;
+}
+
+int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,
+                          uint32_t& length,
+                          oem_platform::Handler* /*oemPlatformHandler*/)
+{
+    int rc = PLDM_SUCCESS;
+
+    fs::path newLicJsonFilePath(fs::path(licFilePath) / newLicenseJsonFile);
+    std::ofstream licJsonFile(newLicJsonFilePath,
+                              std::ios::out | std::ios::binary | std::ios::app);
+    if (!licJsonFile)
+    {
+        error("License json file '{NEW_LIC_JSON}' create failed in write",
+              "NEW_LIC_JSON", newLicJsonFilePath.c_str());
+        return -1;
+    }
+
+    if (buffer != nullptr)
+    {
+        licJsonFile.write(buffer, length);
+    }
+    licJsonFile.close();
+
+    updateBinFileAndLicObjs(newLicJsonFilePath);
+    if (rc != PLDM_SUCCESS)
+    {
+        error(
+            "Update Bin file and License Objs failed with rc as {RC} in write",
+            "RC", rc);
+        return rc;
+    }
+
+    return rc;
+}
+
+int LicenseHandler::newFileAvailable(uint64_t length)
+{
+    licLength = length;
+    return PLDM_SUCCESS;
+}
+
+int LicenseHandler::read(uint32_t offset, uint32_t& length, Response& response,
+                         oem_platform::Handler* /*oemPlatformHandler*/)
+{
+    std::string filePath = codFilePath;
+    filePath += "licFile";
+
+    if (licType != PLDM_FILE_TYPE_COD_LICENSE_KEY)
+    {
+        return PLDM_ERROR_INVALID_DATA;
+    }
+    auto rc = readFile(filePath.c_str(), offset, length, response);
+    fs::remove(filePath);
+    if (rc)
+    {
+        return PLDM_ERROR;
+    }
+    return PLDM_SUCCESS;
+}
+
+int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                        uint32_t metaDataValue1,
+                                        uint32_t /*metaDataValue2*/,
+                                        uint32_t /*metaDataValue3*/,
+                                        uint32_t /*metaDataValue4*/)
+{
+    DBusMapping dbusMapping;
+    dbusMapping.objectPath = "/com/ibm/license";
+    dbusMapping.interface = "com.ibm.License.LicenseManager";
+    dbusMapping.propertyName = "LicenseActivationStatus";
+    dbusMapping.propertyType = "string";
+
+    pldm_license_install_status status =
+        static_cast<pldm_license_install_status>(metaDataValue1);
+
+    if (status == pldm_license_install_status::PLDM_LIC_INVALID_LICENSE)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.InvalidLicense";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set invalid license status due to the ERROR:{ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_ACTIVATED)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.Activated";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set license activated status due to the ERROR:{ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_PENDING)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.Pending";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set license pending status due to the ERROR:{ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_ACTIVATION_FAILED)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.ActivationFailed";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set license activation failure status due to the ERROR:{ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_INCORRECT_SYSTEM)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.IncorrectSystem";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set incorrect system status to license manager due to the ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_INVALID_HOSTSTATE)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.InvalidHostState";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set invalid host state status to license manager due to the ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_INCORRECT_SEQUENCE)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.IncorrectSequence";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set incorrect sequence status to license manager due to the ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    return PLDM_SUCCESS;
+}
+
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_lic.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "file_io_by_type.hpp"
+
+namespace pldm
+{
+namespace responder
+{
+
+using LicType = uint16_t;
+
+/** @class LicenseHandler
+ *
+ *  @brief Inherits and implements FileHandler. This class is used
+ *  to read license
+ */
+class LicenseHandler : public FileHandler
+{
+  public:
+    /** @brief Handler constructor
+     */
+    LicenseHandler(uint32_t fileHandle, uint16_t fileType) :
+        FileHandler(fileHandle), licType(fileType)
+    {}
+
+    virtual int writeFromMemory(uint32_t offset, uint32_t length,
+                                uint64_t address,
+                                oem_platform::Handler* /*oemPlatformHandler*/);
+
+    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
+                               uint64_t /*address*/,
+                               oem_platform::Handler* /*oemPlatformHandler*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int read(uint32_t offset, uint32_t& length, Response& response,
+                     oem_platform::Handler* /*oemPlatformHandler*/);
+
+    virtual int write(const char* buffer, uint32_t /*offset*/, uint32_t& length,
+                      oem_platform::Handler* /*oemPlatformHandler*/);
+
+    virtual int fileAck(uint8_t /*fileStatus*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int newFileAvailable(uint64_t length);
+
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t metaDataValue1,
+                                    uint32_t metaDataValue2,
+                                    uint32_t metaDataValue3,
+                                    uint32_t metaDataValue4);
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    int updateBinFileAndLicObjs(const fs::path& newLicFilePath);
+
+    /** @brief LicenseHandler destructor
+     */
+    ~LicenseHandler() {}
+
+  private:
+    uint16_t licType;   //!< type of the license
+    uint64_t licLength; //!< length of the full license data
+
+    /** @brief PLDM CoD License install status
+     */
+    enum pldm_license_install_status
+    {
+        PLDM_LIC_ACTIVATED = 0x00,
+        PLDM_LIC_INVALID_LICENSE = 0x01,
+        PLDM_LIC_INCORRECT_SYSTEM = 0x02,
+        PLDM_LIC_INCORRECT_SEQUENCE = 0x03,
+        PLDM_LIC_PENDING = 0x04,
+        PLDM_LIC_ACTIVATION_FAILED = 0x05,
+        PLDM_LIC_INVALID_HOSTSTATE = 0x06,
+    };
+};
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -308,6 +308,15 @@ class LidHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief LidHandler destructor
      */
     ~LidHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -48,6 +48,15 @@ class PelHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief PelHandler destructor
      */
     ~PelHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -53,6 +53,15 @@ class ProgressCodeHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief method to set the dbus Raw value Property with
      * the obtained progress code from the host.
      *

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -5,6 +5,7 @@
 #include "libpldmresponder/pdr_utils.hpp"
 #include "libpldmresponder/platform.hpp"
 #include "requester/handler.hpp"
+#include "utils.hpp"
 
 #include <libpldm/entity.h>
 #include <libpldm/oem/ibm/state_set.h>
@@ -56,6 +57,7 @@ class Handler : public oem_platform::Handler
         hostTransitioningToOff(true)
     {
         codeUpdate->setVersions();
+        pldm::responder::utils::clearLicenseStatus();
         setEventReceiverCnt = 0;
 
         using namespace sdbusplus::bus::match::rules;
@@ -78,6 +80,7 @@ class Handler : public oem_platform::Handler
                     setEventReceiverCnt = 0;
                     disableWatchDogTimer();
                     startStopTimer(false);
+                    pldm::responder::utils::clearLicenseStatus();
                 }
                 else if (propVal ==
                          "xyz.openbmc_project.State.Host.HostState.Running")

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.hpp"
 
 #include "common/utils.hpp"
+#include "host-bmc/custom_dbus.hpp"
 
 #include <libpldm/base.h>
 #include <sys/socket.h>
@@ -9,18 +10,39 @@
 #include <unistd.h>
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/Inventory/Decorator/Asset/client.hpp>
 #include <xyz/openbmc_project/Inventory/Item/Connector/client.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
+
+#include <fstream>
 
 PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
+
+using namespace pldm::dbus;
 namespace responder
 {
 namespace utils
 {
+
+static constexpr auto curLicFilePath =
+    "/var/lib/pldm/license/current_license.bin";
+static constexpr auto newLicFilePath = "/var/lib/pldm/license/new_license.bin";
+static constexpr auto newLicJsonFilePath =
+    "/var/lib/pldm/license/new_license.json";
+static constexpr auto licEntryPath = "/xyz/openbmc_project/license/entry";
+static constexpr uint8_t createLic = 1;
+static constexpr uint8_t clearLicStatus = 2;
+
+using InternalFailure =
+    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+using LicJsonObjMap = std::map<fs::path, nlohmann::json>;
+LicJsonObjMap licJsonMap;
+
 int setupUnixSocket(const std::string& socketInterface)
 {
     int sock;
@@ -194,6 +216,221 @@ std::vector<std::string> findPortObjects(const std::string& adapterObjPath)
     }
 
     return portObjects;
+}
+
+Json convertBinFileToJson(const fs::path& path)
+{
+    std::ifstream file(path, std::ios::in | std::ios::binary);
+    std::streampos fileSize;
+
+    // Get the file size
+    file.seekg(0, std::ios::end);
+    fileSize = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    // Read the data into vector from file and convert to json object
+    std::vector<uint8_t> vJson(fileSize);
+    file.read((char*)&vJson[0], fileSize);
+    return Json::from_bson(vJson);
+}
+
+void convertJsonToBinaryFile(const Json& jsonData, const fs::path& path)
+{
+    // Covert the json data to binary format and copy to vector
+    std::vector<uint8_t> vJson = {};
+    vJson = Json::to_bson(jsonData);
+
+    // Copy the vector to file
+    std::ofstream licout(path, std::ios::out | std::ios::binary);
+    size_t size = vJson.size();
+    licout.write(reinterpret_cast<char*>(&vJson[0]), size * sizeof(vJson[0]));
+}
+
+void clearLicenseStatus()
+{
+    if (!fs::exists(curLicFilePath))
+    {
+        return;
+    }
+
+    auto data = convertBinFileToJson(curLicFilePath);
+
+    const Json empty{};
+    const std::vector<Json> emptyList{};
+
+    auto entries = data.value("Licenses", emptyList);
+    fs::path path{licEntryPath};
+
+    for (const auto& entry : entries)
+    {
+        auto licId = entry.value("Id", empty);
+        fs::path l_path = path / licId;
+        licJsonMap.emplace(l_path, entry);
+    }
+
+    createOrUpdateLicenseDbusPaths(clearLicStatus);
+}
+
+int createOrUpdateLicenseDbusPaths(const uint8_t& flag)
+{
+    const Json empty{};
+    std::string authTypeAsNoOfDev = "NumberOfDevice";
+    struct tm tm;
+    time_t licTimeSinceEpoch = 0;
+
+    sdbusplus::com::ibm::License::Entry::server::LicenseEntry::Type licType =
+        sdbusplus::com::ibm::License::Entry::server::LicenseEntry::Type::
+            Prototype;
+    sdbusplus::com::ibm::License::Entry::server::LicenseEntry::AuthorizationType
+        licAuthType = sdbusplus::com::ibm::License::Entry::server::
+            LicenseEntry::AuthorizationType::Device;
+    for (const auto& [key, licJson] : licJsonMap)
+    {
+        auto licName = licJson.value("Name", empty);
+
+        auto type = licJson.value("Type", empty);
+        if (type == "Trial")
+        {
+            licType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::Type::Trial;
+        }
+        else if (type == "Commercial")
+        {
+            licType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::Type::Purchased;
+        }
+        else
+        {
+            licType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::Type::Prototype;
+        }
+
+        auto authType = licJson.value("AuthType", empty);
+        if (authType == "NumberOfDevice")
+        {
+            licAuthType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::AuthorizationType::Capacity;
+        }
+        else if (authType == "Unlimited")
+        {
+            licAuthType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::AuthorizationType::Unlimited;
+        }
+        else
+        {
+            licAuthType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::AuthorizationType::Device;
+        }
+
+        uint32_t licAuthDevNo = 0;
+        if (authType == authTypeAsNoOfDev)
+        {
+            licAuthDevNo = licJson.value("AuthDeviceNumber", 0);
+        }
+
+        auto licSerialNo = licJson.value("SerialNum", "");
+
+        auto expTime = licJson.value("ExpirationTime", "");
+        if (!expTime.empty())
+        {
+            memset(&tm, 0, sizeof(tm));
+            strptime(expTime.c_str(), "%Y-%m-%dT%H:%M:%SZ", &tm);
+            licTimeSinceEpoch = mktime(&tm);
+        }
+
+        CustomDBus::getCustomDBus().implementLicInterfaces(
+            key, licAuthDevNo, licName, licSerialNo, licTimeSinceEpoch, licType,
+            licAuthType);
+
+        auto status = licJson.value("Status", empty);
+
+        // License status is a single entry which needs to be mapped to
+        // OperationalStatus and Availability dbus interfaces
+        auto licOpStatus = false;
+        auto licAvailState = false;
+        if ((flag == clearLicStatus) || (status == "Unknown"))
+        {
+            licOpStatus = false;
+            licAvailState = false;
+        }
+        else if (status == "Enabled")
+        {
+            licOpStatus = true;
+            licAvailState = true;
+        }
+        else if (status == "Disabled")
+        {
+            licOpStatus = false;
+            licAvailState = true;
+        }
+
+        CustomDBus::getCustomDBus().setOperationalStatus(key, licOpStatus);
+        CustomDBus::getCustomDBus().setAvailabilityState(key, licAvailState);
+    }
+
+    return PLDM_SUCCESS;
+}
+
+int createOrUpdateLicenseObjs()
+{
+    bool l_curFilePresent = true;
+    const Json empty{};
+    const std::vector<Json> emptyList{};
+    std::ifstream jsonFileCurrent;
+    Json dataCurrent;
+    Json entries;
+
+    if (!fs::exists(curLicFilePath))
+    {
+        l_curFilePresent = false;
+    }
+
+    if (l_curFilePresent == true)
+    {
+        dataCurrent = convertBinFileToJson(curLicFilePath);
+    }
+
+    auto dataNew = convertBinFileToJson(newLicFilePath);
+
+    if (l_curFilePresent == true)
+    {
+        dataCurrent.merge_patch(dataNew);
+        convertJsonToBinaryFile(dataCurrent, curLicFilePath);
+        entries = dataCurrent.value("Licenses", emptyList);
+    }
+    else
+    {
+        convertJsonToBinaryFile(dataNew, curLicFilePath);
+        entries = dataNew.value("Licenses", emptyList);
+    }
+
+    fs::path path{licEntryPath};
+
+    for (const auto& entry : entries)
+    {
+        auto licId = entry.value("Id", empty);
+        fs::path l_path = path / licId;
+        licJsonMap.emplace(l_path, entry);
+    }
+
+    int rc = createOrUpdateLicenseDbusPaths(createLic);
+    if (rc == PLDM_SUCCESS)
+    {
+        fs::copy_file(newLicFilePath, curLicFilePath,
+                      fs::copy_options::overwrite_existing);
+
+        if (fs::exists(newLicFilePath))
+        {
+            fs::remove_all(newLicFilePath);
+        }
+
+        if (fs::exists(newLicJsonFilePath))
+        {
+            fs::remove_all(newLicJsonFilePath);
+        }
+    }
+
+    return rc;
 }
 } // namespace utils
 } // namespace responder

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nlohmann/json.hpp>
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -10,6 +12,8 @@ namespace responder
 {
 namespace utils
 {
+namespace fs = std::filesystem;
+using Json = nlohmann::json;
 
 /** @brief Setup UNIX socket
  *  This function creates listening socket in non-blocking mode and allows only
@@ -52,6 +56,57 @@ bool checkIfIBMFru(const std::string& objPath);
  *  @return std::vector<std::string> - port object paths
  */
 std::vector<std::string> findPortObjects(const std::string& adapterObjPath);
+
+/** @brief Converts a binary file to json data
+ *  This function converts bson data stored in a binary file to
+ *  nlohmann json data
+ *
+ *  @param[in] path     - binary file path to fetch the bson data
+ *
+ *  @return   on success returns nlohmann::json object
+ */
+Json convertBinFileToJson(const fs::path& path);
+
+/** @brief Converts a json data in to a binary file
+ *  This function converts the json data to a binary json(bson)
+ *  format and copies it to specified destination file.
+ *
+ *  @param[in] jsonData - nlohmann json data
+ *  @param[in] path     - destination path to store the bson data
+ *
+ *  @return   None
+ */
+void convertJsonToBinaryFile(const Json& jsonData, const fs::path& path);
+
+/** @brief Clear License Status
+ *  This function clears all the license status to "Unknown" during
+ *  reset reload operation or when host is coming down to off state.
+ *  During the genesis mode, it skips the license status update.
+ *
+ *  @return   None
+ */
+void clearLicenseStatus();
+
+/** @brief Create or update the d-bus license data
+ *  This function creates or updates the d-bus license details. If the input
+ *  input flag is 1, then new license data will be created and if the the input
+ *  flag is 2 license status will be cleared.
+ *
+ *  @param[in] flag - input flag, 1 : create and 2 : clear
+ *
+ *  @return   on success returns PLDM_SUCCESS
+ *            on failure returns -1
+ */
+int createOrUpdateLicenseDbusPaths(const uint8_t& flag);
+
+/** @brief Create or update the license bjects
+ *  This function creates or updates the license objects as per the data passed
+ *  from host.
+ *
+ *  @return   on success returns PLDM_SUCCESS
+ *            on failure returns -1
+ */
+int createOrUpdateLicenseObjs();
 
 } // namespace utils
 } // namespace responder

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -240,6 +240,40 @@ void DbusToFileHandler::newCsrFileAvailable(const std::string& csr,
                                PLDM_FILE_TYPE_CERT_SIGNING_REQUEST);
 }
 
+void DbusToFileHandler::newLicFileAvailable(const std::string& licenseStr)
+{
+    namespace fs = std::filesystem;
+    std::string dirPath = "/var/lib/ibm/cod";
+    const fs::path licDirPath = dirPath;
+
+    if (!fs::exists(licDirPath))
+    {
+        fs::create_directories(licDirPath);
+        fs::permissions(licDirPath,
+                        fs::perms::others_read | fs::perms::owner_write);
+    }
+
+    fs::path licFilePath = licDirPath / "licFile";
+    std::ofstream licFile;
+
+    licFile.open(licFilePath, std::ios::out | std::ofstream::binary);
+
+    if (!licFile)
+    {
+        error("license file open error: {LIC_PATH}", "LIC_PATH",
+              licFilePath.c_str());
+        return;
+    }
+
+    // Add csr to file
+    licFile << licenseStr << std::endl;
+
+    licFile.close();
+    uint32_t fileSize = fs::file_size(licFilePath);
+
+    newFileAvailableSendToHost(fileSize, 1, PLDM_FILE_TYPE_COD_LICENSE_KEY);
+}
+
 void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
                                                    const uint32_t fileHandle,
                                                    const uint16_t type)

--- a/oem/ibm/requester/dbus_to_file_handler.hpp
+++ b/oem/ibm/requester/dbus_to_file_handler.hpp
@@ -57,6 +57,11 @@ class DbusToFileHandler
     void newCsrFileAvailable(const std::string& csr,
                              const std::string fileHandle);
 
+    /** @brief Process the new license file available
+     *  @param[in] licenseStr - License string
+     */
+    void newLicFileAvailable(const std::string& licenseStr);
+
   private:
     /** @brief Send the new file available command request to hypervisor
      *  @param[in] fileSize - size of the file

--- a/oem/ibm/test/libpldmresponder_fileio_test.cpp
+++ b/oem/ibm/test/libpldmresponder_fileio_test.cpp
@@ -3,6 +3,7 @@
 #include "libpldmresponder/file_io_by_type.hpp"
 #include "libpldmresponder/file_io_type_cert.hpp"
 #include "libpldmresponder/file_io_type_dump.hpp"
+#include "libpldmresponder/file_io_type_lic.hpp"
 #include "libpldmresponder/file_io_type_lid.hpp"
 #include "libpldmresponder/file_io_type_pcie.hpp"
 #include "libpldmresponder/file_io_type_pel.hpp"
@@ -895,6 +896,15 @@ TEST(getHandlerByType, allPaths)
     handler = getHandlerByType(PLDM_FILE_TYPE_ROOT_CERT, fileHandle);
     certType = dynamic_cast<CertHandler*>(handler.get());
     ASSERT_TRUE(certType != nullptr);
+
+    handler = getHandlerByType(PLDM_FILE_TYPE_COD_LICENSE_KEY, fileHandle);
+    auto licType = dynamic_cast<LicenseHandler*>(handler.get());
+    ASSERT_TRUE(licType != nullptr);
+
+    handler = getHandlerByType(PLDM_FILE_TYPE_COD_LICENSED_RESOURCES,
+                               fileHandle);
+    licType = dynamic_cast<LicenseHandler*>(handler.get());
+    ASSERT_TRUE(licType != nullptr);
 
     using namespace sdbusplus::xyz::openbmc_project::Common::Error;
     ASSERT_THROW(getHandlerByType(0xFFFF, fileHandle), InternalFailure);

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -195,6 +195,8 @@ int main(int argc, char** argv)
                                     instanceIdDb);
     sdbusplus::server::manager_t inventoryManager(
         bus, "/xyz/openbmc_project/inventory");
+    sdbusplus::server::manager::manager licObjManager(
+        bus, "/xyz/openbmc_project/license");
 
     Invoker invoker{};
     requester::Handler<requester::Request> reqHandler(&pldmTransport, event,


### PR DESCRIPTION
This commit supports:
1. Creation or update of new license interfaces and properties supplied by host
2. Clearing of license status to Unknown, during host power off transition
3. Restoration of license interfaces during reset reload and setting the license status to Unknown

Tested By:
1. Verified that dbus hosting is done by pldm
2. CoD(Capacity on demand) values are coming up in the BMC
3. Verified that reboot of BMC does not clear values

Change-Id: If1018e0e789cbad290cea6bd8b2f2715dfd5a170