### PR TITLE
oem-ibm: Changes to handle the new way of Dump entry

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -32,19 +32,38 @@ static constexpr auto dumpObjPath = "/xyz/openbmc_project/dump/system";
 static constexpr auto systemDumpEntry = "xyz.openbmc_project.Dump.Entry.System";
 static constexpr auto resDumpEntry = "com.ibm.Dump.Entry.Resource";
 static constexpr auto dumpEntryObjPath =
-    "/xyz/openbmc_project/dump/system/entry/";
+    "/xyz/openbmc_project/dump/system/entry";
 static constexpr auto bmcDumpObjPath = "/xyz/openbmc_project/dump/bmc/entry";
 
 // Resource dump file path to be deleted once hyperviosr validates the input
 // parameters. Need to re-look in to this name when we support multiple
 // resource dumps.
-static constexpr auto resDumpDirPath = "/var/lib/pldm/resourcedump/1";
 
 int DumpHandler::fd = -1;
 namespace fs = std::filesystem;
 
+uint32_t DumpHandler::getDumpIdPrefix(uint16_t dumpType)
+{
+    switch (dumpType)
+    {
+        case PLDM_FILE_TYPE_HARDWARE_DUMP:
+            return 0x00000000;
+        case PLDM_FILE_TYPE_HOSTBOOT_DUMP:
+            return 0x20000000;
+        case PLDM_FILE_TYPE_SBE_DUMP:
+            return 0x30000000;
+        case PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS:
+            return 0xB0000000;
+        default:
+            error("unsupported {TYPE}", "TYPE", dumpType);
+    }
+    return DumpIdPrefix::INVALID_DUMP_ID_PREFIX;
+}
+
 std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
 {
+    info("FileHandle in findDumpObjPath is {FILEHANDLE}", "FILEHANDLE",
+         fileHandle);
     static constexpr auto DUMP_MANAGER_BUSNAME =
         "xyz.openbmc_project.Dump.Manager";
     static constexpr auto DUMP_MANAGER_PATH = "/xyz/openbmc_project/dump";
@@ -55,8 +74,14 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
 
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
     {
-        resDumpRequestDirPath = "/var/lib/pldm/resourcedump/" +
-                                std::to_string(fileHandle);
+        uint32_t dumpIdPrefix =
+            getDumpIdPrefix(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS);
+        fileHandle |= dumpIdPrefix;
+        std::string idStr = std::format("{:08X}", fileHandle);
+
+        resDumpRequestDirPath = "/var/lib/pldm/resourcedump/" + idStr;
+        info("resource dump request dir path is {PATH}", "PATH",
+             resDumpRequestDirPath);
     }
 
     std::string curDumpEntryPath{};
@@ -66,12 +91,35 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
         curDumpEntryPath = (std::string)bmcDumpObjPath + "/" +
                            std::to_string(fileHandle);
     }
-    else if (dumpType == PLDM_FILE_TYPE_SBE_DUMP ||
-             dumpType == PLDM_FILE_TYPE_HOSTBOOT_DUMP ||
-             dumpType == PLDM_FILE_TYPE_HARDWARE_DUMP)
+    else if (dumpType == PLDM_FILE_TYPE_SBE_DUMP)
     {
-        curDumpEntryPath = (std::string)dumpObjPath + "/" +
-                           std::to_string(fileHandle);
+        uint32_t dumpIdPrefix = getDumpIdPrefix(PLDM_FILE_TYPE_SBE_DUMP);
+        fileHandle |= dumpIdPrefix;
+        std::string idStr = std::format("{:08X}", fileHandle);
+
+        curDumpEntryPath = (std::string)dumpEntryObjPath + "/" + idStr;
+        info("SBE dump entry path is {DUMPENTRY}", "DUMPENTRY",
+             curDumpEntryPath);
+    }
+    else if (dumpType == PLDM_FILE_TYPE_HOSTBOOT_DUMP)
+    {
+        uint32_t dumpIdPrefix = getDumpIdPrefix(PLDM_FILE_TYPE_HOSTBOOT_DUMP);
+        fileHandle |= dumpIdPrefix;
+        std::string idStr = std::format("{:08X}", fileHandle);
+
+        curDumpEntryPath = (std::string)dumpEntryObjPath + "/" + idStr;
+        info("HostBoot dump entry path is {DUMPENTRY}", "DUMPENTRY",
+             curDumpEntryPath);
+    }
+    else if (dumpType == PLDM_FILE_TYPE_HARDWARE_DUMP)
+    {
+        uint32_t dumpIdPrefix = getDumpIdPrefix(PLDM_FILE_TYPE_HARDWARE_DUMP);
+        fileHandle |= dumpIdPrefix;
+        std::string idStr = std::format("{:08X}", fileHandle);
+
+        curDumpEntryPath = (std::string)dumpEntryObjPath + "/" + idStr;
+        info("Hardware dump entry path is {DUMPENTRY}", "DUMPENTRY",
+             curDumpEntryPath);
     }
 
     std::string dumpEntryIntf{};
