### PR TITLE
oem-ibm: Add fileAckWithMetaData support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,148 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-26T19:13:37Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "oem/ibm/configurations/fileTable.json": [
+      {
+        "hashed_secret": "c5466ef14c63f778e12ce011da1b27761f48c012",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp": [
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 71,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "76115425ed87da96eced3ae323aab27391989146",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tools/fw-update/metadata-example.json": [
+      {
+        "hashed_secret": "e3b0ba22a16e71ad12dfcd790d2b4eb36c4a1768",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8b80cf295c271c85bec5d0200b00fbd8396fbbb0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c50e03f885dcc3fcc2100e69f22fe40d871a6262",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "660c1ed72dac60bcc44db5732a2abf247a071f69",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -556,6 +556,52 @@ Response Handler::readFile(const pldm_msg* request, size_t payloadLength)
 
     return response;
 }
+Response Handler::fileAckWithMetaData(const pldm_msg* request,
+                                      size_t payloadLength)
+{
+    Response response(sizeof(pldm_msg_hdr) +
+                      PLDM_FILE_ACK_WITH_META_DATA_RESP_BYTES);
+
+    if (payloadLength != PLDM_FILE_ACK_WITH_META_DATA_REQ_BYTES)
+    {
+        return CmdHandler::ccOnlyResponse(request, PLDM_ERROR_INVALID_LENGTH);
+    }
+    uint16_t fileType{};
+    uint32_t fileHandle{};
+    uint8_t fileStatus{};
+    uint32_t fileMetaData1{};
+    uint32_t fileMetaData2{};
+    uint32_t fileMetaData3{};
+    uint32_t fileMetaData4{};
+
+    auto rc = decode_file_ack_with_meta_data_req(
+        request, payloadLength, &fileType, &fileHandle, &fileStatus,
+        &fileMetaData1, &fileMetaData2, &fileMetaData3, &fileMetaData4);
+
+    if (rc != PLDM_SUCCESS)
+    {
+        return CmdHandler::ccOnlyResponse(request, rc);
+    }
+
+    std::unique_ptr<FileHandler> handler{};
+    try
+    {
+        handler = getHandlerByType(fileType, fileHandle);
+    }
+    catch (const InternalFailure& e)
+    {
+        error("unknown file type, '{TYPE}' and error - {ERROR}", "TYPE",
+              fileType, "ERROR", e);
+        return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
+    }
+
+    rc = handler->fileAckWithMetaData(fileStatus, fileMetaData1, fileMetaData2,
+                                      fileMetaData3, fileMetaData4);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_file_ack_with_meta_data_resp(request->hdr.instance_id, rc,
+                                        responsePtr);
+    return response;
+}
 
 Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
 {

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -234,6 +234,11 @@ class Handler : public CmdHandler
             return this->newFileAvailable(request, payloadLength);
         });
 
+        handlers.emplace(
+            PLDM_FILE_ACK_WITH_META_DATA,
+            [this](pldm_tid_t, const pldm_msg* request, size_t payloadLength) {
+            return this->fileAckWithMetaData(request, payloadLength);
+        });
         resDumpMatcher = std::make_unique<sdbusplus::bus::match_t>(
             pldm::utils::DBusHandler::getBus(),
             sdbusplus::bus::match::rules::interfacesAdded() +
@@ -412,6 +417,15 @@ class Handler : public CmdHandler
      *  @return PLDM response message
      */
     Response newFileAvailable(const pldm_msg* request, size_t payloadLength);
+
+    /** @brief Handler for fileAckWithMetaData command
+     *
+     *  @param[in] request - PLDM request msg
+     *  @param[in] payloadLength - length of the message payload
+     *
+     *  @return PLDM response message
+     */
+    Response fileAckWithMetaData(const pldm_msg* request, size_t payloadLength);
 
   private:
     oem_platform::Handler* oemPlatformHandler;

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -79,6 +79,22 @@ class FileHandler
      */
     virtual int newFileAvailable(uint64_t length) = 0;
 
+    /** @brief Method to process a file ack with meta data notification from the
+     *  host. The bmc can chose to do different actions based on the file type.
+     *
+     *  @param[in] fileStatus - Status of the file transfer
+     *  @param[in] metaDataValue1 - value of meta data sent by host
+     *  @param[in] metaDataValue2 - value of meta data sent by host
+     *  @param[in] metaDataValue3 - value of meta data sent by host
+     *  @param[in] metaDataValue4 - value of meta data sent by host
+     *
+     *  @return PLDM status code
+     */
+    virtual int fileAckWithMetaData(uint8_t fileStatus, uint32_t metaDataValue1,
+                                    uint32_t metaDataValue2,
+                                    uint32_t metaDataValue3,
+                                    uint32_t metaDataValue4) = 0;
+
     /** @brief Method to read an oem file type's content into the PLDM response.
      *  @param[in] filePath - file to read from
      *  @param[in] offset - offset to read

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -343,5 +343,143 @@ int DumpHandler::read(uint32_t offset, uint32_t& length, Response& response,
     return readFile(resDumpDirPath, offset, length, response);
 }
 
+int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                     uint32_t metaDataValue1,
+                                     uint32_t metaDataValue2,
+                                     uint32_t /*metaDataValue3*/,
+                                     uint32_t /*metaDataValue4*/)
+{
+    auto path = findDumpObjPath(fileHandle);
+    uint8_t statusCode = (uint8_t)metaDataValue2;
+    if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
+    {
+        DBusMapping dbusMapping;
+        dbusMapping.objectPath = resDumpEntryObjPath +
+                                 std::to_string(fileHandle);
+        dbusMapping.interface = resDumpEntry;
+        dbusMapping.propertyName = "DumpRequestStatus";
+        dbusMapping.propertyType = "string";
+
+        pldm::utils::PropertyValue value =
+            "com.ibm.Dump.Entry.Resource.HostResponse.Success";
+
+        info(
+            "fileAckWithMetaData with token: {META_DATA_VAL1} and status: {META_DATA_VAL2}",
+            "META_DATA_VAL1", metaDataValue1, "META_DATA_VAL2", metaDataValue2);
+        if (statusCode == DumpRequestStatus::ResourceSelectorInvalid)
+        {
+            value =
+                "com.ibm.Dump.Entry.Resource.HostResponse.ResourceSelectorInvalid";
+        }
+        else if (statusCode == DumpRequestStatus::AcfFileInvalid)
+        {
+            value = "com.ibm.Dump.Entry.Resource.HostResponse.AcfFileInvalid";
+        }
+        else if (statusCode == DumpRequestStatus::PasswordInvalid)
+        {
+            value = "com.ibm.Dump.Entry.Resource.HostResponse.PasswordInvalid";
+        }
+        else if (statusCode == DumpRequestStatus::PermissionDenied)
+        {
+            value = "com.ibm.Dump.Entry.Resource.HostResponse.PermissionDenied";
+        }
+        else if (statusCode == DumpRequestStatus::Success)
+        {
+            DBusMapping dbusMapping;
+            dbusMapping.objectPath = "/xyz/openbmc_project/dump/system/entry/" +
+                                     std::to_string(fileHandle);
+            dbusMapping.interface = "com.ibm.Dump.Entry.Resource";
+            dbusMapping.propertyName = "Token";
+            dbusMapping.propertyType = "uint32_t";
+
+            pldm::utils::PropertyValue value = metaDataValue1;
+
+            try
+            {
+                pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+            }
+            catch (const std::exception& e)
+            {
+                error("failed to set token for resource dump,error - {ERROR}",
+                      "ERROR", e);
+                return PLDM_ERROR;
+            }
+        }
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const sdbusplus::exception_t& e)
+        {
+            error(
+                "failed to set DumpRequestStatus property for resource dump entry. error - {ERROR}",
+                "ERROR", e);
+            return PLDM_ERROR;
+        }
+
+        if (statusCode != DumpRequestStatus::Success)
+        {
+            error("Failue in resource dump file ack with metadata");
+            pldm::utils::reportError(
+                "xyz.openbmc_project.PLDM.Error.fileAck.ResourceDumpFileAckWithMetaDataFail");
+
+            PropertyValue value{
+                "xyz.openbmc_project.Common.Progress.OperationStatus.Failed"};
+            DBusMapping dbusMapping{
+                resDumpEntryObjPath + std::to_string(fileHandle),
+                "xyz.openbmc_project.Common.Progress", "Status", "string"};
+            try
+            {
+                pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+            }
+            catch (const sdbusplus::exception_t& e)
+            {
+                error(
+                    "Failure in setting Progress as OperationStatus.Failed in fileAckWithMetaData, error - {ERROR}"
+                    "ERROR",
+                    e);
+            }
+        }
+
+        if (fs::exists(resDumpRequestDirPath))
+        {
+            fs::remove_all(resDumpRequestDirPath);
+        }
+        return PLDM_SUCCESS;
+    }
+
+    if (DumpHandler::fd >= 0 && !path.empty())
+    {
+        if (dumpType == PLDM_FILE_TYPE_DUMP ||
+            dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
+        {
+            PropertyValue value{true};
+            DBusMapping dbusMapping{path, dumpEntry, "Offloaded", "bool"};
+            try
+            {
+                pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+            }
+            catch (const sdbusplus::exception_t& e)
+            {
+                error(
+                    "Failed to set the Offloaded dbus property to true, error - {ERROR}",
+                    "ERROR", e);
+                pldm::utils::reportError(
+                    "xyz.openbmc_project.PLDM.Error.fileAckWithMetaData.DumpEntryOffloadedSetFail");
+                return PLDM_ERROR;
+            }
+
+            close(DumpHandler::fd);
+            auto socketInterface = getOffloadUri(fileHandle);
+            std::remove(socketInterface.c_str());
+            DumpHandler::fd = -1;
+            resetOffloadUri();
+        }
+        return PLDM_SUCCESS;
+    }
+
+    return PLDM_ERROR;
+}
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -40,6 +40,12 @@ class DumpHandler : public FileHandler
 
     virtual int fileAck(uint8_t fileStatus);
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t metaDataValue1,
+                                    uint32_t metaDataValue2,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/);
+
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
 
