### PR TITLE
oem-ibm: Capacity on demand licensing support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,148 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-26T19:13:37Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "oem/ibm/configurations/fileTable.json": [
+      {
+        "hashed_secret": "c5466ef14c63f778e12ce011da1b27761f48c012",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp": [
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 71,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "76115425ed87da96eced3ae323aab27391989146",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tools/fw-update/metadata-example.json": [
+      {
+        "hashed_secret": "e3b0ba22a16e71ad12dfcd790d2b4eb36c4a1768",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8b80cf295c271c85bec5d0200b00fbd8396fbbb0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c50e03f885dcc3fcc2100e69f22fe40d871a6262",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "660c1ed72dac60bcc44db5732a2abf247a071f69",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -2,6 +2,7 @@
 
 #include "types.hpp"
 
+#include <fcntl.h>
 #include <libpldm/base.h>
 #include <libpldm/bios.h>
 #include <libpldm/entity.h>
@@ -47,35 +48,6 @@ using inventoryManager =
 constexpr auto dbusProperties = "org.freedesktop.DBus.Properties";
 constexpr auto mapperService = ObjectMapper::default_service;
 constexpr auto inventoryPath = "/xyz/openbmc_project/inventory";
-/** @struct CustomFD
- *
- *  RAII wrapper for file descriptor.
- */
-struct CustomFD
-{
-    CustomFD(const CustomFD&) = delete;
-    CustomFD& operator=(const CustomFD&) = delete;
-    CustomFD(CustomFD&&) = delete;
-    CustomFD& operator=(CustomFD&&) = delete;
-
-    CustomFD(int fd) : fd(fd) {}
-
-    ~CustomFD()
-    {
-        if (fd >= 0)
-        {
-            close(fd);
-        }
-    }
-
-    int operator()() const
-    {
-        return fd;
-    }
-
-  private:
-    int fd = -1;
-};
 
 /** @brief Calculate the pad for PLDM data
  *

--- a/host-bmc/custom_dbus.cpp
+++ b/host-bmc/custom_dbus.cpp
@@ -27,5 +27,69 @@ std::optional<std::string>
     return std::nullopt;
 }
 
+void CustomDBus::setOperationalStatus(const std::string& path, uint8_t status)
+{
+    if (!operationalStatus.contains(path))
+    {
+        operationalStatus.emplace(
+            path, std::make_unique<OperationalStatusIntf>(
+                      pldm::utils::DBusHandler::getBus(), path.c_str()));
+    }
+
+    if (status == PLDM_STATE_SET_OPERATIONAL_STRESS_STATUS_NORMAL)
+    {
+        operationalStatus.at(path)->functional(true);
+    }
+    else
+    {
+        operationalStatus.at(path)->functional(false);
+    }
+}
+
+bool CustomDBus::getOperationalStatus(const std::string& path) const
+{
+    if (operationalStatus.contains(path))
+    {
+        return operationalStatus.at(path)->functional();
+    }
+
+    return false;
+}
+
+void CustomDBus::implementLicInterfaces(
+    const std::string& path, const uint32_t& authdevno, const std::string& name,
+    const std::string& serialno, const uint64_t& exptime,
+    const sdbusplus::com::ibm::License::Entry::server::LicenseEntry::Type& type,
+    const sdbusplus::com::ibm::License::Entry::server::LicenseEntry::
+        AuthorizationType& authtype)
+{
+    if (!codLic.contains(path))
+    {
+        codLic.emplace(
+            path, std::make_unique<LicIntf>(pldm::utils::DBusHandler::getBus(),
+                                            path.c_str()));
+    }
+
+    codLic.at(path)->authDeviceNumber(authdevno);
+    codLic.at(path)->name(name);
+    codLic.at(path)->serialNumber(serialno);
+    codLic.at(path)->expirationTime(exptime);
+    codLic.at(path)->type(type);
+    codLic.at(path)->authorizationType(authtype);
+}
+
+void CustomDBus::setAvailabilityState(const std::string& path,
+                                      const bool& state)
+{
+    if (!availabilityState.contains(path))
+    {
+        availabilityState.emplace(
+            path, std::make_unique<AvailabilityIntf>(
+                      pldm::utils::DBusHandler::getBus(), path.c_str()));
+    }
+
+    availabilityState.at(path)->available(state);
+}
+
 } // namespace dbus
 } // namespace pldm

--- a/host-bmc/custom_dbus.hpp
+++ b/host-bmc/custom_dbus.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
+#include "com/ibm/License/Entry/LicenseEntry/server.hpp"
 #include "common/utils.hpp"
+
+#include <libpldm/state_set.h>
 
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Inventory/Decorator/LocationCode/server.hpp>
+#include <xyz/openbmc_project/State/Decorator/Availability/server.hpp>
+#include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
 
 #include <memory>
 #include <optional>
@@ -19,6 +24,13 @@ using ObjectPath = std::string;
 using LocationIntf =
     sdbusplus::server::object_t<sdbusplus::xyz::openbmc_project::Inventory::
                                     Decorator::server::LocationCode>;
+using LicIntf = sdbusplus::server::object_t<
+    sdbusplus::com::ibm::License::Entry::server::LicenseEntry>;
+using AvailabilityIntf = sdbusplus::server::object_t<
+    sdbusplus::xyz::openbmc_project::State::Decorator::server::Availability>;
+using OperationalStatusIntf =
+    sdbusplus::server::object_t<sdbusplus::xyz::openbmc_project::State::
+                                    Decorator::server::OperationalStatus>;
 
 /** @class CustomDBus
  *  @brief This is a custom D-Bus object, used to add D-Bus interface and update
@@ -60,8 +72,65 @@ class CustomDBus
      */
     std::optional<std::string> getLocationCode(const std::string& path) const;
 
+    /** @brief Set the Functional property
+     *
+     *  @param[in] path   - The object path
+     *
+     *  @param[in] status - PLDM operational fault status
+     */
+    void setOperationalStatus(const std::string& path, uint8_t status);
+
+    /** @brief Get the Functional property
+     *
+     *  @param[in] path   - The object path
+     *
+     *  @return status    - PLDM operational fault status
+     */
+    bool getOperationalStatus(const std::string& path) const;
+
+    /** @brief Implement the license interface properties
+     *
+     *  @param[in] path      - The object path
+     *
+     *  @param[in] authdevno - License name
+     *
+     *  @param[in] name      - License name
+     *
+     *  @param[in] serialno  - License serial number
+     *
+     *  @param[in] exptime   - License expiration time
+     *
+     *  @param[in] type      - License type
+     *
+     *  @param[in] authtype  - License authorization type
+     *
+     * @note This API implements the following interface
+     *       com.ibm.License.Entry.LicenseEntry and associated
+     *       dbus properties.
+     */
+    void implementLicInterfaces(
+        const std::string& path, const uint32_t& authdevno,
+        const std::string& name, const std::string& serialno,
+        const uint64_t& exptime,
+        const sdbusplus::com::ibm::License::Entry::server::LicenseEntry::Type&
+            type,
+        const sdbusplus::com::ibm::License::Entry::server::LicenseEntry::
+            AuthorizationType& authtype);
+
+    /** @brief Set the availability state property
+     *
+     *  @param[in] path   - The object path
+     *
+     *  @param[in] state  - Availability state
+     */
+    void setAvailabilityState(const std::string& path, const bool& state);
+
   private:
     std::unordered_map<ObjectPath, std::unique_ptr<LocationIntf>> location;
+    std::map<ObjectPath, std::unique_ptr<OperationalStatusIntf>>
+        operationalStatus;
+    std::map<ObjectPath, std::unique_ptr<AvailabilityIntf>> availabilityState;
+    std::unordered_map<ObjectPath, std::unique_ptr<LicIntf>> codLic;
 };
 
 } // namespace dbus

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -55,6 +55,7 @@ if get_option('oem-ibm').allowed()
     '../oem/ibm/libpldmresponder/file_io_type_progress_src.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_vpd.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_pcie.cpp',
+    '../oem/ibm/libpldmresponder/file_io_type_lic.cpp',
   ]
 endif
 

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -1194,6 +1194,53 @@ Response Handler::newFileAvailableWithMetaData(const pldm_msg* request,
     return response;
 }
 
+Response Handler::fileAckWithMetaData(const pldm_msg* request,
+                                      size_t payloadLength)
+{
+    Response response(sizeof(pldm_msg_hdr) +
+                      PLDM_FILE_ACK_WITH_META_DATA_RESP_BYTES);
+
+    if (payloadLength != PLDM_FILE_ACK_WITH_META_DATA_REQ_BYTES)
+    {
+        return CmdHandler::ccOnlyResponse(request, PLDM_ERROR_INVALID_LENGTH);
+    }
+    uint16_t fileType{};
+    uint32_t fileHandle{};
+    uint8_t fileStatus{};
+    uint32_t fileMetaData1{};
+    uint32_t fileMetaData2{};
+    uint32_t fileMetaData3{};
+    uint32_t fileMetaData4{};
+
+    auto rc = decode_file_ack_with_meta_data_req(
+        request, payloadLength, &fileType, &fileHandle, &fileStatus,
+        &fileMetaData1, &fileMetaData2, &fileMetaData3, &fileMetaData4);
+
+    if (rc != PLDM_SUCCESS)
+    {
+        return CmdHandler::ccOnlyResponse(request, rc);
+    }
+
+    std::unique_ptr<FileHandler> handler{};
+    try
+    {
+        handler = getHandlerByType(fileType, fileHandle);
+    }
+    catch (const InternalFailure& e)
+    {
+        error("unknown file type, '{TYPE}' and error - {ERROR}", "TYPE",
+              fileType, "ERROR", e);
+        return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
+    }
+
+    rc = handler->fileAckWithMetaData(fileStatus, fileMetaData1, fileMetaData2,
+                                      fileMetaData3, fileMetaData4);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_file_ack_with_meta_data_resp(request->hdr.instance_id, rc,
+                                        responsePtr);
+    return response;
+}
+
 } // namespace oem_ibm
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -1146,6 +1146,54 @@ Response Handler::newFileAvailable(const pldm_msg* request,
     return response;
 }
 
+Response Handler::newFileAvailableWithMetaData(const pldm_msg* request,
+                                               size_t payloadLength)
+{
+    Response response(sizeof(pldm_msg_hdr) +
+                      PLDM_NEW_FILE_AVAILABLE_WITH_META_DATA_RESP_BYTES);
+
+    if (payloadLength != PLDM_NEW_FILE_AVAILABLE_WITH_META_DATA_REQ_BYTES)
+    {
+        return CmdHandler::ccOnlyResponse(request, PLDM_ERROR_INVALID_LENGTH);
+    }
+    uint16_t fileType{};
+    uint32_t fileHandle{};
+    uint64_t length{};
+    uint32_t fileMetaData1{};
+    uint32_t fileMetaData2{};
+    uint32_t fileMetaData3{};
+    uint32_t fileMetaData4{};
+
+    auto rc = decode_new_file_with_metadata_req(
+        request, payloadLength, &fileType, &fileHandle, &length, &fileMetaData1,
+        &fileMetaData2, &fileMetaData3, &fileMetaData4);
+
+    if (rc != PLDM_SUCCESS)
+    {
+        return CmdHandler::ccOnlyResponse(request, rc);
+    }
+
+    std::unique_ptr<FileHandler> handler{};
+    try
+    {
+        handler = getHandlerByType(fileType, fileHandle);
+    }
+    catch (const InternalFailure& e)
+    {
+        error("unknown file type, '{TYPE}' error - {ERROR}", "TYPE", fileType,
+              "ERROR", e);
+        return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
+    }
+
+    rc = handler->newFileAvailableWithMetaData(
+        length, fileMetaData1, fileMetaData2, fileMetaData3, fileMetaData4);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_new_file_with_metadata_resp(request->hdr.instance_id, rc,
+                                       responsePtr);
+
+    return response;
+}
+
 } // namespace oem_ibm
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -1180,8 +1180,9 @@ Response Handler::newFileAvailableWithMetaData(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        error("unknown file type, '{TYPE}' error - {ERROR}", "TYPE", fileType,
-              "ERROR", e);
+        error(
+            "Unknown file type, '{TYPE}' in NewFileAvailableMetaData response, error - {ERROR}",
+            "TYPE", fileType, "ERROR", e);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 
@@ -1228,8 +1229,9 @@ Response Handler::fileAckWithMetaData(const pldm_msg* request,
     }
     catch (const InternalFailure& e)
     {
-        error("unknown file type, '{TYPE}' and error - {ERROR}", "TYPE",
-              fileType, "ERROR", e);
+        error(
+            "Unknown file type, '{TYPE}' in FileAckWithMetaData response and error - {ERROR}",
+            "TYPE", fileType, "ERROR", e);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
     }
 

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -239,6 +239,11 @@ class Handler : public CmdHandler
             [this](pldm_tid_t, const pldm_msg* request, size_t payloadLength) {
             return this->newFileAvailableWithMetaData(request, payloadLength);
         });
