### PR TITLE
hotplug: Add API to check FRU presence

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -659,5 +659,25 @@ void setFruPresence(const std::string& fruObjPath, bool present)
     }
 }
 
+bool checkFruPresence(const char* objPath)
+{
+    bool isPresent = false;
+    static constexpr auto presentInterface =
+        "xyz.openbmc_project.Inventory.Item";
+    static constexpr auto presentProperty = "Present";
+    try
+    {
+        auto propVal = pldm::utils::DBusHandler().getDbusPropertyVariant(
+            objPath, presentProperty, presentInterface);
+        isPresent = std::get<bool>(propVal);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        error("Failed to check for FRU presence for '{OBJ_PATH}' - {ERR_EXCEP}",
+              "OBJ_PATH", objPath, "ERR_EXCEP", e);
+    }
+    return isPresent;
+}
+
 } // namespace utils
 } // namespace pldm

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -480,5 +480,14 @@ bool checkIfLogicalBitSet(const uint16_t& containerId);
  *  @param[in] present - status to set either true/false
  */
 void setFruPresence(const std::string& fruObjPath, bool present);
+
+/** @brief checks whether the fru is actually present
+ *
+ *  @param[in] objPath - the fru object path
+ *
+ *  @return bool to indicate presence or absence
+ */
+bool checkFruPresence(const char* objPath);
+
 } // namespace utils
 } // namespace pldm

--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -164,6 +164,12 @@ void FruImpl::buildFRUTable()
 
     for (const auto& object : objects)
     {
+        auto isPresent =
+            pldm::utils::checkFruPresence(object.first.str.c_str());
+        if (!isPresent)
+        {
+            continue;
+        }
         const auto& interfaces = object.second;
         for (const auto& interface : interfaces)
         {


### PR DESCRIPTION
API that checks if FRU with a given object path is present in the inventory interface is introduced. FRU records are built only for FRUs that are present in the inventory interface list. The presence of a FRU is determined by the "Present" Dbus property.

Tested By: IPL and reset on BMC.