### PR TITLE
oem-ibm: Adding value_name json key for dynamic deallocation of Memory

### DIFF
--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/enum_attrs.json
@@ -70,6 +70,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard"
@@ -77,6 +78,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard",

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/enum_attrs.json
@@ -86,6 +86,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard"
@@ -93,6 +94,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard",

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/enum_attrs.json
@@ -86,6 +86,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard"
@@ -93,6 +94,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard",

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/enum_attrs.json
@@ -86,6 +86,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard"
@@ -93,6 +94,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard",

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/enum_attrs.json
@@ -86,6 +86,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard"
@@ -93,6 +94,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard",

--- a/oem/ibm/configurations/bios/enum_attrs.json
+++ b/oem/ibm/configurations/bios/enum_attrs.json
@@ -86,6 +86,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard"
@@ -93,6 +94,7 @@
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
+            "value_names": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
             "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
             "displayName": "Predictive Memory Guard",


### PR DESCRIPTION
This commit adds value_name json key to BIOS attribute that allows user to enable/disable the dynamic deallocation of memory based on predictive memory fail events.

Tested: Verified the BIOS attribute with get bios attribute command from pldmtool.