+        handlers.emplace(
+            PLDM_FILE_ACK_WITH_META_DATA,
+            [this](pldm_tid_t, const pldm_msg* request, size_t payloadLength) {
+            return this->fileAckWithMetaData(request, payloadLength);
+        });
 
         resDumpMatcher = std::make_unique<sdbusplus::bus::match_t>(
             pldm::utils::DBusHandler::getBus(),
@@ -428,6 +433,15 @@ class Handler : public CmdHandler
      */
     Response newFileAvailableWithMetaData(const pldm_msg* request,
                                           size_t payloadLength);
+
+    /** @brief Handler for fileAckWithMetaData command
+     *
+     *  @param[in] request - PLDM request msg
+     *  @param[in] payloadLength - length of the message payload
+     *
+     *  @return PLDM response message
+     */
+    Response fileAckWithMetaData(const pldm_msg* request, size_t payloadLength);
 
   private:
     oem_platform::Handler* oemPlatformHandler;

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -157,8 +157,9 @@ Response transferAll(DMAInterface* intf, uint8_t command, fs::path& path,
 
 namespace oem_ibm
 {
-static constexpr auto dumpObjPath = "/xyz/openbmc_project/dump/resource/entry/";
+static constexpr auto dumpObjPath = "/xyz/openbmc_project/dump/system/entry/";
 static constexpr auto resDumpEntry = "com.ibm.Dump.Entry.Resource";
+static constexpr auto sysDumpEntry = "xyz.openbmc_project.Dump.Entry.System";
 
 static constexpr auto certObjPath = "/xyz/openbmc_project/certs/ca/";
 static constexpr auto certAuthority =
@@ -257,7 +258,7 @@ class Handler : public CmdHandler
             sdbusplus::message::object_path path;
             msg.read(path, interfaces);
             std::string vspstring;
-            std::string password;
+            std::string userchallenge;
 
             for (const auto& interface : interfaces)
             {
@@ -269,9 +270,10 @@ class Handler : public CmdHandler
                         {
                             vspstring = std::get<std::string>(property.second);
                         }
-                        else if (property.first == "Password")
+                        else if (property.first == "UserChallenge")
                         {
-                            password = std::get<std::string>(property.second);
+                            userchallenge =
+                                std::get<std::string>(property.second);
                         }
                     }
                     dbusToFileHandlers
@@ -280,7 +282,34 @@ class Handler : public CmdHandler
                                 pldm::requester::oem_ibm::DbusToFileHandler>(
                                 hostSockFd, hostEid, instanceIdDb, path,
                                 handler))
-                        ->processNewResourceDump(vspstring, password);
+                        ->processNewResourceDump(vspstring, userchallenge);
+                    break;
+                }
+                if (interface.first == sysDumpEntry)
+                {
+                    for (const auto& property : interface.second)
+                    {
+                        if (property.first == "SystemImpact")
+                        {
+                            if (std::get<std::string>(property.second) ==
+                                "xyz.openbmc_project.Dump.Entry.System.SystemImpact.NonDisruptive")
+                            {
+                                vspstring = "system";
+                            }
+                        }
+                        else if (property.first == "UserChallenge")
+                        {
+                            userchallenge =
+                                std::get<std::string>(property.second);
+                        }
+                    }
+                    dbusToFileHandlers
+                        .emplace_back(
+                            std::make_unique<
+                                pldm::requester::oem_ibm::DbusToFileHandler>(
+                                hostSockFd, hostEid, instanceIdDb, path,
+                                handler))
+                        ->processNewResourceDump(vspstring, userchallenge);
                     break;
                 }
             }

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -555,6 +555,9 @@ static constexpr auto sysDumpEntry = "xyz.openbmc_project.Dump.Entry.System";
 static constexpr auto certObjPath = "/xyz/openbmc_project/certs/ca/";
 static constexpr auto certAuthority =
     "xyz.openbmc_project.PLDM.Provider.Certs.Authority.CSR";
+
+static constexpr auto codLicObjPath = "/com/ibm/license";
+static constexpr auto codLicInterface = "com.ibm.License.LicenseManager";
 class Handler : public CmdHandler
 {
   public:
@@ -746,6 +749,39 @@ class Handler : public CmdHandler
                 }
             }
         });
+        codLicenseSubs = std::make_unique<sdbusplus::bus::match_t>(
+            pldm::utils::DBusHandler::getBus(),
+            sdbusplus::bus::match::rules::propertiesChanged(codLicObjPath,
+                                                            codLicInterface),
+            [this, hostSockFd, hostEid, instanceIdDb,
+             handler](sdbusplus::message_t& msg) {
+            sdbusplus::message::object_path path;
+            std::map<dbus::Property, pldm::utils::PropertyValue> props;
+            std::string iface;
+            msg.read(iface, props);
+            std::string licenseStr;
+
+            for (auto& prop : props)
+            {
+                if (prop.first == "LicenseString")
+                {
+                    pldm::utils::PropertyValue licStrVal{prop.second};
+                    licenseStr = std::get<std::string>(licStrVal);
+                    if (licenseStr.empty())
+                    {
+                        return;
+                    }
+                    dbusToFileHandlers
+                        .emplace_back(
+                            std::make_unique<
+                                pldm::requester::oem_ibm::DbusToFileHandler>(
+                                hostSockFd, hostEid, instanceIdDb, path,
+                                handler))
+                        ->newLicFileAvailable(licenseStr);
+                    break;
+                }
+            }
+        });
     }
 
     /** @brief Handler for readFileIntoMemory command
@@ -880,6 +916,9 @@ class Handler : public CmdHandler
     std::unique_ptr<sdbusplus::bus::match_t>
         vmiCertMatcher;    //!< Pointer to capture the interface added signal
                            //!< for new csr string
+    std::unique_ptr<sdbusplus::bus::match_t>
+        codLicenseSubs;    //!< Pointer to capture the property changed signal
+                           //!< for new license string
     /** @brief PLDM request handler */
     pldm::requester::Handler<pldm::requester::Request>* handler;
     std::vector<std::unique_ptr<pldm::requester::oem_ibm::DbusToFileHandler>>

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/utils.hpp"
+#include "file_io_by_type.hpp"
 #include "oem/ibm/requester/dbus_to_file_handler.hpp"
 #include "oem_ibm_handler.hpp"
 #include "pldmd/handler.hpp"
@@ -11,6 +12,7 @@
 #include <libpldm/oem/ibm/file_io.h>
 #include <libpldm/oem/ibm/host.h>
 #include <stdint.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -33,6 +35,14 @@ namespace dma
 constexpr uint32_t minSize = 16;
 
 constexpr size_t maxSize = DMA_MAXSIZE;
+constexpr auto xdmaDev = "/dev/aspeed-xdma";
+
+struct FileMetaData
+{
+    uint32_t length;
+    uint32_t offset;
+    uint64_t address;
+};
 
 namespace fs = std::filesystem;
 
@@ -47,30 +57,292 @@ namespace fs = std::filesystem;
  */
 class DMA
 {
+    /** @brief DMA constructor is private to avoid object creation
+     *  without lengh.
+     */
+    DMA() {}
+
   public:
+    /** @brief DMA constructor
+     *
+     *  @param[in] length - using length allocating shared memory to transfer
+     * data.
+     */
+    DMA(uint32_t length)
+    {
+        isTxComplete = false;
+        memAddr = nullptr;
+        xdmaFd = -1;
+        sourceFd = -1;
+        iotPtr = nullptr;
+        iotPtrbc = nullptr;
+        timer = nullptr;
+        m_length = length;
+        static const size_t pageSize = getpagesize();
+        uint32_t numPages = m_length / pageSize;
+        pageAlignedLength = numPages * pageSize;
+        if (m_length > pageAlignedLength)
+        {
+            pageAlignedLength += pageSize;
+        }
+    }
+
+    /** @brief DMA destructor
+     */
+    ~DMA()
+    {
+        if (iotPtr != nullptr)
+        {
+            iotPtrbc = iotPtr.release();
+        }
+
+        if (iotPtrbc != nullptr)
+        {
+            delete iotPtrbc;
+            iotPtrbc = nullptr;
+        }
+
+        if (timer != nullptr)
+        {
+            auto time = timer.release();
+            delete time;
+        }
+
+        if (xdmaFd > 0)
+        {
+            close(xdmaFd);
+            xdmaFd = -1;
+        }
+        if (sourceFd > 0)
+        {
+            close(sourceFd);
+            sourceFd = -1;
+        }
+    }
+    /** @brief Method to fetch the shared memory file descriptor for data
+     * transfer
+     *
+     *  @return returns shared memory file descriptor
+     */
+    int getNewXdmaFd()
+    {
+        try
+        {
+            xdmaFd = open(xdmaDev, O_RDWR | O_NONBLOCK);
+        }
+        catch (...)
+        {
+            xdmaFd = -1;
+        }
+        return xdmaFd;
+    }
+    /** @brief Method to fetch the existing shared memory file descriptor for
+     *  data transfer
+     *  @return returns existing shared memory file descriptor
+     */
+    int getXdmaFd()
+    {
+        if (xdmaFd > 0)
+        {
+            return xdmaFd;
+        }
+        return getNewXdmaFd();
+    }
+
+    /** @brief function will keep one copy of fd for exception case so it
+     *  can close it.
+     *  @param[in] fd - source path file descriptor
+     */
+    inline void setDMASourceFd(int fd)
+    {
+        sourceFd = fd;
+    }
+
+    /** @brief function will keep one copy of shared memory fd for exception
+     *  case so it can close it.
+     *
+     *  @param[in] fd - xdma shared memory path file descriptor
+     */
+    inline void setXDMASourceFd(int fd)
+    {
+        xdmaFd = fd;
+    }
+
+    /** @brief function will return pagealignedlength to allocate memory for
+     *  data transfer.
+     */
+    inline int32_t getpageAlignedLength()
+    {
+        return pageAlignedLength;
+    }
+
+    /** @brief function will return shared memory address
+     *  from XDMA drive path
+     */
+    void* getXDMAsharedlocation()
+    {
+        if (xdmaFd < 0)
+        {
+            error(
+                "Failed to get memory location due to invalid file descriptor during DMA.");
+            return nullptr;
+        }
+
+        memAddr = mmap(nullptr, pageAlignedLength, PROT_WRITE | PROT_READ,
+                       MAP_SHARED, xdmaFd, 0);
+        if (MAP_FAILED == memAddr)
+        {
+            error("Failed to get memory location with err num '{ERRNO}'",
+                  "ERRNO", errno);
+            return nullptr;
+        }
+
+        return memAddr;
+    }
+
+    /** @brief Method to update file related metadata
+     *
+     *  @param[in] data - contain file related info like length, address,
+     * offset.
+     */
+    inline void setFileMetaData(FileMetaData& data)
+    {
+        fileMetaData.address = data.address;
+        fileMetaData.offset = data.offset;
+        fileMetaData.length = data.length;
+    }
+
+    /** @brief Method to get file related metadata
+     */
+    inline FileMetaData& getFileMetaData()
+    {
+        return fileMetaData;
+    }
+
+    /** @brief Method to initialize IO instance for event loop
+     *
+     *  @param[in] ioptr -  pointer to manage eventloop
+     */
+    inline void insertIOInstance(std::unique_ptr<IO>&& ioptr)
+    {
+        iotPtr = std::move(ioptr);
+    }
+
+    /** @brief Method to delete cyclic dependecy while deleting object
+     *  DMA interface and IO event loop has cyclic dependecy
+     */
+    void deleteIOInstance()
+    {
+        if (timer != nullptr)
+        {
+            auto time = timer.release();
+            delete time;
+        }
+        if (iotPtr != nullptr)
+        {
+            iotPtrbc = iotPtr.release();
+        }
+    }
+
+    /** @brief Method to set value for response received
+     *
+     *  @param[in] bresponse - transfer status
+     */
+    inline void setTransferStatus(bool bresponse)
+    {
+        isTxComplete = bresponse;
+    }
+
+    /** @brief Method to get to know tranfer success/fail.
+     *
+     *  @return returns true if transfer success else false on timeout.
+     */
+    inline bool getTransferStatus()
+    {
+        return isTxComplete;
+    }
+
+    /** @brief Method to initialize timer for each tranfer object
+     *
+     *  @param[in] event - sdeventplus event for IO object
+     *  @param[in] callback - callback function pointer
+     *
+     *  @return returns true if timer creation success else false
+     */
+    bool initTimer(
+        sdeventplus::Event& event,
+        fu2::unique_function<void(Timer&, Timer::TimePoint)>&& callback);
+
     /** @brief API to transfer data between BMC and host using DMA
      *
-     * @param[in] path     - pathname of the file to transfer data from or to
-     * @param[in] offset   - offset in the file
-     * @param[in] length   - length of the data to transfer
-     * @param[in] address  - DMA address on the host
-     * @param[in] upstream - indicates direction of the transfer; true indicates
-     *                       transfer to the host
+     *  @param[in] path     - pathname of the file to transfer data
+     *  @param[in] offset   - offset in the file
+     *  @param[in] length   - length of the data to transfer
+     *  @param[in] address  - DMA address on the host
+     *  @param[in] upstream - indicates direction of the transfer; true
+     *  indicates transfer to the host
      *
-     * @return returns 0 on success, negative errno on failure
+     *  @return returns 0 on success, negative errno on failure
      */
     int transferDataHost(int fd, uint32_t offset, uint32_t length,
                          uint64_t address, bool upstream);
 
     /** @brief API to transfer data on to unix socket from host using DMA
      *
-     * @param[in] path     - pathname of the file to transfer data from or to
-     * @param[in] length   - length of the data to transfer
-     * @param[in] address  - DMA address on the host
+     *  @param[in] path - pathname of the file to transfer data
+     *  @param[in] length  - length of the data to transfer
+     *  @param[in] address  - DMA address on the host
      *
-     * @return returns 0 on success, negative errno on failure
+     *  @return returns 0 on success, negative errno on failure
      */
     int transferHostDataToSocket(int fd, uint32_t length, uint64_t address);
+
+    int openSourcefile(fs::path path, int flag)
+    {
+        sourceFd = open(path.c_str(), flag);
+        if (sourceFd == -1)
+        {
+            error("File does not exist at {PATH}", "PATH", path.string());
+        }
+        return sourceFd;
+    }
+
+    inline int getsourceFileDesc()
+    {
+        return sourceFd;
+    }
+
+  private:
+    /* flag to track data transfer completion */
+    bool isTxComplete;
+
+    /* Mapped DMA address to perform transfer operation */
+    void* memAddr;
+
+    /* File descriptor of DMA address */
+    int xdmaFd;
+
+    /* File descriptor of file which needs to be transfer */
+    int sourceFd;
+
+    /* Page alignment length to map DMA memory size during transfer */
+    uint32_t pageAlignedLength;
+
+    /* Pointer to create event loop obejct */
+    std::unique_ptr<IO> iotPtr;
+
+    /* Pointer to hold event loop obeject to track object memory to avoid memory
+     * leak */
+    IO* iotPtrbc;
+
+    /* Pointer to create timer obejct for event loop object */
+    std::unique_ptr<Timer> timer;
+
+    /* Length to calculate page alignment length based on pagesize  */
+    uint32_t m_length;
+
+    /* Contain file related info like length, address, offset. */
+    FileMetaData fileMetaData;
 };
 
 /** @brief Transfer the data between BMC and host using DMA.
@@ -93,64 +365,183 @@ class DMA
  */
 
 template <class DMAInterface>