@@ -48,8 +54,20 @@ class DumpHandler : public FileHandler
     ~DumpHandler() {}
 
   private:
-    static int fd;     //!< fd to manage the dump offload to bmc
-    uint16_t dumpType; //!< type of the dump
+    static int fd;             //!< fd to manage the dump offload to bmc
+    uint16_t dumpType;         //!< type of the dump
+    std::string
+        resDumpRequestDirPath; //!< directory where the resource
+                               //!< dump request parameter file is stored
+
+    enum DumpRequestStatus
+    {
+        Success = 0x0,
+        AcfFileInvalid = 0x1,
+        PasswordInvalid = 0x2,
+        PermissionDenied = 0x3,
+        ResourceSelectorInvalid = 0x4,
+    };
 };
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -308,6 +308,15 @@ class LidHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief LidHandler destructor
      */
     ~LidHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -48,6 +48,15 @@ class PelHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief PelHandler destructor
      */
     ~PelHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -61,6 +61,15 @@ class ProgressCodeHandler : public FileHandler
     virtual int setRawBootProperty(
         const std::tuple<uint64_t, std::vector<uint8_t>>& progressCodeBuffer);
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief ProgressCodeHandler destructor
      */
 


### PR DESCRIPTION
This commit adds fileAckWithMetaData command support used for
dump usecase. This also adds the 1060 dump changes into 1110.

Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>