### PR TITLE
Remove all instances where we log InternalError

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -755,8 +755,6 @@ void HostPDRHandler::setHostSensorState(const PDRList& stateSensorPDRs)
         if (!pdr)
         {
             error("Failed to get state sensor PDR");
-            pldm::utils::reportError(
-                "xyz.openbmc_project.bmc.pldm.InternalFailure");
             return;
         }
 
@@ -790,8 +788,6 @@ void HostPDRHandler::setHostSensorState(const PDRList& stateSensorPDRs)
                         "Failed to encode get state sensor readings request for sensorID '{SENSOR_ID}' and  instanceID '{INSTANCE}', response code '{RC}'",
                         "SENSOR_ID", sensorId, "INSTANCE", instanceId, "RC",
                         rc);
-                    pldm::utils::reportError(
-                        "xyz.openbmc_project.bmc.pldm.InternalFailure");
                     return;
                 }
 
@@ -819,8 +815,6 @@ void HostPDRHandler::setHostSensorState(const PDRList& stateSensorPDRs)
                             "Failed to decode get state sensor readings response for sensorID '{SENSOR_ID}' and  instanceID '{INSTANCE}', response code'{RC}' and completion code '{CC}'",
                             "SENSOR_ID", sensorId, "INSTANCE", instanceId, "RC",
                             rc, "CC", completionCode);
-                        pldm::utils::reportError(
-                            "xyz.openbmc_project.bmc.pldm.InternalFailure");
                     }
 
                     uint8_t eventState;

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -1014,8 +1014,6 @@ void Handler::setEventReceiver()
             error(
                 "Failed to decode setEventReceiver command, response code '{RC}' and completion code '{CC}'",
                 "RC", rc, "CC", (unsigned)completionCode);
-            pldm::utils::reportError(
-                "xyz.openbmc_project.bmc.pldm.InternalFailure");
         }
     };
     rc = handler->registerRequest(

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -319,8 +319,6 @@ int DumpHandler::fileAck(uint8_t fileStatus)
         if (fileStatus != PLDM_SUCCESS)
         {
             error("Failure in resource dump file ack");
-            pldm::utils::reportError(
-                "xyz.openbmc_project.bmc.pldm.InternalFailure");
 
             PropertyValue value{
                 "xyz.openbmc_project.Common.Progress.OperationStatus.Failed"};

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -37,8 +37,6 @@ void DbusToFileHandler::sendNewFileAvailableCmd(uint64_t fileSize)
     {
         error(
             "Failed to send resource dump parameters as instance ID DB is not set");
-        pldm::utils::reportError(
-            "xyz.openbmc_project.bmc.pldm.InternalFailure");
         return;
     }
     auto instanceId = instanceIdDb->next(mctp_eid);
@@ -91,8 +89,6 @@ void DbusToFileHandler::sendNewFileAvailableCmd(uint64_t fileSize)
 
 void DbusToFileHandler::reportResourceDumpFailure()
 {
-    pldm::utils::reportError("xyz.openbmc_project.bmc.pldm.InternalFailure");
-
     PropertyValue value{resDumpStatus};
     DBusMapping dbusMapping{resDumpCurrentObjPath, resDumpProgressIntf,
                             "Status", "string"};
@@ -281,8 +277,6 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
     if (instanceIdDb == NULL)
     {
         error("Failed to send csr to remote terminus.");
-        pldm::utils::reportError(
-            "xyz.openbmc_project.bmc.pldm.InternalFailure");
         return;
     }
     auto instanceId = instanceIdDb->next(mctp_eid);
@@ -314,8 +308,6 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
             error(
                 "Failed to decode new file available response for vmi or remote terminus returned error, response code '{RC}' and completion code '{CC}'",
                 "RC", rc, "CC", static_cast<unsigned>(completionCode));
-            pldm::utils::reportError(
-                "xyz.openbmc_project.bmc.pldm.InternalFailure");
         }
     };
     rc = handler->registerRequest(
@@ -326,8 +318,6 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
         error(
             "Failed to send NewFileAvailable Request to Host for vmi, response code '{RC}'",
             "RC", rc);
-        pldm::utils::reportError(
-            "xyz.openbmc_project.bmc.pldm.InternalFailure");
     }
 }
 


### PR DESCRIPTION
In the pel registry , we have already removed all the instances where we send InternalError error, since its not really useful for debugging.

We need to carefully check the cases and add unique errors in the pel registry and then add those to the pldm code. Removing them for now to unblock the driver release.