-Response transferAll(DMAInterface* intf, uint8_t command, fs::path& path,
-                     uint32_t offset, uint32_t length, uint64_t address,
-                     bool upstream, uint8_t instanceId)
+void transferAll(std::shared_ptr<DMAInterface> intf, int32_t fd,
+                 uint32_t offset, uint32_t length, uint64_t address,
+                 bool upstream, SharedAIORespData& sharedAIORespDataobj,
+                 sdeventplus::Event& event)
 {
-    uint32_t origLength = length;
-    Response response(sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_RESP_BYTES, 0);
-    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
-
-    int flags{};
-    if (upstream)
+    uint8_t command = sharedAIORespDataobj.command;
+    uint8_t instance_id = sharedAIORespDataobj.instance_id;
+    if (nullptr == intf)
     {
-        flags = O_RDONLY;
-    }
-    else if (fs::exists(path))
-    {
-        flags = O_RDWR;
-    }
-    else
-    {
-        flags = O_WRONLY;
-    }
-    int file = open(path.string().c_str(), flags);
-    if (file == -1)
-    {
-        error("File at path '{PATH}' does not exist", "PATH", path.string());
-        encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
+        Response response(sizeof(pldm_msg_hdr) + command, 0);
+        auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+        encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
                                    responsePtr);
-        return response;
+        error("Xdma interface is NULL");
+        if (sharedAIORespDataobj.respInterface != nullptr)
+        {
+            sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+        }
+        if (fd > 0)
+            close(fd);
+        return;
     }
-    pldm::utils::CustomFD fd(file);
+    // intf->setDMASourceFd(file);
+    uint32_t origLength = length;
+    static auto& bus = pldm::utils::DBusHandler::getBus();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+    std::weak_ptr<dma::DMA> wInterface = intf;
 
-    while (length > dma::maxSize)
-    {
-        auto rc = intf->transferDataHost(fd(), offset, dma::maxSize, address,
-                                         upstream);
+    dma::FileMetaData data;
+    data.length = length;
+    data.offset = offset;
+    data.address = address;
+    intf->setFileMetaData(data);
+    auto timerCb = [=](Timer& /*source*/, Timer::TimePoint /*time*/) {
+        if (!intf->getTransferStatus())
+        {
+            error(
+                "EventLoop Timeout..!! Terminating data tranfer file operation where transferred data length:{TXDATA} Remaining length:{REMAIN_DATA}",
+                "TXDATA", origLength, "REMAIN_DATA", data.length);
+            Response response(sizeof(pldm_msg_hdr) + command, 0);
+            auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+            encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                       responsePtr);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            intf->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(intf)).reset();
+        }
+        return;
+    };
+
+    auto callback = [=](IO&, int, uint32_t revents) {
+        if (!(revents & (EPOLLIN | EPOLLOUT)))
+        {
+            return;
+        }
+        auto weakPtr = wInterface.lock();
+        dma::FileMetaData& data = weakPtr->getFileMetaData();
+        int file = weakPtr->getsourceFileDesc();
+        Response response(sizeof(pldm_msg_hdr) + command, 0);
+        auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+        int rc = 0;
+
+        while (data.length > dma::maxSize)
+        {
+            rc = weakPtr->transferDataHost(file, data.offset, dma::maxSize,
+                                           data.address, upstream);
+
+            data.length -= dma::maxSize;
+            data.offset += dma::maxSize;
+            data.address += dma::maxSize;
+            if (rc < 0)
+            {
+                encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                           responsePtr);
+                error(
+                    "Failed to transfer muliple chunks of data to remote terminus due to RC: '{RC}'.",
+                    "RC", rc);
+                if (sharedAIORespDataobj.respInterface != nullptr)
+                {
+                    sharedAIORespDataobj.respInterface->sendPLDMRespMsg(
+                        response);
+                }
+                weakPtr->deleteIOInstance();
+                (static_cast<std::shared_ptr<dma::DMA>>(wInterface)).reset();
+                return;
+            }
+        }
+        rc = weakPtr->transferDataHost(file, data.offset, data.length,
+                                       data.address, upstream);
         if (rc < 0)
         {
-            encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
+            encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
                                        responsePtr);
-            return response;
+            error(
+                "Failed to transfer single chunks of data to remote terminus due to RC: '{RC}'.",
+                "RC", rc);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            weakPtr->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(wInterface)).reset();
+            return;
         }
+        if (static_cast<int>(data.length) == rc)
+        {
+            weakPtr->setTransferStatus(true);
+            encode_rw_file_memory_resp(instance_id, command, PLDM_SUCCESS,
+                                       origLength, responsePtr);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            weakPtr->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(wInterface)).reset();
+            return;
+        }
+    };
 
-        offset += dma::maxSize;
-        length -= dma::maxSize;
-        address += dma::maxSize;
-    }
-
-    auto rc = intf->transferDataHost(fd(), offset, length, address, upstream);
-    if (rc < 0)
+    try
     {
-        encode_rw_file_memory_resp(instanceId, command, PLDM_ERROR, 0,
-                                   responsePtr);
-        return response;
-    }
+        int xdmaFd = intf->getNewXdmaFd();
+        if (xdmaFd < 0)
+        {
+            error(
+                "Failed to get the XDMA file descriptor while initialising event loop.");
+            Response response(sizeof(pldm_msg_hdr) + command, 0);
+            auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
 
-    encode_rw_file_memory_resp(instanceId, command, PLDM_SUCCESS, origLength,
-                               responsePtr);
-    return response;
+            encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                       responsePtr);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            intf->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(intf)).reset();
+            return;
+        }
+        if (intf->initTimer(event, std::move(timerCb)) == false)
+        {
+            error(
+                "Failed to start the event timer while initialising event loop.");
+            Response response(sizeof(pldm_msg_hdr) + command, 0);
+            auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+            encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                       responsePtr);
+            if (sharedAIORespDataobj.respInterface != nullptr)
+            {
+                sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+            }
+            intf->deleteIOInstance();
+            (static_cast<std::shared_ptr<dma::DMA>>(intf)).reset();
+            return;
+        }
+        intf->insertIOInstance(std::move(std::make_unique<IO>(
+            event, xdmaFd, EPOLLIN | EPOLLOUT, std::move(callback))));
+    }
+    catch (const std::runtime_error& e)
+    {
+        Response response(sizeof(pldm_msg_hdr) + command, 0);
+        auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+        error("Failed to start the event loop with error: {ERROR} ", "ERROR",
+              e);
+        encode_rw_file_memory_resp(instance_id, command, PLDM_ERROR, 0,
+                                   responsePtr);
+        if (sharedAIORespDataobj.respInterface != nullptr)
+        {
+            sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
+        }
+        intf->deleteIOInstance();
+        (static_cast<std::shared_ptr<dma::DMA>>(intf)).reset();
+    }
+    return;
 }
 
 } // namespace dma
@@ -169,10 +560,12 @@ class Handler : public CmdHandler
   public:
     Handler(oem_platform::Handler* oemPlatformHandler, int hostSockFd,
             uint8_t hostEid, pldm::InstanceIdDb* instanceIdDb,
-            pldm::requester::Handler<pldm::requester::Request>* handler) :
+            pldm::requester::Handler<pldm::requester::Request>* handler,
+            pldm::response_api::AltResponse* respInterface) :
         oemPlatformHandler(oemPlatformHandler),
         hostSockFd(hostSockFd), hostEid(hostEid), instanceIdDb(instanceIdDb),
-        handler(handler)
+        handler(handler),
+        sharedAIORespDataobj({0, 0, nullptr, 0, respInterface})
     {
         handlers.emplace(
             PLDM_READ_FILE_INTO_MEMORY,
@@ -245,7 +638,6 @@ class Handler : public CmdHandler
             [this](pldm_tid_t, const pldm_msg* request, size_t payloadLength) {
             return this->fileAckWithMetaData(request, payloadLength);
         });
-
         resDumpMatcher = std::make_unique<sdbusplus::bus::match_t>(
             pldm::utils::DBusHandler::getBus(),
             sdbusplus::bus::match::rules::interfacesAdded() +
@@ -492,6 +884,7 @@ class Handler : public CmdHandler
     pldm::requester::Handler<pldm::requester::Request>* handler;
     std::vector<std::unique_ptr<pldm::requester::oem_ibm::DbusToFileHandler>>
         dbusToFileHandlers;
+    SharedAIORespData sharedAIORespDataobj;
 };
 
 } // namespace oem_ibm

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -234,6 +234,12 @@ class Handler : public CmdHandler
             return this->newFileAvailable(request, payloadLength);
         });
 