@@ -514,6 +562,8 @@ int DumpHandler::newFileAvailableWithMetaData(uint64_t length,
                                               uint32_t /*metaDataValue3*/,
                                               uint32_t /*metaDataValue4*/)
 {
+    info("File handle in newFileAvailableWithMetaData is {FILEHANDLE}",
+         "FILEHANDLE", fileHandle);
     static constexpr auto dumpInterface = "com.ibm.Dump.Notify";
     auto& bus = pldm::utils::DBusHandler::getBus();
 
@@ -554,13 +604,20 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
                                      uint32_t /*metaDataValue3*/,
                                      uint32_t /*metaDataValue4*/)
 {
+    info("File Handle in fileAckWithMetaData is {FILEHANDLE}", "FILEHANDLE",
+         fileHandle);
+
     auto path = findDumpObjPath(fileHandle);
     uint8_t statusCode = (uint8_t)metaDataValue2;
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
     {
         DBusMapping dbusMapping;
-        std::string idString = std::format("{:08X}", fileHandle);
-        dbusMapping.objectPath = dumpEntryObjPath + idString;
+        uint32_t dumpIdPrefix =
+            getDumpIdPrefix(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS);
+        fileHandle |= dumpIdPrefix;
+        std::string idStr = std::format("{:08X}", fileHandle);
+
+        dbusMapping.objectPath = dumpEntryObjPath + idStr;
         dbusMapping.interface = resDumpEntry;
         dbusMapping.propertyName = "DumpRequestStatus";
         dbusMapping.propertyType = "string";
@@ -580,9 +637,10 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         {
             value = "com.ibm.Dump.Entry.Resource.HostResponse.AcfFileInvalid";
         }
-        else if (statusCode == DumpRequestStatus::PasswordInvalid)
+        else if (statusCode == DumpRequestStatus::UserChallengeInvalid)
         {
-            value = "com.ibm.Dump.Entry.Resource.HostResponse.PasswordInvalid";
+            value =
+                "com.ibm.Dump.Entry.Resource.HostResponse.UserChallengeInvalid";
         }
         else if (statusCode == DumpRequestStatus::PermissionDenied)
         {
@@ -591,7 +649,12 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
         else if (statusCode == DumpRequestStatus::Success)
         {
             DBusMapping dbusMapping;
+
+            uint32_t dumpIdPrefix =
+                getDumpIdPrefix(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS);
+            fileHandle |= dumpIdPrefix;
             std::string idStr = std::format("{:08X}", fileHandle);
+
             dbusMapping.objectPath = "/xyz/openbmc_project/dump/system/entry/" +
                                      idStr;
             dbusMapping.interface = "com.ibm.Dump.Entry.Resource";
@@ -633,9 +696,14 @@ int DumpHandler::fileAckWithMetaData(uint8_t /*fileStatus*/,
 
             PropertyValue value{
                 "xyz.openbmc_project.Common.Progress.OperationStatus.Failed"};
-            DBusMapping dbusMapping{
-                dumpEntryObjPath + std::to_string(fileHandle),
-                "xyz.openbmc_project.Common.Progress", "Status", "string"};
+            uint32_t dumpIdPrefix =
+                getDumpIdPrefix(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS);
+            fileHandle |= dumpIdPrefix;
+            std::string idStr = std::format("{:08X}", fileHandle);
+
+            DBusMapping dbusMapping{dumpEntryObjPath + idStr,
+                                    "xyz.openbmc_project.Common.Progress",
+                                    "Status", "string"};
             try
             {
                 pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -59,6 +59,7 @@ class DumpHandler : public FileHandler
     std::string findDumpObjPath(uint32_t fileHandle);
     std::string getOffloadUri(uint32_t fileHandle);
     void resetOffloadUri();
+    uint32_t getDumpIdPrefix(uint16_t dumpType);
     virtual void postDataTransferCallBack(bool IsWriteToMemOp,
                                           uint32_t /*length*/);
 
@@ -76,9 +77,13 @@ class DumpHandler : public FileHandler
     {
         Success = 0x0,
         AcfFileInvalid = 0x1,
-        PasswordInvalid = 0x2,
+        UserChallengeInvalid = 0x2,
         PermissionDenied = 0x3,
         ResourceSelectorInvalid = 0x4,
+    };
+    enum DumpIdPrefix
+    {
+        INVALID_DUMP_ID_PREFIX = 0xFF
     };
 };
 

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -44,8 +44,16 @@ void DbusToFileHandler::sendNewFileAvailableCmd(uint64_t fileSize)
                                     PLDM_NEW_FILE_REQ_BYTES);
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
     // Need to revisit this logic at the time of multiple resource dump support
-    uint32_t fileHandle = 1;
 
+    std::string pathString = static_cast<std::string>(resDumpCurrentObjPath);
+    std::string filename = fs::path(pathString).filename().string();
+
+    char* end;
+    uint32_t fileHandle = std::strtoul(filename.c_str(), &end, hexaDecimalBase);
+
+    info(
+        "File name in sendNewFileAvailableCmd that we encode new_file_req is {FILENAME}",
+        "FILENAME", filename);
     auto rc = encode_new_file_req(instanceId,
                                   PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS,
                                   fileHandle, fileSize, request);
@@ -137,12 +145,18 @@ void DbusToFileHandler::processNewResourceDump(
 
     // Need to reconsider this logic to set the value as "1" when we have the
     // support to handle multiple resource dumps
-    fs::path resDumpFilePath = resDumpDirPath / "1";
 
-    std::ofstream fileHandle;
-    fileHandle.open(resDumpFilePath, std::ios::out | std::ofstream::binary);
+    std::string pathString = static_cast<std::string>(resDumpCurrentObjPath);
+    std::string filename = fs::path(pathString).filename().string();
 
-    if (!fileHandle)
+    info("In processNewResourceDump fileHandle is {FILENAME}", "FILENAME",
+         filename);
+    fs::path resDumpFilePath = resDumpDirPath / filename;
+
+    std::ofstream fileHandleFd;
+    fileHandleFd.open(resDumpFilePath, std::ios::out | std::ofstream::binary);
+
+    if (!fileHandleFd)
     {
         error("Failed to open resource dump file '{PATH}'", "PATH",
               resDumpFilePath);
@@ -163,10 +177,10 @@ void DbusToFileHandler::processNewResourceDump(
     }
 
     // Fill up the file with resource dump parameters and respective sizes
-    auto fileFunc = [&fileHandle](auto& paramBuf) {
+    auto fileFunc = [&fileHandleFd](auto& paramBuf) {
         uint32_t paramSize = paramBuf.size();
-        fileHandle.write((char*)&paramSize, sizeof(paramSize));
-        fileHandle << paramBuf;
+        fileHandleFd.write((char*)&paramSize, sizeof(paramSize));
+        fileHandleFd << paramBuf;
     };
     fileFunc(vspString);
     fileFunc(resDumpReqPass);
@@ -179,7 +193,7 @@ void DbusToFileHandler::processNewResourceDump(
 
     fileFunc(str);
 
-    fileHandle.close();
+    fileHandleFd.close();
     size_t fileSize = fs::file_size(resDumpFilePath);
 
     sendNewFileAvailableCmd(fileSize);

--- a/oem/ibm/requester/dbus_to_file_handler.hpp
+++ b/oem/ibm/requester/dbus_to_file_handler.hpp
@@ -17,6 +17,7 @@ namespace requester
 namespace oem_ibm
 {
 using ResDumpStatus = std::string;
+static constexpr auto hexaDecimalBase = 16;
 
 /** @class DbusToFileHandler
  *  @brief This class can process resource dump parameters and send PLDM


### PR DESCRIPTION
The dump entries are numbered in a new format (for ex:
System dump entry is numbered - A000<>
Resource dump entry is numbered - B000<>)
Made changes in code to incorporate these changes.
The code also changes the Token handling and UserChallenge
changes in 1110.

tested: Token and dump flow was successfully tested.

Change-Id: I0a7ddc71af87224d79ba7576b3c94fa8b25e2085
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>