+        handlers.emplace(
+            PLDM_NEW_FILE_AVAILABLE_WITH_META_DATA,
+            [this](pldm_tid_t, const pldm_msg* request, size_t payloadLength) {
+            return this->newFileAvailableWithMetaData(request, payloadLength);
+        });
+
         resDumpMatcher = std::make_unique<sdbusplus::bus::match_t>(
             pldm::utils::DBusHandler::getBus(),
             sdbusplus::bus::match::rules::interfacesAdded() +
@@ -412,6 +418,16 @@ class Handler : public CmdHandler
      *  @return PLDM response message
      */
     Response newFileAvailable(const pldm_msg* request, size_t payloadLength);
+
+    /** @brief Handler for newFileAvailableWithMetaData command
+     *
+     *  @param[in] request - PLDM request msg
+     *  @param[in] payloadLength - length of the message payload
+     *
+     *  @return PLDM response messsage
+     */
+    Response newFileAvailableWithMetaData(const pldm_msg* request,
+                                          size_t payloadLength);
 
   private:
     oem_platform::Handler* oemPlatformHandler;

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -1,6 +1,5 @@
-#include "file_io_by_type.hpp"
-
 #include "common/utils.hpp"
+#include "file_io.hpp"
 #include "file_io_type_cert.hpp"
 #include "file_io_type_dump.hpp"
 #include "file_io_type_lid.hpp"
@@ -13,6 +12,7 @@
 #include <libpldm/base.h>
 #include <libpldm/oem/ibm/file_io.h>
 #include <stdint.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 
 #include <phosphor-logging/lg2.hpp>
@@ -30,50 +30,330 @@ namespace pldm
 namespace responder
 {
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+using namespace sdeventplus;
+using namespace sdeventplus::source;
 
-int FileHandler::transferFileData(int32_t fd, bool upstream, uint32_t offset,
-                                  uint32_t& length, uint64_t address)
+void FileHandler::dmaResponseToRemoteTerminus(
+    const SharedAIORespData& sharedAIORespDataobj,
+    const pldm_completion_codes rStatus, uint32_t length)
 {
-    dma::DMA xdmaInterface;
-    while (length > dma::maxSize)
+    Response response(sizeof(pldm_msg_hdr) + sharedAIORespDataobj.command, 0);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_rw_file_by_type_memory_resp(sharedAIORespDataobj.instance_id,
+                                       sharedAIORespDataobj.command, rStatus,
+                                       length, responsePtr);
+    if (nullptr != sharedAIORespDataobj.respInterface)
     {
-        auto rc = xdmaInterface.transferDataHost(fd, offset, dma::maxSize,
-                                                 address, upstream);
-        if (rc < 0)
-        {
-            return PLDM_ERROR;
-        }
-        offset += dma::maxSize;
-        length -= dma::maxSize;
-        address += dma::maxSize;
+        sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
     }
-    auto rc = xdmaInterface.transferDataHost(fd, offset, length, address,
-                                             upstream);
-    return rc < 0 ? PLDM_ERROR : PLDM_SUCCESS;
 }
 
-int FileHandler::transferFileDataToSocket(int32_t fd, uint32_t& length,
-                                          uint64_t address)
+void FileHandler::dmaResponseToRemoteTerminus(
+    const SharedAIORespData& sharedAIORespDataobj,
+    const pldm_fileio_completion_codes rStatus, uint32_t length)
 {
-    dma::DMA xdmaInterface;
-    while (length > dma::maxSize)
+    Response response(sizeof(pldm_msg_hdr) + sharedAIORespDataobj.command, 0);
+    auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
+    encode_rw_file_by_type_memory_resp(sharedAIORespDataobj.instance_id,
+                                       sharedAIORespDataobj.command, rStatus,
+                                       length, responsePtr);
+    if (nullptr != sharedAIORespDataobj.respInterface)
     {
-        auto rc = xdmaInterface.transferHostDataToSocket(fd, dma::maxSize,
-                                                         address);
-        if (rc < 0)
-        {
-            return PLDM_ERROR;
-        }
-        length -= dma::maxSize;
-        address += dma::maxSize;
+        sharedAIORespDataobj.respInterface->sendPLDMRespMsg(response);
     }
-    auto rc = xdmaInterface.transferHostDataToSocket(fd, length, address);
-    return rc < 0 ? PLDM_ERROR : PLDM_SUCCESS;
 }
 
-int FileHandler::transferFileData(const fs::path& path, bool upstream,
-                                  uint32_t offset, uint32_t& length,
-                                  uint64_t address)
+void FileHandler::deleteAIOobjects(
+    const std::shared_ptr<dma::DMA>& xdmaInterface,
+    const SharedAIORespData& sharedAIORespDataobj)
+{
+    if (nullptr != xdmaInterface)
+    {
+        xdmaInterface->deleteIOInstance();
+        (static_cast<std::shared_ptr<dma::DMA>>(xdmaInterface)).reset();
+    }
+
+    if (nullptr != sharedAIORespDataobj.functionPtr)
+    {
+        (static_cast<std::shared_ptr<FileHandler>>(
+             sharedAIORespDataobj.functionPtr))
+            .reset();
+    }
+}
+
+void FileHandler::transferFileData(int fd, bool upstream, uint32_t offset,
+                                   uint32_t& length, uint64_t address,
+                                   SharedAIORespData& sharedAIORespDataobj,
+                                   sdeventplus::Event& event)
+{
+    std::shared_ptr<dma::DMA> xdmaInterface =
+        std::make_shared<dma::DMA>(length);
+    if (nullptr == xdmaInterface)
+    {
+        error("Failed to initializing DMA interface during for fileType:{TYPE}",
+              "TYPE", sharedAIORespDataobj.fileType);
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+        deleteAIOobjects(nullptr, sharedAIORespDataobj);
+        close(fd);
+        return;
+    }
+    xdmaInterface->setDMASourceFd(fd);
+    uint32_t origLength = length;
+    uint8_t command = sharedAIORespDataobj.command;
+    static auto& bus = pldm::utils::DBusHandler::getBus();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+    dma::FileMetaData data{length, offset, address};
+    xdmaInterface->setFileMetaData(data);
+    std::weak_ptr<dma::DMA> wxInterface = xdmaInterface;
+    auto timerCb = [=, this](Timer& /*source*/, Timer::TimePoint /*time*/) {
+        if (!xdmaInterface->getTransferStatus())
+        {
+            error(
+                "EventLoop Timeout..!! Terminating FileHandler data tranfer operation for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+        }
+        return;
+    };
+
+    auto callback = [=, this](IO&, int, uint32_t revents) {
+        if (!(revents & (EPOLLIN | EPOLLOUT)))
+        {
+            return;
+        }
+        auto wInterface = wxInterface.lock();
+        dma::FileMetaData& data = wInterface->getFileMetaData();
+        int rc = 0;
+        while (data.length > dma::maxSize)
+        {
+            rc = wInterface->transferDataHost(fd, data.offset, dma::maxSize,
+                                              data.address, upstream);
+            data.length -= dma::maxSize;
+            data.offset += dma::maxSize;
+            data.address += dma::maxSize;
+            if (rc < 0)
+            {
+                error(
+                    "Failed to transfer muliple chunks of data to host fileType:{TYPE}",
+                    "TYPE", sharedAIORespDataobj.fileType);
+                dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR,
+                                            0);
+                deleteAIOobjects(wInterface, sharedAIORespDataobj);
+                return;
+            }
+        }
+        rc = wInterface->transferDataHost(fd, data.offset, data.length,
+                                          data.address, upstream);
+        if (rc < 0)
+        {
+            error(
+                "transferFileData : Failed to transfer single chunks of data to host for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            deleteAIOobjects(wInterface, sharedAIORespDataobj);
+            return;
+        }
+        if (static_cast<int>(data.length) == rc)
+        {
+            wInterface->setTransferStatus(true);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_SUCCESS,
+                                        origLength);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY,
+                    data.length);
+            }
+            deleteAIOobjects(wInterface, sharedAIORespDataobj);
+            return;
+        }
+    };
+    try
+    {
+        int xdmaFd = xdmaInterface->getNewXdmaFd();
+        if (xdmaFd < 0)
+        {
+            error("Failed to get the XDMA file descriptor for fileType:{TYPE}",
+                  "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+            return;
+        }
+        if (xdmaInterface->initTimer(event, std::move(timerCb)) == false)
+        {
+            error("Failed to start the event timer for fileType:{TYPE}", "TYPE",
+                  sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+            return;
+        }
+        xdmaInterface->insertIOInstance(std::move(std::make_unique<IO>(
+            event, xdmaFd, EPOLLIN | EPOLLOUT, std::move(callback))));
+    }
+    catch (const std::runtime_error& e)
+    {
+        error("Failed to start the event loop for fileType:{TYPE} : {ERROR}",
+              "TYPE", sharedAIORespDataobj.fileType, "ERROR", e);
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+        deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+    }
+}
+
+void FileHandler::transferFileDataToSocket(
+    int32_t fd, uint32_t& length, uint64_t address,
+    SharedAIORespData& sharedAIORespDataobj, sdeventplus::Event& event)
+{
+    std::shared_ptr<dma::DMA> xdmaInterface =
+        std::make_shared<dma::DMA>(length);
+    uint8_t command = sharedAIORespDataobj.command;
+    if (nullptr == xdmaInterface)
+    {
+        error(
+            "XDMA interface initialization failed while transfering data via socket for fileType:{TYPE}",
+            "TYPE", sharedAIORespDataobj.fileType);
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+        if (sharedAIORespDataobj.functionPtr != nullptr)
+        {
+            sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+        }
+        deleteAIOobjects(nullptr, sharedAIORespDataobj);
+        return;
+    }
+    uint32_t origLength = length;
+    static auto& bus = pldm::utils::DBusHandler::getBus();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+    dma::FileMetaData data{length, 0, address};
+    xdmaInterface->setFileMetaData(data);
+    std::weak_ptr<dma::DMA> wxInterface = xdmaInterface;
+    std::weak_ptr<FileHandler> wxfunctionPtr = sharedAIORespDataobj.functionPtr;
+    auto timerCb = [=, this](Timer& /*source*/, Timer::TimePoint /*time*/) {
+        if (!xdmaInterface->getTransferStatus())
+        {
+            error(
+                "EventLoop Timeout...Terminating tranfer operation while transfering data via socket for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+            }
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+        }
+        return;
+    };
+    auto callback = [=, this](IO&, int, uint32_t revents) {
+        if (!(revents & (EPOLLIN | EPOLLOUT)))
+        {
+            return;
+        }
+        auto wInterface = wxInterface.lock();
+        dma::FileMetaData& data = wInterface->getFileMetaData();
+        int rc = 0;
+        while (data.length > dma::maxSize)
+        {
+            rc = wInterface->transferHostDataToSocket(fd, dma::maxSize,
+                                                      data.address);
+            data.length -= dma::maxSize;
+            data.address += dma::maxSize;
+            if (rc < 0)
+            {
+                error(
+                    "Failed to transfer muliple chunks of data to host while transfering data via socket for fileType:{TYPE}",
+                    "TYPE", sharedAIORespDataobj.fileType);
+                dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR,
+                                            0);
+                if (sharedAIORespDataobj.functionPtr != nullptr)
+                {
+                    sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                        command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+                }
+                deleteAIOobjects(wInterface, sharedAIORespDataobj);
+                return;
+            }
+        }
+        rc = wInterface->transferHostDataToSocket(fd, data.length,
+                                                  data.address);
+        if (rc < 0)
+        {
+            error(
+                "Failed to transfer single chunks of data to host while transfering data via socket for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+            }
+            deleteAIOobjects(wInterface, sharedAIORespDataobj);
+            return;
+        }
+        if (static_cast<int>(data.length) == rc)
+        {
+            wInterface->setTransferStatus(true);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_SUCCESS,
+                                        origLength);
+            deleteAIOobjects(wInterface, sharedAIORespDataobj);
+            return;
+        }
+    };
+    try
+    {
+        int xdmaFd = xdmaInterface->getNewXdmaFd();
+        if (xdmaFd < 0)
+        {
+            error(
+                "Failed to open shared memory location while transfering data via socket for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+            }
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+            return;
+        }
+        if (xdmaInterface->initTimer(event, std::move(timerCb)) == false)
+        {
+            error(
+                "Failed to start the event timer while transfering data via socket for fileType:{TYPE}",
+                "TYPE", sharedAIORespDataobj.fileType);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+            if (sharedAIORespDataobj.functionPtr != nullptr)
+            {
+                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                    command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+            }
+            deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+            return;
+        }
+        xdmaInterface->insertIOInstance(std::move(std::make_unique<IO>(
+            event, xdmaFd, EPOLLIN | EPOLLOUT, std::move(callback))));
+    }
+    catch (const std::runtime_error& e)
+    {
+        error(
+            "Failed to start the event loop while transfering data via socket for fileType:{TYPE} : {ERROR}",
+            "TYPE", sharedAIORespDataobj.fileType, "ERROR", e);
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
+        if (sharedAIORespDataobj.functionPtr != nullptr)
+        {
+            sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
+        }
+        deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
+    }
+    return;
+}
+
+void FileHandler::transferFileData(const fs::path& path, bool upstream,
+                                   uint32_t offset, uint32_t& length,
+                                   uint64_t address,
+                                   SharedAIORespData& sharedAIORespDataobj,
+                                   sdeventplus::Event& event)
 {
     bool fileExists = false;
     if (upstream)
@@ -82,7 +362,9 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
         if (!fileExists)
         {
             error("File '{PATH}' does not exist.", "PATH", path);
-            return PLDM_INVALID_FILE_HANDLE;
+            FileHandler::dmaResponseToRemoteTerminus(
+                sharedAIORespDataobj, PLDM_INVALID_FILE_HANDLE, length);
+            FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
         }
 
         size_t fileSize = fs::file_size(path);
@@ -91,7 +373,9 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
             error(
                 "Offset '{OFFSET}' exceeds file size '{SIZE}' for file handle {FILE_HANDLE}",
                 "OFFSET", offset, "SIZE", fileSize, "FILE_HANDLE", fileHandle);
-            return PLDM_DATA_OUT_OF_RANGE;
+            FileHandler::dmaResponseToRemoteTerminus(
+                sharedAIORespDataobj, PLDM_DATA_OUT_OF_RANGE, length);
+            FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
         }
         if (offset + length > fileSize)
         {
@@ -116,11 +400,13 @@ int FileHandler::transferFileData(const fs::path& path, bool upstream,
     if (file == -1)
     {
         error("File '{PATH}' does not exist.", "PATH", path);
-        return PLDM_ERROR;
+        return;
+        FileHandler::dmaResponseToRemoteTerminus(sharedAIORespDataobj,
+                                                 PLDM_ERROR, 0);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
-    utils::CustomFD fd(file);
-
-    return transferFileData(fd(), upstream, offset, length, address);
+    transferFileData(file, upstream, offset, length, address,
+                     sharedAIORespDataobj, event);
 }
 
 std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
@@ -174,6 +460,71 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
         case PLDM_FILE_TYPE_CABLE_INFO:
         {
             return std::make_unique<PCIeInfoHandler>(fileHandle, fileType);
+        }
+        default:
+        {
+            throw InternalFailure();
+            break;
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<FileHandler> getSharedHandlerByType(uint16_t fileType,
+                                                    uint32_t fileHandle)
+{
+    switch (fileType)
+    {
+        case PLDM_FILE_TYPE_PEL:
+        {
+            return std::make_shared<PelHandler>(fileHandle);
+        }
+        case PLDM_FILE_TYPE_LID_PERM:
+        {
+            return std::make_shared<LidHandler>(fileHandle, true);
+        }
+        case PLDM_FILE_TYPE_LID_TEMP:
+        {
+            return std::make_shared<LidHandler>(fileHandle, false);
+        }
+        case PLDM_FILE_TYPE_LID_MARKER:
+        {
+            return std::make_shared<LidHandler>(fileHandle, false,
+                                                PLDM_FILE_TYPE_LID_MARKER);
+        }
+        case PLDM_FILE_TYPE_LID_RUNNING:
+        {
+            return std::make_shared<LidHandler>(fileHandle, false,
+                                                PLDM_FILE_TYPE_LID_RUNNING);
+        }
+        case PLDM_FILE_TYPE_DUMP:
+        case PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS:
+        case PLDM_FILE_TYPE_RESOURCE_DUMP:
+        case PLDM_FILE_TYPE_BMC_DUMP:
+        case PLDM_FILE_TYPE_SBE_DUMP:
+            // case PLDM_FILE_TYPE_HOSTBOOT_DUMP:
+            // case PLDM_FILE_TYPE_HARDWARE_DUMP:
+            {
+                return std::make_shared<DumpHandler>(fileHandle, fileType);
+            }
+        case PLDM_FILE_TYPE_CERT_SIGNING_REQUEST:
+        case PLDM_FILE_TYPE_SIGNED_CERT:
+        case PLDM_FILE_TYPE_ROOT_CERT:
+        {
+            return std::make_shared<CertHandler>(fileHandle, fileType);
+        }
+        case PLDM_FILE_TYPE_PROGRESS_SRC:
+        {
+            return std::make_shared<ProgressCodeHandler>(fileHandle);
+        }
+        case PLDM_FILE_TYPE_PCIE_TOPOLOGY:
+        case PLDM_FILE_TYPE_CABLE_INFO:
+        {
+            return std::make_shared<PCIeInfoHandler>(fileHandle, fileType);
+        }
+        case PLDM_FILE_TYPE_PSPD_VPD_PDD_KEYWORD:
+        {
+            return std::make_shared<keywordHandler>(fileHandle, fileType);
         }
         default:
         {

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -2,6 +2,7 @@
 #include "file_io.hpp"
 #include "file_io_type_cert.hpp"
 #include "file_io_type_dump.hpp"
+#include "file_io_type_lic.hpp"
 #include "file_io_type_lid.hpp"
 #include "file_io_type_pcie.hpp"
 #include "file_io_type_pel.hpp"
@@ -446,6 +447,11 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
         case PLDM_FILE_TYPE_PROGRESS_SRC:
         {
             return std::make_unique<ProgressCodeHandler>(fileHandle);
+        }
+        case PLDM_FILE_TYPE_COD_LICENSE_KEY:
+        case PLDM_FILE_TYPE_COD_LICENSED_RESOURCES:
+        {
+            return std::make_unique<LicenseHandler>(fileHandle, fileType);
         }
         case PLDM_FILE_TYPE_LID_RUNNING:
         {

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -112,6 +112,23 @@ class FileHandler
     virtual int transferFileDataToSocket(int fd, uint32_t& length,
                                          uint64_t address);
 
+    /** @brief method to process a new file available metadata notification from
+     *  the host
+     *
+     *  @param[in] length - size of the file content to be transferred
+     *  @param[in] metaDataValue1 - value of meta data sent by host
+     *  @param[in] metaDataValue2 - value of meta data sent by host
+     *  @param[in] metaDataValue3 - value of meta data sent by host
+     *  @param[in] metaDataValue4 - value of meta data sent by host
+     *
+     *  @return PLDM status code
+     */
+    virtual int newFileAvailableWithMetaData(uint64_t length,
+                                             uint32_t metaDataValue1,
+                                             uint32_t metaDataValue2,
+                                             uint32_t metaDataValue3,
+                                             uint32_t metaDataValue4) = 0;
+
     /** @brief Constructor to create a FileHandler object
      */
     FileHandler(uint32_t fileHandle) : fileHandle(fileHandle) {}

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -129,6 +129,22 @@ class FileHandler
                                              uint32_t metaDataValue3,
                                              uint32_t metaDataValue4) = 0;
 
+    /** @brief Method to process a file ack with meta data notification from the
+     *  host. The bmc can chose to do different actions based on the file type.
+     *
+     *  @param[in] fileStatus - Status of the file transfer
+     *  @param[in] metaDataValue1 - value of meta data sent by host
+     *  @param[in] metaDataValue2 - value of meta data sent by host
+     *  @param[in] metaDataValue3 - value of meta data sent by host
+     *  @param[in] metaDataValue4 - value of meta data sent by host
+     *
+     *  @return PLDM status code
+     */
+    virtual int fileAckWithMetaData(uint8_t fileStatus, uint32_t metaDataValue1,
+                                    uint32_t metaDataValue2,
+                                    uint32_t metaDataValue3,
+                                    uint32_t metaDataValue4) = 0;
+
     /** @brief Constructor to create a FileHandler object
      */
     FileHandler(uint32_t fileHandle) : fileHandle(fileHandle) {}

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -51,7 +51,7 @@ class CertHandler : public FileHandler
 
     virtual int newFileAvailable(uint64_t length);
 
-    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+    virtual int fileAckWithMetaData(uint8_t fileStatus,
                                     uint32_t /*metaDataValue1*/,
                                     uint32_t /*metaDataValue2*/,
                                     uint32_t /*metaDataValue3*/,

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -28,12 +28,16 @@ class CertHandler : public FileHandler
         FileHandler(fileHandle), certType(fileType)
     {}
 
-    virtual int writeFromMemory(uint32_t offset, uint32_t length,
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
+    virtual void readIntoMemory(uint32_t offset, uint32_t length,
                                 uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/);
-    virtual int readIntoMemory(uint32_t offset, uint32_t length,
-                               uint64_t address,
-                               oem_platform::Handler* /*oemPlatformHandler*/);
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& event);
     virtual int read(uint32_t offset, uint32_t& length, Response& response,
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
@@ -59,6 +63,8 @@ class CertHandler : public FileHandler
                                              uint32_t /*metaDataValue3*/,
                                              uint32_t /*metaDataValue4*/);
 
+    virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
+
     /** @brief CertHandler destructor
      */
     ~CertHandler() {}
@@ -67,6 +73,7 @@ class CertHandler : public FileHandler
     uint16_t certType;      //!< type of the certificate
     static CertMap certMap; //!< holds the fd and remaining read/write size for
                             //!< each certificate
+    std::string certfilePath;
     enum SignedCertStatus
     {
         PLDM_INVALID_CERT_DATA = 0X03

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -1,5 +1,6 @@
 #include "file_io_type_dump.hpp"
 
+#include "com/ibm/Dump/Notify/server.hpp"
 #include "common/utils.hpp"
 #include "utils.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
@@ -12,7 +13,6 @@
 
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/server.hpp>
-#include <xyz/openbmc_project/Dump/NewDump/server.hpp>
 
 #include <exception>
 #include <filesystem>
@@ -110,24 +110,26 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
 
 int DumpHandler::newFileAvailable(uint64_t length)
 {
-    static constexpr auto dumpInterface = "xyz.openbmc_project.Dump.NewDump";
+    static constexpr auto dumpInterface = "com.ibm.Dump.Notify";
     auto& bus = pldm::utils::DBusHandler::getBus();
 
     auto notifyObjPath = dumpObjPath;
+    auto notifyDumpType =
+        sdbusplus::common::com::ibm::dump::Notify::DumpType::System;
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
     {
-        // Setting the Notify path for resource dump
-        notifyObjPath = resDumpObjPath;
+        // Setting the dump type for resource dump
+        notifyDumpType =
+            sdbusplus::common::com::ibm::dump::Notify::DumpType::Resource;
     }
 
     try
     {
         auto service = pldm::utils::DBusHandler().getService(notifyObjPath,
                                                              dumpInterface);
-        using namespace sdbusplus::xyz::openbmc_project::Dump::server;
         auto method = bus.new_method_call(service.c_str(), notifyObjPath,
-                                          dumpInterface, "Notify");
-        method.append(fileHandle, length);
+                                          dumpInterface, "NotifyDump");
+        method.append(fileHandle, length, notifyDumpType, 0);
         bus.call_noreply(method, dbusTimeout);
     }
     catch (const std::exception& e)
@@ -343,5 +345,44 @@ int DumpHandler::read(uint32_t offset, uint32_t& length, Response& response,
     return readFile(resDumpDirPath, offset, length, response);
 }
 
+int DumpHandler::newFileAvailableWithMetaData(uint64_t length,
+                                              uint32_t metaDataValue1,
+                                              uint32_t /*metaDataValue2*/,
+                                              uint32_t /*metaDataValue3*/,
+                                              uint32_t /*metaDataValue4*/)
+{
+    static constexpr auto dumpInterface = "com.ibm.Dump.Notify";
+    auto& bus = pldm::utils::DBusHandler::getBus();
+
+    auto notifyObjPath = dumpObjPath;
+    auto notifyDumpType =
+        sdbusplus::common::com::ibm::dump::Notify::DumpType::System;
+    if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
+    {
+        notifyDumpType =
+            sdbusplus::common::com::ibm::dump::Notify::DumpType::Resource;
+    }
+
+    try
+    {
+        auto service = pldm::utils::DBusHandler().getService(notifyObjPath,
+                                                             dumpInterface);
+        auto method = bus.new_method_call(service.c_str(), notifyObjPath,
+                                          dumpInterface, "NotifyDump");
+        method.append(fileHandle, length, notifyDumpType, metaDataValue1);
+        bus.call(method, dbusTimeout);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        error(
+            "failed to make a d-bus call to notify a new dump request using newFileAvailableWithMetaData, error - {ERROR}",
+            "ERROR", e);
+        pldm::utils::reportError(
+            "xyz.openbmc_project.PLDM.Error.newFileAvailableWithMetaData.NewDumpNotifyFail");
+        return PLDM_ERROR;
+    }
+
+    return PLDM_SUCCESS;
+}
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -30,8 +30,10 @@ namespace responder
 static constexpr auto dumpEntry = "xyz.openbmc_project.Dump.Entry";
 static constexpr auto dumpObjPath = "/xyz/openbmc_project/dump/system";
 static constexpr auto systemDumpEntry = "xyz.openbmc_project.Dump.Entry.System";
-static constexpr auto resDumpObjPath = "/xyz/openbmc_project/dump/resource";
 static constexpr auto resDumpEntry = "com.ibm.Dump.Entry.Resource";
+static constexpr auto resDumpEntryObjPath =
+    "/xyz/openbmc_project/dump/system/entry/";
+static constexpr auto bmcDumpObjPath = "/xyz/openbmc_project/dump/bmc/entry";
 
 // Resource dump file path to be deleted once hyperviosr validates the input
 // parameters. Need to re-look in to this name when we support multiple
@@ -47,27 +49,70 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
         "xyz.openbmc_project.Dump.Manager";
     static constexpr auto DUMP_MANAGER_PATH = "/xyz/openbmc_project/dump";
 
+    static constexpr auto OBJECT_MANAGER_INTERFACE =
+        "org.freedesktop.DBus.ObjectManager";
+    auto& bus = pldm::utils::DBusHandler::getBus();
+
+    if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
+    {
+        resDumpRequestDirPath = "/var/lib/pldm/resourcedump/" +
+                                std::to_string(fileHandle);
+    }
+
     // Stores the current resource dump entry path
     std::string curResDumpEntryPath{};
 
-    ObjectValueTree objects;
-    // Select the dump entry interface for system dump or resource dump
-    DumpEntryInterface dumpEntryIntf = systemDumpEntry;
+    if (dumpType == PLDM_FILE_TYPE_BMC_DUMP)
+    {
+        curResDumpEntryPath = (std::string)bmcDumpObjPath + "/" +
+                              std::to_string(fileHandle);
+    }
+    else if (dumpType == PLDM_FILE_TYPE_SBE_DUMP)
+    {
+        curResDumpEntryPath = (std::string)dumpObjPath + "/" +
+                              std::to_string(fileHandle);
+    }
+    else if (dumpType == PLDM_FILE_TYPE_HOSTBOOT_DUMP)
+    {
+        curResDumpEntryPath = (std::string)dumpObjPath + "/" +
+                              std::to_string(fileHandle);
+    }
+    else if (dumpType == PLDM_FILE_TYPE_HARDWARE_DUMP)
+    {
+        curResDumpEntryPath = (std::string)dumpObjPath + "/" +
+                              std::to_string(fileHandle);
+    }
+
+    std::string dumpEntryIntf{};
+
     if ((dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP) ||
         (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS))
     {
         dumpEntryIntf = resDumpEntry;
     }
+    else if (dumpType == PLDM_FILE_TYPE_DUMP)
+    {
+        dumpEntryIntf = systemDumpEntry;
+    }
+    else
+    {
+        return curResDumpEntryPath;
+    }
+
+    dbus::ObjectValueTree objects;
 
     try
     {
-        objects = pldm::utils::DBusHandler::getManagedObj(DUMP_MANAGER_BUSNAME,
-                                                          DUMP_MANAGER_PATH);
+        auto method =
+            bus.new_method_call(DUMP_MANAGER_BUSNAME, DUMP_MANAGER_PATH,
+                                OBJECT_MANAGER_INTERFACE, "GetManagedObjects");
+        auto reply = bus.call(method, dbusTimeout);
+        reply.read(objects);
     }
     catch (const sdbusplus::exception_t& e)
     {
         error(
-            "Failed to retrieve dump object using GetManagedObjects call for path '{PATH}' and interface '{INTERFACE}', error - {ERROR}",
+            "Failure with GetManagedObjects in findDumpObjPath call '{PATH}' and interface '{INTERFACE}', error - {ERROR}",
             "PATH", DUMP_MANAGER_PATH, "INTERFACE", dumpEntryIntf, "ERROR", e);
         return curResDumpEntryPath;
     }
@@ -92,14 +137,16 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
                         if (fileHandle == dumpId)
                         {
                             curResDumpEntryPath = object.first.str;
+                            info("Hit the object path match for {CUR_RES_DUMP}",
+                                 "CUR_RES_DUMP", curResDumpEntryPath);
                             return curResDumpEntryPath;
                         }
                     }
                     else
                     {
                         error(
-                            "Invalid SourceDumpId in curResDumpEntryPath '{PATH}' but continuing with next entry for a match...",
-                            "PATH", object.first.str);
+                            "Invalid SourceDumpId in curResDumpEntryPath '{CUR_RES_DUMP}' but continuing with next entry for a match...",
+                            "CUR_RES_DUMP", curResDumpEntryPath);
                     }
                 }
             }
@@ -146,6 +193,8 @@ int DumpHandler::newFileAvailable(uint64_t length)
 std::string DumpHandler::getOffloadUri(uint32_t fileHandle)
 {
     auto path = findDumpObjPath(fileHandle);
+    info("DumpHandler::getOffloadUri path = {PATH} fileHandle = {FILE_HNDL}",
+         "PATH", path.c_str(), "FILE_HNDL", fileHandle);
     if (path.empty())
     {
         return {};
@@ -158,12 +207,15 @@ std::string DumpHandler::getOffloadUri(uint32_t fileHandle)
         socketInterface =
             pldm::utils::DBusHandler().getDbusProperty<std::string>(
                 path.c_str(), "OffloadUri", dumpEntry);
+        info("socketInterface={SOCKET_INTF}", "SOCKET_INTF", socketInterface);
     }
     catch (const std::exception& e)
     {
         error(
             "Error '{ERROR}' found while fetching the dump offload URI with object path '{PATH}' and interface '{INTERFACE}'",
             "ERROR", e, "PATH", path, "INTERFACE", socketInterface);
+        pldm::utils::reportError(
+            "xyz.openbmc_project.PLDM.Error.DumpHandler.getOffloadUriFail");
     }
 
     return socketInterface;
@@ -238,9 +290,9 @@ int DumpHandler::fileAck(uint8_t fileStatus)
             }
         }
 
-        if (fs::exists(resDumpDirPath))
+        if (fs::exists(resDumpRequestDirPath))
         {
-            fs::remove_all(resDumpDirPath);
+            fs::remove_all(resDumpRequestDirPath);
         }
         return PLDM_SUCCESS;
     }
@@ -249,31 +301,35 @@ int DumpHandler::fileAck(uint8_t fileStatus)
     {
         if (fileStatus == PLDM_ERROR_FILE_DISCARDED)
         {
-            uint32_t val = 0xFFFFFFFF;
-            PropertyValue value = static_cast<uint32_t>(val);
-            auto dumpIntf = resDumpEntry;
-
-            if (dumpType == PLDM_FILE_TYPE_DUMP)
+            if (dumpType == PLDM_FILE_TYPE_DUMP ||
+                dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
             {
-                dumpIntf = systemDumpEntry;
-            }
+                uint32_t val = 0xFFFFFFFF;
+                PropertyValue value = static_cast<uint32_t>(val);
+                auto dumpIntf = resDumpEntry;
 
-            DBusMapping dbusMapping{path.c_str(), dumpIntf, "SourceDumpId",
-                                    "uint32_t"};
-            try
-            {
-                pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
-            }
-            catch (const std::exception& e)
-            {
-                error(
-                    "Failed to make a D-bus call to DUMP manager for reseting source dump file '{PATH}' on interface '{INTERFACE}', error - {ERROR}",
-                    "PATH", path, "INTERFACE", dumpIntf, "ERROR", e);
-                pldm::utils::reportError(
-                    "xyz.openbmc_project.bmc.PLDM.fileAck.SourceDumpIdResetFail");
-                return PLDM_ERROR;
-            }
+                if (dumpType == PLDM_FILE_TYPE_DUMP)
+                {
+                    dumpIntf = systemDumpEntry;
+                }
 
+                DBusMapping dbusMapping{path.c_str(), dumpIntf, "SourceDumpId",
+                                        "uint32_t"};
+                try
+                {
+                    pldm::utils::DBusHandler().setDbusProperty(dbusMapping,
+                                                               value);
+                }
+                catch (const std::exception& e)
+                {
+                    error(
+                        "Failed to make a D-bus call to DUMP manager for reseting source dump file '{PATH}' on interface '{INTERFACE}', error - {ERROR}",
+                        "PATH", path, "INTERFACE", dumpIntf, "ERROR", e);
+                    pldm::utils::reportError(
+                        "xyz.openbmc_project.bmc.PLDM.fileAck.SourceDumpIdResetFail");
+                    return PLDM_ERROR;
+                }
+            }
             auto& bus = pldm::utils::DBusHandler::getBus();
             try
             {
@@ -311,12 +367,12 @@ int DumpHandler::fileAck(uint8_t fileStatus)
             }
 
             auto socketInterface = getOffloadUri(fileHandle);
-            std::remove(socketInterface.c_str());
             if (DumpHandler::fd >= 0)
             {
                 close(DumpHandler::fd);
                 DumpHandler::fd = -1;
             }
+            std::remove(socketInterface.c_str());
         }
         return PLDM_SUCCESS;
     }
@@ -328,21 +384,71 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
                                 uint64_t address,
                                 oem_platform::Handler* /*oemPlatformHandler*/)
 {
-    if (dumpType != PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
+    auto path = findDumpObjPath(fileHandle);
+    static constexpr auto dumpFilepathInterface =
+        "xyz.openbmc_project.Common.FilePath";
+    if ((dumpType == PLDM_FILE_TYPE_DUMP) ||
+        (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP))
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
-    return transferFileData(resDumpDirPath, true, offset, length, address);
+    else if (dumpType != PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
+    {
+        try
+        {
+            auto filePath =
+                pldm::utils::DBusHandler().getDbusProperty<std::string>(
+                    path.c_str(), "Path", dumpFilepathInterface);
+            auto rc = transferFileData(fs::path(filePath), true, offset, length,
+                                       address);
+            return rc;
+        }
+        catch (const sdbusplus::exception_t& e)
+        {
+            error(
+                "Failed to fetch the filepath of the dump entry '{FILE_HNDLE}', error - {ERROR}",
+                "FILE_HNDLE", lg2::hex, fileHandle, "ERROR", e);
+            pldm::utils::reportError(
+                "xyz.openbmc_project.PLDM.Error.readIntoMemory.GetFilepathFail");
+            return PLDM_ERROR;
+        }
+    }
+    return transferFileData(resDumpRequestDirPath, true, offset, length,
+                            address);
 }
 
 int DumpHandler::read(uint32_t offset, uint32_t& length, Response& response,
                       oem_platform::Handler* /*oemPlatformHandler*/)
 {
-    if (dumpType != PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
+    auto path = findDumpObjPath(fileHandle);
+    static constexpr auto dumpFilepathInterface =
+        "xyz.openbmc_project.Common.FilePath";
+    if ((dumpType == PLDM_FILE_TYPE_DUMP) ||
+        (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP))
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
-    return readFile(resDumpDirPath, offset, length, response);
+    else if (dumpType != PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
+    {
+        try
+        {
+            auto filePath =
+                pldm::utils::DBusHandler().getDbusProperty<std::string>(
+                    path.c_str(), "Path", dumpFilepathInterface);
+            auto rc = readFile(filePath.c_str(), offset, length, response);
+            return rc;
+        }
+        catch (const sdbusplus::exception_t& e)
+        {
+            error(
+                "Failed to fetch the filepath of the dump entry '{FILE_HNDLE}', error - {ERROR}",
+                "FILE_HNDL", lg2::hex, fileHandle, "ERROR", e);
+            pldm::utils::reportError(
+                "xyz.openbmc_project.PLDM.Error.read.GetFilepathFail");
+            return PLDM_ERROR;
+        }
+    }
+    return readFile(resDumpRequestDirPath, offset, length, response);
 }
 
 int DumpHandler::newFileAvailableWithMetaData(uint64_t length,

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -190,7 +190,7 @@ void DumpHandler::resetOffloadUri()
     }
 
     info("DumpHandler::resetOffloadUri path = {PATH} fileHandle = {FILE_HNDLE}",
-         "PATH", path.c_str(), "FILE_HNDL", fileHandle);
+         "PATH", path.c_str(), "FILE_HNDLE", fileHandle);
 
     PropertyValue offloadUriValue{""};
     DBusMapping dbusMapping{path, dumpEntry, "OffloadUri", "string"};
@@ -241,8 +241,29 @@ std::string DumpHandler::getOffloadUri(uint32_t fileHandle)
     return socketInterface;
 }
 
-int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
-                                 oem_platform::Handler* /*oemPlatformHandler*/)
+void DumpHandler::postDataTransferCallBack(bool IsWriteToMemOp,
+                                           uint32_t /*length*/)
+{
+    /// execute when DMA transfer failed.
+    if (IsWriteToMemOp)
+    {
+        error("DumpHandler::writeFromMemory: transferFileDataToSocket failed");
+        if (DumpHandler::fd >= 0)
+        {
+            close(DumpHandler::fd);
+            DumpHandler::fd = -1;
+        }
+        auto socketInterface = getOffloadUri(fileHandle);
+        std::remove(socketInterface.c_str());
+        resetOffloadUri();
+        return;
+    }
+}
+
+void DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
+                                  oem_platform::Handler* /*oemPlatformHandler*/,
+                                  SharedAIORespData& sharedAIORespDataobj,
+                                  sdeventplus::Event& event)
 {
     if (DumpHandler::fd == -1)
     {
@@ -250,18 +271,25 @@ int DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
         int sock = setupUnixSocket(socketInterface);
         if (sock < 0)
         {
-            sock = -errno;
             close(DumpHandler::fd);
             error(
                 "Failed to setup Unix socket while write from memory for interface '{INTERFACE}', response code '{SOCKET_RC}'",
                 "INTERFACE", socketInterface, "SOCKET_RC", sock);
             std::remove(socketInterface.c_str());
-            return PLDM_ERROR;
+            resetOffloadUri();
+
+            FileHandler::dmaResponseToRemoteTerminus(sharedAIORespDataobj,
+                                                     PLDM_ERROR, 0);
+            FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+
+            return;
         }
 
         DumpHandler::fd = sock;
     }
-    return transferFileDataToSocket(DumpHandler::fd, length, address);
+
+    transferFileDataToSocket(DumpHandler::fd, length, address,
+                             sharedAIORespDataobj, event);
 }
 
 int DumpHandler::write(const char* buffer, uint32_t, uint32_t& length,
@@ -403,9 +431,11 @@ int DumpHandler::fileAck(uint8_t fileStatus)
     return PLDM_ERROR;
 }
 
-int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
-                                uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/)
+void DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event)
 {
     auto path = findDumpObjPath(fileHandle);
     static constexpr auto dumpFilepathInterface =
@@ -413,7 +443,10 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
     if ((dumpType == PLDM_FILE_TYPE_DUMP) ||
         (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP))
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+        return;
     }
     else if (dumpType != PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
     {
@@ -422,9 +455,9 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
             auto filePath =
                 pldm::utils::DBusHandler().getDbusProperty<std::string>(
                     path.c_str(), "Path", dumpFilepathInterface);
-            auto rc = transferFileData(fs::path(filePath), true, offset, length,
-                                       address);
-            return rc;
+            transferFileData(fs::path(filePath), true, offset, length, address,
+                             sharedAIORespDataobj, event);
+            return;
         }
         catch (const sdbusplus::exception_t& e)
         {
@@ -433,11 +466,14 @@ int DumpHandler::readIntoMemory(uint32_t offset, uint32_t length,
                 "FILE_HNDLE", lg2::hex, fileHandle, "ERROR", e);
             pldm::utils::reportError(
                 "xyz.openbmc_project.PLDM.Error.readIntoMemory.GetFilepathFail");
-            return PLDM_ERROR;
+            FileHandler::dmaResponseToRemoteTerminus(sharedAIORespDataobj,
+                                                     PLDM_ERROR, 0);
+            FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+            return;
         }
     }
-    return transferFileData(resDumpRequestDirPath, true, offset, length,
-                            address);
+    transferFileData(resDumpRequestDirPath, true, offset, length, address,
+                     sharedAIORespDataobj, event);
 }
 
 int DumpHandler::read(uint32_t offset, uint32_t& length, Response& response,

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -54,8 +54,11 @@ class DumpHandler : public FileHandler
     ~DumpHandler() {}
 
   private:
-    static int fd;     //!< fd to manage the dump offload to bmc
-    uint16_t dumpType; //!< type of the dump
+    static int fd;             //!< fd to manage the dump offload to bmc
+    uint16_t dumpType;         //!< type of the dump
+    std::string
+        resDumpRequestDirPath; //!< directory where the resource
+                               //!< dump request parameter file is stored
 };
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -46,6 +46,12 @@ class DumpHandler : public FileHandler
                                              uint32_t /*metaDataValue3*/,
                                              uint32_t /*metaDataValue4*/);
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t metaDataValue1,
+                                    uint32_t metaDataValue2,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/);
+
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
 
@@ -61,6 +67,14 @@ class DumpHandler : public FileHandler
     std::string
         resDumpRequestDirPath; //!< directory where the resource
                                //!< dump request parameter file is stored
+    enum DumpRequestStatus
+    {
+        Success = 0x0,
+        AcfFileInvalid = 0x1,
+        PasswordInvalid = 0x2,
+        PermissionDenied = 0x3,
+        ResourceSelectorInvalid = 0x4,
+    };
 };
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -40,6 +40,12 @@ class DumpHandler : public FileHandler
 
     virtual int fileAck(uint8_t fileStatus);
 
+    virtual int newFileAvailableWithMetaData(uint64_t length,
+                                             uint32_t metaDataValue1,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/);
+
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
 

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -22,13 +22,17 @@ class DumpHandler : public FileHandler
         FileHandler(fileHandle), dumpType(fileType)
     {}
 
-    virtual int writeFromMemory(uint32_t offset, uint32_t length,
-                                uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
 
-    virtual int readIntoMemory(uint32_t offset, uint32_t length,
-                               uint64_t address,
-                               oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void readIntoMemory(uint32_t offset, uint32_t length,
+                                uint64_t address,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& event);
 
     virtual int read(uint32_t offset, uint32_t& length, Response& response,
                      oem_platform::Handler* /*oemPlatformHandler*/);
@@ -54,8 +58,9 @@ class DumpHandler : public FileHandler
 
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
-
     void resetOffloadUri();
+    virtual void postDataTransferCallBack(bool IsWriteToMemOp,
+                                          uint32_t /*length*/);
 
     /** @brief DumpHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -49,6 +49,8 @@ class DumpHandler : public FileHandler
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
 
+    void resetOffloadUri();
+
     /** @brief DumpHandler destructor
      */
     ~DumpHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_lic.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.cpp
@@ -1,0 +1,307 @@
+#include "file_io_type_lic.hpp"
+
+#include "libpldm/base.h"
+#include "libpldm/file_io.h"
+
+#include "common/utils.hpp"
+
+#include <stdint.h>
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <iostream>
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm
+{
+using namespace pldm::responder::utils;
+using namespace pldm::utils;
+using Json = nlohmann::json;
+const Json emptyJson{};
+const std::vector<Json> emptyJsonList{};
+
+namespace responder
+{
+static constexpr auto codFilePath = "/var/lib/ibm/cod/";
+static constexpr auto licFilePath = "/var/lib/pldm/license/";
+constexpr auto newLicenseFile = "new_license.bin";
+constexpr auto newLicenseJsonFile = "new_license.json";
+
+int LicenseHandler::updateBinFileAndLicObjs(const fs::path& newLicJsonFilePath)
+{
+    int rc = PLDM_SUCCESS;
+    fs::path newLicFilePath(fs::path(licFilePath) / newLicenseFile);
+    std::ifstream jsonFileNew(newLicJsonFilePath);
+
+    auto dataNew = Json::parse(jsonFileNew, nullptr, false);
+    if (dataNew.is_discarded())
+    {
+        error("Failed to parse the new license json file '{NEW_LIC_JSON}'",
+              "NEW_LIC_JSON", newLicJsonFilePath);
+        throw InternalFailure();
+    }
+
+    // Store the json data in a file with binary format
+    convertJsonToBinaryFile(dataNew, newLicFilePath);
+
+    // Create or update the license objects
+    rc = createOrUpdateLicenseObjs();
+    if (rc != PLDM_SUCCESS)
+    {
+        error("Failed to create or update license objs with rc as {RC}", "RC",
+              rc);
+        return rc;
+    }
+    return PLDM_SUCCESS;
+}
+
+void LicenseHandler::writeFromMemory(
+    uint32_t offset, uint32_t length, uint64_t address,
+    oem_platform::Handler* /*oemPlatformHandler*/,
+    SharedAIORespData& sharedAIORespDataobj, sdeventplus::Event& event)
+{
+    namespace fs = std::filesystem;
+    if (!fs::exists(licFilePath))
+    {
+        fs::create_directories(licFilePath);
+        fs::permissions(licFilePath,
+                        fs::perms::others_read | fs::perms::owner_write);
+    }
+    fs::path newLicJsonFilePath(fs::path(licFilePath) / newLicenseJsonFile);
+    std::ofstream licJsonFile(newLicJsonFilePath,
+                              std::ios::out | std::ios::binary);
+    if (!licJsonFile)
+    {
+        error(
+            "Failed to create license json file '{NEW_LIC_JSON}' while write from memory",
+            "NEW_LIC_JSON", newLicJsonFilePath);
+        FileHandler::dmaResponseToRemoteTerminus(sharedAIORespDataobj,
+                                                 PLDM_ERROR, 0);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+        return;
+    }
+
+    transferFileData(newLicJsonFilePath, false, offset, length, address,
+                     sharedAIORespDataobj, event);
+}
+
+void LicenseHandler::postDataTransferCallBack(bool IsWriteToMemOp,
+                                              uint32_t length)
+{
+    if (IsWriteToMemOp)
+    {
+        fs::path newLicJsonFilePath(fs::path(licFilePath) / newLicenseJsonFile);
+
+        if (length == licLength)
+        {
+            int rc = updateBinFileAndLicObjs(newLicJsonFilePath);
+            if (rc != PLDM_SUCCESS)
+            {
+                error(
+                    "Failed to update bin file and license objs with rc as {RC} while post data transfer callback",
+                    "RC", rc);
+                return;
+            }
+        }
+    }
+}
+
+int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,
+                          uint32_t& length,
+                          oem_platform::Handler* /*oemPlatformHandler*/)
+{
+    int rc = PLDM_SUCCESS;
+
+    fs::path newLicJsonFilePath(fs::path(licFilePath) / newLicenseJsonFile);
+    std::ofstream licJsonFile(newLicJsonFilePath,
+                              std::ios::out | std::ios::binary | std::ios::app);
+    if (!licJsonFile)
+    {
+        error(
+            "Failed to create license json file '{NEW_LIC_JSON}' while in write",
+            "NEW_LIC_JSON", newLicJsonFilePath);
+        return -1;
+    }
+
+    if (buffer)
+    {
+        licJsonFile.write(buffer, length);
+    }
+    licJsonFile.close();
+
+    updateBinFileAndLicObjs(newLicJsonFilePath);
+    if (rc != PLDM_SUCCESS)
+    {
+        error("Failed to update bin file and license objs with rc as {RC}",
+              "RC", rc);
+        return rc;
+    }
+
+    return rc;
+}
+
+int LicenseHandler::newFileAvailable(uint64_t length)
+{
+    licLength = length;
+    return PLDM_SUCCESS;
+}
+
+int LicenseHandler::read(uint32_t offset, uint32_t& length, Response& response,
+                         oem_platform::Handler* /*oemPlatformHandler*/)
+{
+    std::string filePath = codFilePath;
+    filePath += "licFile";
+
+    if (licType != PLDM_FILE_TYPE_COD_LICENSE_KEY)
+    {
+        return PLDM_ERROR_INVALID_DATA;
+    }
+    auto rc = readFile(filePath.c_str(), offset, length, response);
+    fs::remove(filePath);
+    if (rc)
+    {
+        return PLDM_ERROR;
+    }
+    return PLDM_SUCCESS;
+}
+
+int LicenseHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                        uint32_t metaDataValue1,
+                                        uint32_t /*metaDataValue2*/,
+                                        uint32_t /*metaDataValue3*/,
+                                        uint32_t /*metaDataValue4*/)
+{
+    DBusMapping dbusMapping;
+    dbusMapping.objectPath = "/com/ibm/license";
+    dbusMapping.interface = "com.ibm.License.LicenseManager";
+    dbusMapping.propertyName = "LicenseActivationStatus";
+    dbusMapping.propertyType = "string";
+
+    pldm_license_install_status status =
+        static_cast<pldm_license_install_status>(metaDataValue1);
+
+    if (status == pldm_license_install_status::PLDM_LIC_INVALID_LICENSE)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.InvalidLicense";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set invalid license status due to the ERROR:{ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_ACTIVATED)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.Activated";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set license activated status due to the ERROR:{ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_PENDING)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.Pending";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set license pending status due to the ERROR:{ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_ACTIVATION_FAILED)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.ActivationFailed";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set license activation failure status due to the ERROR:{ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_INCORRECT_SYSTEM)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.IncorrectSystem";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set incorrect system status to license manager due to the ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_INVALID_HOSTSTATE)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.InvalidHostState";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set invalid host state status to license manager due to the ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    else if (status == pldm_license_install_status::PLDM_LIC_INCORRECT_SEQUENCE)
+    {
+        pldm::utils::PropertyValue value =
+            "com.ibm.License.LicenseManager.Status.IncorrectSequence";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "Failed to set incorrect sequence status to license manager due to the ERROR={ERR_EXCEP}",
+                "ERR_EXCEP", e);
+            return PLDM_ERROR;
+        }
+    }
+    return PLDM_SUCCESS;
+}
+
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_lic.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "file_io.hpp"
+
+namespace pldm
+{
+namespace responder
+{
+
+using LicType = uint16_t;
+
+/** @class LicenseHandler
+ *
+ *  @brief Inherits and implements FileHandler. This class is used
+ *  to read license
+ */
+class LicenseHandler : public FileHandler
+{
+  public:
+    /** @brief Handler constructor
+     */
+    LicenseHandler(uint32_t fileHandle, uint16_t fileType) :
+        FileHandler(fileHandle), licType(fileType)
+    {}
+
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
+
+    virtual void readIntoMemory(uint32_t /*offset*/, uint32_t length,
+                                uint64_t /*address*/,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& /*event*/)
+    {
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+    }
+
+    virtual int read(uint32_t offset, uint32_t& length, Response& response,
+                     oem_platform::Handler* /*oemPlatformHandler*/);
+
+    virtual int write(const char* buffer, uint32_t /*offset*/, uint32_t& length,
+                      oem_platform::Handler* /*oemPlatformHandler*/);
+
+    virtual int fileAck(uint8_t /*fileStatus*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual int newFileAvailable(uint64_t length);
+
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t metaDataValue1,
+                                    uint32_t metaDataValue2,
+                                    uint32_t metaDataValue3,
+                                    uint32_t metaDataValue4);
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
+
+    int updateBinFileAndLicObjs(const fs::path& newLicFilePath);
+
+    /** @brief LicenseHandler destructor
+     */
+    ~LicenseHandler() {}
+
+  private:
+    uint16_t licType;   //!< type of the license
+    uint64_t licLength; //!< length of the full license data
+
+    /** @brief PLDM CoD License install status
+     */
+    enum pldm_license_install_status
+    {
+        PLDM_LIC_ACTIVATED = 0x00,
+        PLDM_LIC_INVALID_LICENSE = 0x01,
+        PLDM_LIC_INCORRECT_SYSTEM = 0x02,
+        PLDM_LIC_INCORRECT_SEQUENCE = 0x03,
+        PLDM_LIC_PENDING = 0x04,
+        PLDM_LIC_ACTIVATION_FAILED = 0x05,
+        PLDM_LIC_INVALID_HOSTSTATE = 0x06,
+    };
+};
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -317,6 +317,15 @@ class LidHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief LidHandler destructor
      */
     ~LidHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -308,6 +308,15 @@ class LidHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief LidHandler destructor
      */
     ~LidHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -22,20 +22,26 @@ class PCIeInfoHandler : public FileHandler
      */
     PCIeInfoHandler(uint32_t fileHandle, uint16_t fileType);
 
-    virtual int writeFromMemory(uint32_t offset, uint32_t length,
-                                uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
                       oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int fileAck(uint8_t fileStatus);
 
-    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                               uint64_t /*address*/,
-                               oem_platform::Handler* /*oemPlatformHandler*/)
+    virtual void readIntoMemory(uint32_t /*offset*/, uint32_t length,
+                                uint64_t /*address*/,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& /*event*/)
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
 
     virtual int read(uint32_t /*offset*/, uint32_t& /*length*/,
@@ -67,6 +73,10 @@ class PCIeInfoHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                          uint32_t /*length*/)
+    {}
 
     /** @brief PCIeInfoHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -48,6 +48,15 @@ class PelHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief PelHandler destructor
      */
     ~PelHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -57,6 +57,15 @@ class PelHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief PelHandler destructor
      */
     ~PelHandler() {}

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -19,13 +19,17 @@ class PelHandler : public FileHandler
      */
     PelHandler(uint32_t fileHandle) : FileHandler(fileHandle) {}
 
-    virtual int writeFromMemory(uint32_t offset, uint32_t length,
-                                uint64_t address,
-                                oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void writeFromMemory(uint32_t offset, uint32_t length,
+                                 uint64_t address,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& event);
 
-    virtual int readIntoMemory(uint32_t offset, uint32_t length,
-                               uint64_t address,
-                               oem_platform::Handler* /*oemPlatformHandler*/);
+    virtual void readIntoMemory(uint32_t offset, uint32_t length,
+                                uint64_t address,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& event);
 
     virtual int read(uint32_t offset, uint32_t& length, Response& response,
                      oem_platform::Handler* /*oemPlatformHandler*/);
@@ -37,7 +41,7 @@ class PelHandler : public FileHandler
     virtual int fileAck(uint8_t fileStatus);
 
     /** @brief method to store a pel file in tempfs and send
-     *  d-bus notification to pel daemon that it is ready for consumption
+     *         d-bus notification to pel daemon that it is ready for consumption
      *
      *  @param[in] pelFileName - the pel file path
      */
@@ -47,6 +51,7 @@ class PelHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+    virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
 
     virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
                                              uint32_t /*metaDataValue1*/,
@@ -69,6 +74,10 @@ class PelHandler : public FileHandler
     /** @brief PelHandler destructor
      */
     ~PelHandler() {}
+
+  private:
+    fs::path Pelpath;
+    int fd;
 };
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -20,21 +20,29 @@ class ProgressCodeHandler : public FileHandler
      */
     ProgressCodeHandler(uint32_t fileHandle) : FileHandler(fileHandle) {}
 
-    int writeFromMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                        uint64_t /*address*/,
-                        oem_platform::Handler* /*oemPlatformHandler*/) override
+    void writeFromMemory(uint32_t /*offset*/, uint32_t length,
+                         uint64_t /*address*/,
+                         oem_platform::Handler* /*oemPlatformHandler*/,
+                         SharedAIORespData& sharedAIORespDataobj,
+                         sdeventplus::Event& /*event*/) override
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
 
     int write(const char* buffer, uint32_t offset, uint32_t& length,
               oem_platform::Handler* oemPlatformHandler) override;
 
-    int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                       uint64_t /*address*/,
-                       oem_platform::Handler* /*oemPlatformHandler*/) override
+    void readIntoMemory(uint32_t /*offset*/, uint32_t length,
+                        uint64_t /*address*/,
+                        oem_platform::Handler* /*oemPlatformHandler*/,
+                        SharedAIORespData& sharedAIORespDataobj,
+                        sdeventplus::Event& /*event*/) override
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
 
     int read(uint32_t /*offset*/, uint32_t& /*length*/, Response& /*response*/,
@@ -78,6 +86,16 @@ class ProgressCodeHandler : public FileHandler
      */
     virtual int setRawBootProperty(
         const std::tuple<uint64_t, std::vector<uint8_t>>& progressCodeBuffer);
+
+    /** @brief Method to do necessary operation according different
+     *         file type and being call when data transfer completed.
+     *
+     *  @param[in] IsWriteToMemOp - type of operation to decide what operation
+     *                              needs to be done after data transfer.
+     */
+    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                          uint32_t /*length*/)
+    {}
 
     /** @brief ProgressCodeHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -53,6 +53,15 @@ class ProgressCodeHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
+                                             uint32_t /*metaDataValue1*/,
+                                             uint32_t /*metaDataValue2*/,
+                                             uint32_t /*metaDataValue3*/,
+                                             uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief method to set the dbus Raw value Property with
      * the obtained progress code from the host.
      *

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -62,6 +62,15 @@ class ProgressCodeHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
+    virtual int fileAckWithMetaData(uint8_t /*fileStatus*/,
+                                    uint32_t /*metaDataValue1*/,
+                                    uint32_t /*metaDataValue2*/,
+                                    uint32_t /*metaDataValue3*/,
+                                    uint32_t /*metaDataValue4*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
     /** @brief method to set the dbus Raw value Property with
      * the obtained progress code from the host.
      *

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
@@ -20,17 +20,25 @@ class keywordHandler : public FileHandler
     keywordHandler(uint32_t fileHandle, uint16_t fileType) :
         FileHandler(fileHandle), vpdFileType(fileType)
     {}
-    virtual int writeFromMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                                uint64_t /*address*/,
-                                oem_platform::Handler* /*oemPlatformHandler*/)
+    virtual void writeFromMemory(uint32_t /*offset*/, uint32_t length,
+                                 uint64_t /*address*/,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
+                                 SharedAIORespData& sharedAIORespDataobj,
+                                 sdeventplus::Event& /*event*/)
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
-    virtual int readIntoMemory(uint32_t /*offset*/, uint32_t /*length*/,
-                               uint64_t /*address*/,
-                               oem_platform::Handler* /*oemPlatformHandler*/)
+    virtual void readIntoMemory(uint32_t /*offset*/, uint32_t length,
+                                uint64_t /*address*/,
+                                oem_platform::Handler* /*oemPlatformHandler*/,
+                                SharedAIORespData& sharedAIORespDataobj,
+                                sdeventplus::Event& /*event*/)
     {
-        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
     virtual int read(uint32_t offset, uint32_t& length, Response& response,
                      oem_platform::Handler* /*oemPlatformHandler*/);
@@ -64,6 +72,16 @@ class keywordHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+    /** @brief Method to do necessary operation according different
+     *         file type and being call when data transfer completed.
+     *
+     *  @param[in] IsWriteToMemOp - type of operation to decide what operation
+     *                              needs to be done after data transfer.
+     */
+    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                          uint32_t /*length*/)
+    {}
+
     /** @brief keywordHandler destructor
      */
     ~keywordHandler() {}

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -5,6 +5,7 @@
 #include "libpldmresponder/pdr_utils.hpp"
 #include "libpldmresponder/platform.hpp"
 #include "requester/handler.hpp"
+#include "utils.hpp"
 
 #include <libpldm/entity.h>
 #include <libpldm/oem/ibm/state_set.h>
@@ -56,6 +57,7 @@ class Handler : public oem_platform::Handler
         hostTransitioningToOff(true)
     {
         codeUpdate->setVersions();
+        pldm::responder::utils::clearLicenseStatus();
         setEventReceiverCnt = 0;
 
         using namespace sdbusplus::bus::match::rules;
@@ -78,6 +80,7 @@ class Handler : public oem_platform::Handler
                     setEventReceiverCnt = 0;
                     disableWatchDogTimer();
                     startStopTimer(false);
+                    pldm::responder::utils::clearLicenseStatus();
                 }
                 else if (propVal ==
                          "xyz.openbmc_project.State.Host.HostState.Running")

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.hpp"
 
 #include "common/utils.hpp"
+#include "host-bmc/custom_dbus.hpp"
 
 #include <libpldm/base.h>
 #include <sys/socket.h>
@@ -9,20 +10,41 @@
 #include <unistd.h>
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/Inventory/Decorator/Asset/client.hpp>
 #include <xyz/openbmc_project/Inventory/Item/Connector/client.hpp>
 #include <xyz/openbmc_project/ObjectMapper/client.hpp>
+
+#include <fstream>
 
 PHOSPHOR_LOG2_USING;
 
 namespace pldm
 {
+
+using namespace pldm::dbus;
 namespace responder
 {
 std::mutex lockMutex;
 
 namespace utils
 {
+
+static constexpr auto curLicFilePath =
+    "/var/lib/pldm/license/current_license.bin";
+static constexpr auto newLicFilePath = "/var/lib/pldm/license/new_license.bin";
+static constexpr auto newLicJsonFilePath =
+    "/var/lib/pldm/license/new_license.json";
+static constexpr auto licEntryPath = "/xyz/openbmc_project/license/entry";
+static constexpr uint8_t createLic = 1;
+static constexpr uint8_t clearLicStatus = 2;
+
+using InternalFailure =
+    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+using LicJsonObjMap = std::map<fs::path, nlohmann::json>;
+LicJsonObjMap licJsonMap;
+
 int setupUnixSocket(const std::string& socketInterface)
 {
     int sock;
@@ -198,6 +220,221 @@ std::vector<std::string> findPortObjects(const std::string& adapterObjPath)
     }
 
     return portObjects;
+}
+
+Json convertBinFileToJson(const fs::path& path)
+{
+    std::ifstream file(path, std::ios::in | std::ios::binary);
+    std::streampos fileSize;
+
+    // Get the file size
+    file.seekg(0, std::ios::end);
+    fileSize = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    // Read the data into vector from file and convert to json object
+    std::vector<uint8_t> vJson(fileSize);
+    file.read((char*)&vJson[0], fileSize);
+    return Json::from_bson(vJson);
+}
+
+void convertJsonToBinaryFile(const Json& jsonData, const fs::path& path)
+{
+    // Covert the json data to binary format and copy to vector
+    std::vector<uint8_t> vJson = {};
+    vJson = Json::to_bson(jsonData);
+
+    // Copy the vector to file
+    std::ofstream licout(path, std::ios::out | std::ios::binary);
+    size_t size = vJson.size();
+    licout.write(reinterpret_cast<char*>(&vJson[0]), size * sizeof(vJson[0]));
+}
+
+void clearLicenseStatus()
+{
+    if (!fs::exists(curLicFilePath))
+    {
+        return;
+    }
+
+    auto data = convertBinFileToJson(curLicFilePath);
+
+    const Json empty{};
+    const std::vector<Json> emptyList{};
+
+    auto entries = data.value("Licenses", emptyList);
+    fs::path path{licEntryPath};
+
+    for (const auto& entry : entries)
+    {
+        auto licId = entry.value("Id", empty);
+        fs::path l_path = path / licId;
+        licJsonMap.emplace(l_path, entry);
+    }
+
+    createOrUpdateLicenseDbusPaths(clearLicStatus);
+}
+
+int createOrUpdateLicenseDbusPaths(const uint8_t& flag)
+{
+    const Json empty{};
+    std::string authTypeAsNoOfDev = "NumberOfDevice";
+    struct tm tm;
+    time_t licTimeSinceEpoch = 0;
+
+    sdbusplus::com::ibm::License::Entry::server::LicenseEntry::Type licType =
+        sdbusplus::com::ibm::License::Entry::server::LicenseEntry::Type::
+            Prototype;
+    sdbusplus::com::ibm::License::Entry::server::LicenseEntry::AuthorizationType
+        licAuthType = sdbusplus::com::ibm::License::Entry::server::
+            LicenseEntry::AuthorizationType::Device;
+    for (const auto& [key, licJson] : licJsonMap)
+    {
+        auto licName = licJson.value("Name", empty);
+
+        auto type = licJson.value("Type", empty);
+        if (type == "Trial")
+        {
+            licType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::Type::Trial;
+        }
+        else if (type == "Commercial")
+        {
+            licType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::Type::Purchased;
+        }
+        else
+        {
+            licType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::Type::Prototype;
+        }
+
+        auto authType = licJson.value("AuthType", empty);
+        if (authType == "NumberOfDevice")
+        {
+            licAuthType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::AuthorizationType::Capacity;
+        }
+        else if (authType == "Unlimited")
+        {
+            licAuthType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::AuthorizationType::Unlimited;
+        }
+        else
+        {
+            licAuthType = sdbusplus::com::ibm::License::Entry::server::
+                LicenseEntry::AuthorizationType::Device;
+        }
+
+        uint32_t licAuthDevNo = 0;
+        if (authType == authTypeAsNoOfDev)
+        {
+            licAuthDevNo = licJson.value("AuthDeviceNumber", 0);
+        }
+
+        auto licSerialNo = licJson.value("SerialNum", "");
+
+        auto expTime = licJson.value("ExpirationTime", "");
+        if (!expTime.empty())
+        {
+            memset(&tm, 0, sizeof(tm));
+            strptime(expTime.c_str(), "%Y-%m-%dT%H:%M:%SZ", &tm);
+            licTimeSinceEpoch = mktime(&tm);
+        }
+
+        CustomDBus::getCustomDBus().implementLicInterfaces(
+            key, licAuthDevNo, licName, licSerialNo, licTimeSinceEpoch, licType,
+            licAuthType);
+
+        auto status = licJson.value("Status", empty);
+
+        // License status is a single entry which needs to be mapped to
+        // OperationalStatus and Availability dbus interfaces
+        auto licOpStatus = false;
+        auto licAvailState = false;
+        if ((flag == clearLicStatus) || (status == "Unknown"))
+        {
+            licOpStatus = false;
+            licAvailState = false;
+        }
+        else if (status == "Enabled")
+        {
+            licOpStatus = true;
+            licAvailState = true;
+        }
+        else if (status == "Disabled")
+        {
+            licOpStatus = false;
+            licAvailState = true;
+        }
+
+        CustomDBus::getCustomDBus().setOperationalStatus(key, licOpStatus);
+        CustomDBus::getCustomDBus().setAvailabilityState(key, licAvailState);
+    }
+
+    return PLDM_SUCCESS;
+}
+
+int createOrUpdateLicenseObjs()
+{
+    bool l_curFilePresent = true;
+    const Json empty{};
+    const std::vector<Json> emptyList{};
+    std::ifstream jsonFileCurrent;
+    Json dataCurrent;
+    Json entries;
+
+    if (!fs::exists(curLicFilePath))
+    {
+        l_curFilePresent = false;
+    }
+
+    if (l_curFilePresent == true)
+    {
+        dataCurrent = convertBinFileToJson(curLicFilePath);
+    }
+
+    auto dataNew = convertBinFileToJson(newLicFilePath);
+
+    if (l_curFilePresent == true)
+    {
+        dataCurrent.merge_patch(dataNew);
+        convertJsonToBinaryFile(dataCurrent, curLicFilePath);
+        entries = dataCurrent.value("Licenses", emptyList);
+    }
+    else
+    {
+        convertJsonToBinaryFile(dataNew, curLicFilePath);
+        entries = dataNew.value("Licenses", emptyList);
+    }
+
+    fs::path path{licEntryPath};
+
+    for (const auto& entry : entries)
+    {
+        auto licId = entry.value("Id", empty);
+        fs::path l_path = path / licId;
+        licJsonMap.emplace(l_path, entry);
+    }
+
+    int rc = createOrUpdateLicenseDbusPaths(createLic);
+    if (rc == PLDM_SUCCESS)
+    {
+        fs::copy_file(newLicFilePath, curLicFilePath,
+                      fs::copy_options::overwrite_existing);
+
+        if (fs::exists(newLicFilePath))
+        {
+            fs::remove_all(newLicFilePath);
+        }
+
+        if (fs::exists(newLicJsonFilePath))
+        {
+            fs::remove_all(newLicJsonFilePath);
+        }
+    }
+
+    return rc;
 }
 } // namespace utils
 } // namespace responder

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -2,6 +2,8 @@
 
 #include <unistd.h>
 
+#include <nlohmann/json.hpp>
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -12,6 +14,8 @@ namespace responder
 {
 namespace utils
 {
+namespace fs = std::filesystem;
+using Json = nlohmann::json;
 
 /** @struct CustomFD
  *
@@ -88,6 +92,57 @@ bool checkIfIBMFru(const std::string& objPath);
  *  @return std::vector<std::string> - port object paths
  */
 std::vector<std::string> findPortObjects(const std::string& adapterObjPath);
+
+/** @brief Converts a binary file to json data
+ *  This function converts bson data stored in a binary file to
+ *  nlohmann json data
+ *
+ *  @param[in] path     - binary file path to fetch the bson data
+ *
+ *  @return   on success returns nlohmann::json object
+ */
+Json convertBinFileToJson(const fs::path& path);
+
+/** @brief Converts a json data in to a binary file
+ *  This function converts the json data to a binary json(bson)
+ *  format and copies it to specified destination file.
+ *
+ *  @param[in] jsonData - nlohmann json data
+ *  @param[in] path     - destination path to store the bson data
+ *
+ *  @return   None
+ */
+void convertJsonToBinaryFile(const Json& jsonData, const fs::path& path);
+
+/** @brief Clear License Status
+ *  This function clears all the license status to "Unknown" during
+ *  reset reload operation or when host is coming down to off state.
+ *  During the genesis mode, it skips the license status update.
+ *
+ *  @return   None
+ */
+void clearLicenseStatus();
+
+/** @brief Create or update the d-bus license data
+ *  This function creates or updates the d-bus license details. If the input
+ *  input flag is 1, then new license data will be created and if the the input
+ *  flag is 2 license status will be cleared.
+ *
+ *  @param[in] flag - input flag, 1 : create and 2 : clear
+ *
+ *  @return   on success returns PLDM_SUCCESS
+ *            on failure returns -1
+ */
+int createOrUpdateLicenseDbusPaths(const uint8_t& flag);
+
+/** @brief Create or update the license bjects
+ *  This function creates or updates the license objects as per the data passed
+ *  from host.
+ *
+ *  @return   on success returns PLDM_SUCCESS
+ *            on failure returns -1
+ */
+int createOrUpdateLicenseObjs();
 
 } // namespace utils
 } // namespace responder

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unistd.h>
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -10,6 +12,40 @@ namespace responder
 {
 namespace utils
 {
+
+/** @struct CustomFD
+ *
+ *  CustomFD class is created for special purpose using RAII and it wil be
+ * useful during AIO file transfer operation.
+ */
+struct CustomFD
+{
+    CustomFD(const CustomFD&) = delete;
+    CustomFD& operator=(const CustomFD&) = delete;
+    CustomFD(CustomFD&&) = delete;
+    CustomFD& operator=(CustomFD&&) = delete;
+
+    CustomFD(int fd, bool closeOnOutScope = true) :
+        fd(fd), closeOnOutScope(closeOnOutScope)
+    {}
+
+    ~CustomFD()
+    {
+        if (fd >= 0 && closeOnOutScope)
+        {
+            close(fd);
+        }
+    }
+
+    int operator()() const
+    {
+        return fd;
+    }
+
+  private:
+    int fd = -1;
+    bool closeOnOutScope;
+};
 
 /** @brief Setup UNIX socket
  *  This function creates listening socket in non-blocking mode and allows only

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -240,6 +240,40 @@ void DbusToFileHandler::newCsrFileAvailable(const std::string& csr,
                                PLDM_FILE_TYPE_CERT_SIGNING_REQUEST);
 }
 
+void DbusToFileHandler::newLicFileAvailable(const std::string& licenseStr)
+{
+    namespace fs = std::filesystem;
+    std::string dirPath = "/var/lib/ibm/cod";
+    const fs::path licDirPath = dirPath;
+
+    if (!fs::exists(licDirPath))
+    {
+        fs::create_directories(licDirPath);
+        fs::permissions(licDirPath,
+                        fs::perms::others_read | fs::perms::owner_write);
+    }
+
+    fs::path licFilePath = licDirPath / "licFile";
+    std::ofstream licFile;
+
+    licFile.open(licFilePath, std::ios::out | std::ofstream::binary);
+
+    if (!licFile)
+    {
+        error("license file open error: {LIC_PATH}", "LIC_PATH",
+              licFilePath.c_str());
+        return;
+    }
+
+    // Add csr to file
+    licFile << licenseStr << std::endl;
+
+    licFile.close();
+    uint32_t fileSize = fs::file_size(licFilePath);
+
+    newFileAvailableSendToHost(fileSize, 1, PLDM_FILE_TYPE_COD_LICENSE_KEY);
+}
+
 void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
                                                    const uint32_t fileHandle,
                                                    const uint16_t type)

--- a/oem/ibm/requester/dbus_to_file_handler.hpp
+++ b/oem/ibm/requester/dbus_to_file_handler.hpp
@@ -57,6 +57,11 @@ class DbusToFileHandler
     void newCsrFileAvailable(const std::string& csr,
                              const std::string fileHandle);
 
+    /** @brief Process the new license file available
+     *  @param[in] licenseStr - License string
+     */
+    void newLicFileAvailable(const std::string& licenseStr);
+
   private:
     /** @brief Send the new file available command request to hypervisor
      *  @param[in] fileSize - size of the file

--- a/oem/ibm/test/libpldmresponder_fileio_test.cpp
+++ b/oem/ibm/test/libpldmresponder_fileio_test.cpp
@@ -3,6 +3,7 @@
 #include "libpldmresponder/file_io_by_type.hpp"
 #include "libpldmresponder/file_io_type_cert.hpp"
 #include "libpldmresponder/file_io_type_dump.hpp"
+#include "libpldmresponder/file_io_type_lic.hpp"
 #include "libpldmresponder/file_io_type_lid.hpp"
 #include "libpldmresponder/file_io_type_pcie.hpp"
 #include "libpldmresponder/file_io_type_pel.hpp"
@@ -802,6 +803,15 @@ TEST(getHandlerByType, allPaths)
     handler = getHandlerByType(PLDM_FILE_TYPE_ROOT_CERT, fileHandle);
     certType = dynamic_cast<CertHandler*>(handler.get());
     ASSERT_TRUE(certType != nullptr);
+
+    handler = getHandlerByType(PLDM_FILE_TYPE_COD_LICENSE_KEY, fileHandle);
+    auto licType = dynamic_cast<LicenseHandler*>(handler.get());
+    ASSERT_TRUE(licType != nullptr);
+
+    handler = getHandlerByType(PLDM_FILE_TYPE_COD_LICENSED_RESOURCES,
+                               fileHandle);
+    licType = dynamic_cast<LicenseHandler*>(handler.get());
+    ASSERT_TRUE(licType != nullptr);
 
     using namespace sdbusplus::xyz::openbmc_project::Common::Error;
     ASSERT_THROW(getHandlerByType(0xFFFF, fileHandle), InternalFailure);

--- a/pldmd/pldm_resp_interface.hpp
+++ b/pldmd/pldm_resp_interface.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "common/flight_recorder.hpp"
+#include "common/transport.hpp"
+#include "common/utils.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <vector>
+using namespace pldm;
+using namespace pldm::utils;
+using namespace pldm::flightrecorder;
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm
+{
+namespace response_api
+{
+
+/** @class AltResponse
+ *
+ *  @brief This class performs the necessary operation in pldm for
+ *         responding remote pldm. This class is mostly designed in special case
+ *         when pldm need to send reply to host after FILE IO operation
+ *         completed.
+ */
+class AltResponse
+{
+  public:
+    /** @brief Response constructor
+     */
+    AltResponse() = delete;
+    AltResponse(const AltResponse&) = delete;
+    AltResponse(PldmTransport* pldmTransport, pldm_tid_t& TID,
+                bool verbose = false) :
+        pldmTransport(pldmTransport),
+        TID(TID), verbose(verbose)
+    {}
+
+    /** @brief method to send response to remote pldm using Response interface
+     *  @param response - response of each request
+     *  @returns returns 0 if success else error number
+     */
+    int sendPLDMRespMsg(auto response)
+    {
+        FlightRecorder::GetInstance().saveRecord(response, true);
+        if (verbose)
+        {
+            printBuffer(Tx, response);
+        }
+
+        int rc =
+            (*pldmTransport).sendMsg(TID, response.data(), response.size());
+        if (rc < 0)
+        {
+            rc = errno;
+            warning("sendto system call failed, errno= {ERRNO}", "ERRNO", rc);
+        }
+        return rc;
+    }
+
+  private:
+    PldmTransport* pldmTransport; //!< PLDM transport object
+    pldm_tid_t TID;               //!< PLDM hostEID reference
+    bool verbose;
+};
+
+struct ResponseInterface
+{
+    std::unique_ptr<AltResponse> responseObj;
+};
+
+} // namespace response_api
+
+} // namespace pldm

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -196,6 +196,8 @@ int main(int argc, char** argv)
                                     instanceIdDb);
     sdbusplus::server::manager_t inventoryManager(
         bus, "/xyz/openbmc_project/inventory");
+    sdbusplus::server::manager::manager licObjManager(
+        bus, "/xyz/openbmc_project/license");
 
     Invoker invoker{};
     requester::Handler<requester::Request> reqHandler(&pldmTransport, event,


### PR DESCRIPTION
This commit supports:

1. Creation or update of new license interfaces and properties supplied by host
2. Clearing of license status to Unknown, during host power off transition
3. Restoration of license interfaces during reset reload and setting the license status to Unknown

Tested By:

1. Verified that dbus hosting is done by pldm
2. CoD(Capacity on demand) values are coming up in the BMC
3. Verified that reboot of BMC does not clear values

Change-Id: I9377e66753c2df7f8e1ac8b6a4ed285db69ad090