### PR TITLE
oem-ibm: Add Real SAI sensor and effecter PDR support

### DIFF
--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Bonnell/4.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Bonnell/4.json
@@ -28,28 +28,6 @@
                     ]
                 },
                 {
-                    "type": 24581,
-                    "instance": 1,
-                    "container": 1,
-                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
-                    "sensors": [
-                        {
-                            "set": {
-                                "id": 10,
-                                "size": 1,
-                                "states": [1, 2]
-                            },
-                            "dbus": {
-                                "path": "/xyz/openbmc_project/inventory/system",
-                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                                "property_name": "Functional",
-                                "property_type": "bool",
-                                "property_values": [true, false]
-                            }
-                        }
-                    ]
-                },
-                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                     "sensors": [
                         {

--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Everest/4.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Everest/4.json
@@ -28,28 +28,6 @@
                     ]
                 },
                 {
-                    "type": 24581,
-                    "instance": 1,
-                    "container": 1,
-                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
-                    "sensors": [
-                        {
-                            "set": {
-                                "id": 10,
-                                "size": 1,
-                                "states": [1, 2]
-                            },
-                            "dbus": {
-                                "path": "/xyz/openbmc_project/inventory/system",
-                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                                "property_name": "Functional",
-                                "property_type": "bool",
-                                "property_values": [true, false]
-                            }
-                        }
-                    ]
-                },
-                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/bmc",
                     "sensors": [
                         {

--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Rainier1S4U/4.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Rainier1S4U/4.json
@@ -28,28 +28,6 @@
                     ]
                 },
                 {
-                    "type": 24581,
-                    "instance": 1,
-                    "container": 1,
-                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
-                    "sensors": [
-                        {
-                            "set": {
-                                "id": 10,
-                                "size": 1,
-                                "states": [1, 2]
-                            },
-                            "dbus": {
-                                "path": "/xyz/openbmc_project/inventory/system",
-                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                                "property_name": "Functional",
-                                "property_type": "bool",
-                                "property_values": [true, false]
-                            }
-                        }
-                    ]
-                },
-                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                     "sensors": [
                         {

--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Rainier2U/4.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Rainier2U/4.json
@@ -28,28 +28,6 @@
                     ]
                 },
                 {
-                    "type": 24581,
-                    "instance": 1,
-                    "container": 1,
-                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
-                    "sensors": [
-                        {
-                            "set": {
-                                "id": 10,
-                                "size": 1,
-                                "states": [1, 2]
-                            },
-                            "dbus": {
-                                "path": "/xyz/openbmc_project/inventory/system",
-                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                                "property_name": "Functional",
-                                "property_type": "bool",
-                                "property_values": [true, false]
-                            }
-                        }
-                    ]
-                },
-                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                     "sensors": [
                         {

--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Rainier4U/4.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Rainier4U/4.json
@@ -28,28 +28,6 @@
                     ]
                 },
                 {
-                    "type": 24581,
-                    "instance": 1,
-                    "container": 1,
-                    "parent_entity_path": "/xyz/openbmc_project/inventory/system",
-                    "sensors": [
-                        {
-                            "set": {
-                                "id": 10,
-                                "size": 1,
-                                "states": [1, 2]
-                            },
-                            "dbus": {
-                                "path": "/xyz/openbmc_project/inventory/system",
-                                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                                "property_name": "Functional",
-                                "property_type": "bool",
-                                "property_values": [true, false]
-                            }
-                        }
-                    ]
-                },
-                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis/motherboard/base_op_panel_blyth",
                     "sensors": [
                         {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -34,17 +34,24 @@ int pldm::responder::oem_ibm_platform::Handler::
     for (size_t i = 0; i < compSensorCnt; i++)
     {
         uint8_t sensorOpState{};
+        uint8_t presentState = PLDM_SENSOR_UNKNOWN;
         if (entityType == PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE &&
             stateSetId == PLDM_OEM_IBM_BOOT_STATE)
         {
             sensorOpState = fetchBootSide(entityInstance, codeUpdate);
+        }
+        else if (entityType == PLDM_OEM_IBM_ENTITY_REAL_SAI &&
+                 stateSetId == PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS)
+        {
+            sensorOpState = fetchRealSAIStatus();
+            presentState = PLDM_SENSOR_NORMAL;
         }
         else
         {
             rc = PLDM_PLATFORM_INVALID_STATE_VALUE;
             break;
         }
-        stateField.push_back({PLDM_SENSOR_ENABLED, PLDM_SENSOR_UNKNOWN,
+        stateField.push_back({PLDM_SENSOR_ENABLED, presentState,
                               PLDM_SENSOR_UNKNOWN, sensorOpState});
     }
     return rc;
@@ -160,6 +167,11 @@ int pldm::responder::oem_ibm_platform::Handler::
                 {
                     processPowerOffHardGraceful();
                 }
+            }
+            else if (entityType == PLDM_OEM_IBM_ENTITY_REAL_SAI &&
+                     stateSetId == PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS)
+            {
+                turnOffRealSAIEffecter();
             }
             else
             {
@@ -369,6 +381,101 @@ void buildAllCodeUpdateSensorPDR(oem_ibm_platform::Handler* platformHandler,
     repo.addRecord(pdrEntry);
 }
 
+void buildAllRealSAIEffecterPDR(oem_ibm_platform::Handler* platformHandler,
+                                uint16_t entityType, uint16_t entityInstance,
+                                pdr_utils::Repo& repo)
+{
+    size_t pdrSize = 0;
+    pdrSize = sizeof(pldm_state_effecter_pdr) +
+              sizeof(state_effecter_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_effecter_pdr* pdr =
+        reinterpret_cast<pldm_state_effecter_pdr*>(entry.data());
+    if (!pdr)
+    {
+        error("Failed to get Real SAI effecter PDR record due to the "
+              "error {ERR_CODE}",
+              "ERR_CODE", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_EFFECTER_ID));
+        return;
+    }
+    pdr->hdr.record_handle = 0;
+    pdr->hdr.version = 1;
+    pdr->hdr.type = PLDM_STATE_EFFECTER_PDR;
+    pdr->hdr.record_change_num = 0;
+    pdr->hdr.length = sizeof(pldm_state_effecter_pdr) - sizeof(pldm_pdr_hdr);
+    pdr->terminus_handle = TERMINUS_HANDLE;
+    pdr->effecter_id = platformHandler->getNextEffecterId();
+    pdr->entity_type = entityType;
+    pdr->entity_instance = entityInstance;
+    pdr->container_id = 1;
+    pdr->effecter_semantic_id = 0;
+    pdr->effecter_init = PLDM_NO_INIT;
+    pdr->has_description_pdr = false;
+    pdr->composite_effecter_count = 1;
+
+    auto* possibleStatesPtr = pdr->possible_states;
+    auto possibleStates =
+        reinterpret_cast<state_effecter_possible_states*>(possibleStatesPtr);
+    possibleStates->state_set_id = PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS;
+    possibleStates->possible_states_size = 1;
+    auto state =
+        reinterpret_cast<state_effecter_possible_states*>(possibleStates);
+    state->states[0].byte = 2;
+    pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+    pdrEntry.data = entry.data();
+    pdrEntry.size = pdrSize;
+    repo.addRecord(pdrEntry);
+}
+
+void buildAllRealSAISensorPDR(oem_ibm_platform::Handler* platformHandler,
+                              uint16_t entityType, uint16_t entityInstance,
+                              pdr_utils::Repo& repo)
+{
+    size_t pdrSize = 0;
+    pdrSize = sizeof(pldm_state_sensor_pdr) +
+              sizeof(state_sensor_possible_states);
+    std::vector<uint8_t> entry{};
+    entry.resize(pdrSize);
+    pldm_state_sensor_pdr* pdr =
+        reinterpret_cast<pldm_state_sensor_pdr*>(entry.data());
+    if (!pdr)
+    {
+        error("Failed to get Real SAI sensor PDR record due to the "
+              "error {ERR_CODE}",
+              "ERR_CODE", lg2::hex,
+              static_cast<unsigned>(PLDM_PLATFORM_INVALID_SENSOR_ID));
+        return;
+    }
+    pdr->hdr.record_handle = 0;
+    pdr->hdr.version = 1;
+    pdr->hdr.type = PLDM_STATE_SENSOR_PDR;
+    pdr->hdr.record_change_num = 0;
+    pdr->hdr.length = sizeof(pldm_state_sensor_pdr) - sizeof(pldm_pdr_hdr);
+    pdr->terminus_handle = TERMINUS_HANDLE;
+    pdr->sensor_id = platformHandler->getNextSensorId();
+    pdr->entity_type = entityType;
+    pdr->entity_instance = entityInstance;
+    pdr->container_id = 1;
+    pdr->sensor_init = PLDM_NO_INIT;
+    pdr->sensor_auxiliary_names_pdr = false;
+    pdr->composite_sensor_count = 1;
+
+    auto* possibleStatesPtr = pdr->possible_states;
+    auto possibleStates =
+        reinterpret_cast<state_sensor_possible_states*>(possibleStatesPtr);
+    possibleStates->state_set_id = PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS;
+    possibleStates->possible_states_size = 2;
+    auto state =
+        reinterpret_cast<state_sensor_possible_states*>(possibleStates);
+    state->states[0].byte = 6;
+    pldm::responder::pdr_utils::PdrEntry pdrEntry{};
+    pdrEntry.data = entry.data();
+    pdrEntry.size = pdrSize;
+    repo.addRecord(pdrEntry);
+}
+
 void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     pdr_utils::Repo& repo)
 {
@@ -384,6 +491,8 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     buildAllCodeUpdateEffecterPDR(this, PLDM_ENTITY_SYSTEM_CHASSIS,
                                   ENTITY_INSTANCE_1,
                                   PLDM_OEM_IBM_SYSTEM_POWER_STATE, repo);
+    buildAllRealSAIEffecterPDR(this, PLDM_OEM_IBM_ENTITY_REAL_SAI,
+                               ENTITY_INSTANCE_1, repo);
 
     buildAllCodeUpdateSensorPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
                                 ENTITY_INSTANCE_0, PLDM_OEM_IBM_BOOT_STATE,
@@ -397,17 +506,26 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     buildAllCodeUpdateSensorPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
                                 ENTITY_INSTANCE_0,
                                 PLDM_OEM_IBM_VERIFICATION_STATE, repo);
+    buildAllRealSAISensorPDR(this, PLDM_OEM_IBM_ENTITY_REAL_SAI,
+                             ENTITY_INSTANCE_1, repo);
 
     buildAllSystemPowerStateEffecterPDR(
         this, PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER, ENTITY_INSTANCE_0,
         PLDM_STATE_SET_SYSTEM_POWER_STATE, repo);
 
+    pldm_entity saiEntity = {PLDM_OEM_IBM_ENTITY_REAL_SAI, 1, 1};
+    attachOemEntityToEntityAssociationPDR(
+        this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,
+        saiEntity);
     pldm_entity powerStateEntity = {PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER, 0,
                                     1};
     attachOemEntityToEntityAssociationPDR(
         this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,
         powerStateEntity);
 
+    realSAISensorId = findStateSensorId(
+        repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_REAL_SAI, ENTITY_INSTANCE_1, 1,
+        PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS);
     auto sensorId = findStateSensorId(
         repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
         ENTITY_INSTANCE_0, 1, PLDM_OEM_IBM_VERIFICATION_STATE);
@@ -884,6 +1002,68 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
             "ERR_EXCEP", e);
     }
     processPowerOffSoftGraceful();
+}
+
+void pldm::responder::oem_ibm_platform::Handler::turnOffRealSAIEffecter()
+{
+    try
+    {
+        pldm::utils::DBusMapping dbusPartitionMapping{
+            "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group", "Asserted", "bool"};
+        pldm::utils::DBusHandler().setDbusProperty(dbusPartitionMapping, false);
+    }
+    catch (const std::exception& e)
+    {
+        error("Turn off of partition SAI effecter failed with "
+              "error:{ERR_EXCEP}",
+              "ERR_EXCEP", e);
+    }
+    try
+    {
+        pldm::utils::DBusMapping dbusPlatformMapping{
+            "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group", "Asserted", "bool"};
+        pldm::utils::DBusHandler().setDbusProperty(dbusPlatformMapping, false);
+    }
+    catch (const std::exception& e)
+    {
+        error("Turn off of platform SAI effecter failed with "
+              "error:{ERR_EXCEP}",
+              "ERR_EXCEP", e);
+    }
+}
+
+uint8_t pldm::responder::oem_ibm_platform::Handler::fetchRealSAIStatus()
+{
+    try
+    {
+        auto isPartitionSAIOn = pldm::utils::DBusHandler().getDbusProperty<bool>(
+            "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+            "Asserted", "xyz.openbmc_project.Led.Group");
+        auto isPlatformSAIOn = pldm::utils::DBusHandler().getDbusProperty<bool>(
+            "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+            "Asserted", "xyz.openbmc_project.Led.Group");
+
+        if (isPartitionSAIOn || isPlatformSAIOn)
+        {
+            return PLDM_SENSOR_WARNING;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        error("Fetching of Real SAI sensor status failed with "
+              "error:{ERR_EXCEP}",
+              "ERR_EXCEP", e);
+    }
+    return PLDM_SENSOR_NORMAL;
+}
+
+void pldm::responder::oem_ibm_platform::Handler::processSAIUpdate()
+{
+    auto realSAIState = fetchRealSAIStatus();
+    sendStateSensorEvent(realSAISensorId, PLDM_STATE_SENSOR_STATE, 0,
+                         uint8_t(realSAIState), uint8_t(PLDM_SENSOR_UNKNOWN));
 }
 
 } // namespace oem_ibm_platform

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -10,6 +10,7 @@
 #include <libpldm/entity.h>
 #include <libpldm/oem/ibm/state_set.h>
 #include <libpldm/platform.h>
+#include <libpldm/state_set.h>
 
 #include <sdbusplus/bus/match.hpp>
 #include <sdeventplus/event.hpp>
@@ -145,6 +146,38 @@ class Handler : public oem_platform::Handler
                         }
                     }
                 }
+            }
+        });
+
+        platformSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged(
+                "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+                "xyz.openbmc_project.Led.Group"),
+            [this](sdbusplus::message_t& msg) {
+            pldm::utils::DbusChangedProps props{};
+            std::string intf;
+            msg.read(intf, props);
+            const auto itr = props.find("Asserted");
+            if (itr != props.end())
+            {
+                processSAIUpdate();
+            }
+        });
+
+        partitionSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged(
+                "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+                "xyz.openbmc_project.Led.Group"),
+            [this](sdbusplus::message_t& msg) {
+            pldm::utils::DbusChangedProps props{};
+            std::string intf;
+            msg.read(intf, props);
+            const auto itr = props.find("Asserted");
+            if (itr != props.end())
+            {
+                processSAIUpdate();
             }
         });
     }
@@ -322,6 +355,19 @@ class Handler : public oem_platform::Handler
      */
     void setSurvTimer(uint8_t tid, bool value);
 
+    /** @brief To turn off Real SAI effecter*/
+    void turnOffRealSAIEffecter();
+
+    /** @brief Fetch Real SAI status based on the partition SAI and platform SAI
+     *  sensor states. Real SAI is turned on if any of the partition or platform
+     *  SAI turned on else Real SAI is turned off
+     *  @return Real SAI sensor state PLDM_SENSOR_WARNING/PLDM_SENSOR_NORMAL
+     */
+    uint8_t fetchRealSAIStatus();
+
+    /** @brief Method to process virtual platform/partition SAI update*/
+    void processSAIUpdate();
+
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object
@@ -370,6 +416,12 @@ class Handler : public oem_platform::Handler
     /** @brief D-Bus property changed signal match */
     std::unique_ptr<sdbusplus::bus::match_t> powerStateOffMatch;
 
+    /** @brief D-Bus Interface added signal match for virtual platform SAI */
+    std::unique_ptr<sdbusplus::bus::match_t> platformSAIMatch;
+
+    /** @brief D-Bus Interface added signal match for virtual partition SAI */
+    std::unique_ptr<sdbusplus::bus::match_t> partitionSAIMatch;
+
     /** @brief Timer used for monitoring surveillance pings from host */
     sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
 
@@ -378,6 +430,9 @@ class Handler : public oem_platform::Handler
     bool hostTransitioningToOff;
 
     int setEventReceiverCnt = 0;
+
+    /** @brief Real SAI sensor id*/
+    uint16_t realSAISensorId;
 };
 
 /** @brief Method to encode code update event msg

--- a/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
+++ b/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
@@ -292,6 +292,33 @@ TEST(generateStateEffecterOEMPDR, testGoodRequest)
     bf3.byte = 126;
     ASSERT_EQ(states->states[0].byte, bf3.byte);
 
+    // Test for effecter number 5, to turn off Real SAI led
+    auto record5 = pdr::getRecordByHandle(inRepo, 5, e);
+    ASSERT_NE(record5, nullptr);
+
+    pdr = reinterpret_cast<pldm_state_effecter_pdr*>(e.data);
+
+    ASSERT_EQ(pdr->hdr.record_handle, 5);
+    ASSERT_EQ(pdr->hdr.version, 1);
+    ASSERT_EQ(pdr->hdr.type, PLDM_STATE_EFFECTER_PDR);
+    ASSERT_EQ(pdr->hdr.record_change_num, 0);
+    ASSERT_EQ(pdr->hdr.length, 16);
+    ASSERT_EQ(pdr->terminus_handle, TERMINUS_HANDLE);
+    ASSERT_EQ(pdr->entity_type, PLDM_OEM_IBM_ENTITY_REAL_SAI);
+    ASSERT_EQ(pdr->entity_instance, 1);
+    ASSERT_EQ(pdr->container_id, 1);
+    ASSERT_EQ(pdr->effecter_semantic_id, 0);
+    ASSERT_EQ(pdr->effecter_init, PLDM_NO_INIT);
+    ASSERT_EQ(pdr->has_description_pdr, false);
+    ASSERT_EQ(pdr->composite_effecter_count, 1);
+    states =
+        reinterpret_cast<state_effecter_possible_states*>(pdr->possible_states);
+    ASSERT_EQ(states->state_set_id, PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS);
+    ASSERT_EQ(states->possible_states_size, 1);
+    bitfield8_t bf5{};
+    bf5.byte = 2;
+    ASSERT_EQ(states->states[0].byte, bf5.byte);
+
     pldm_pdr_destroy(inPDRRepo);
 }
 
@@ -319,13 +346,13 @@ TEST(generateStateSensorOEMPDR, testGoodRequest)
     pdr_utils::PdrEntry e;
 
     // Test for sensor number 1, for current boot side state
-    auto record1 = pdr::getRecordByHandle(inRepo, 5, e);
+    auto record1 = pdr::getRecordByHandle(inRepo, 6, e);
     ASSERT_NE(record1, nullptr);
 
     pldm_state_sensor_pdr* pdr =
         reinterpret_cast<pldm_state_sensor_pdr*>(e.data);
 
-    ASSERT_EQ(pdr->hdr.record_handle, 5);
+    ASSERT_EQ(pdr->hdr.record_handle, 6);
     ASSERT_EQ(pdr->hdr.version, 1);
     ASSERT_EQ(pdr->hdr.type, PLDM_STATE_SENSOR_PDR);
     ASSERT_EQ(pdr->hdr.record_change_num, 0);
@@ -346,12 +373,12 @@ TEST(generateStateSensorOEMPDR, testGoodRequest)
     ASSERT_EQ(states->states[0].byte, bf1.byte);
 
     // Test for sensor number 2, for next boot side state
-    auto record2 = pdr::getRecordByHandle(inRepo, 6, e);
+    auto record2 = pdr::getRecordByHandle(inRepo, 7, e);
     ASSERT_NE(record2, nullptr);
 
     pdr = reinterpret_cast<pldm_state_sensor_pdr*>(e.data);
 
-    ASSERT_EQ(pdr->hdr.record_handle, 6);
+    ASSERT_EQ(pdr->hdr.record_handle, 7);
     ASSERT_EQ(pdr->hdr.version, 1);
     ASSERT_EQ(pdr->hdr.type, PLDM_STATE_SENSOR_PDR);
     ASSERT_EQ(pdr->hdr.record_change_num, 0);
@@ -372,12 +399,12 @@ TEST(generateStateSensorOEMPDR, testGoodRequest)
     ASSERT_EQ(states->states[0].byte, bf2.byte);
 
     // Test for sensor number 3, for firmware update state control
-    auto record3 = pdr::getRecordByHandle(inRepo, 7, e);
+    auto record3 = pdr::getRecordByHandle(inRepo, 8, e);
     ASSERT_NE(record3, nullptr);
 
     pdr = reinterpret_cast<pldm_state_sensor_pdr*>(e.data);
 
-    ASSERT_EQ(pdr->hdr.record_handle, 7);
+    ASSERT_EQ(pdr->hdr.record_handle, 8);
     ASSERT_EQ(pdr->hdr.version, 1);
     ASSERT_EQ(pdr->hdr.type, PLDM_STATE_SENSOR_PDR);
     ASSERT_EQ(pdr->hdr.record_change_num, 0);
@@ -396,6 +423,32 @@ TEST(generateStateSensorOEMPDR, testGoodRequest)
     bitfield8_t bf3{};
     bf3.byte = 126;
     ASSERT_EQ(states->states[0].byte, bf3.byte);
+
+    // Test for sensor number 5, for Real SAI sensor states
+    auto record5 = pdr::getRecordByHandle(inRepo, 10, e);
+    ASSERT_NE(record5, nullptr);
+
+    pdr = reinterpret_cast<pldm_state_sensor_pdr*>(e.data);
+
+    ASSERT_EQ(pdr->hdr.record_handle, 10);
+    ASSERT_EQ(pdr->hdr.version, 1);
+    ASSERT_EQ(pdr->hdr.type, PLDM_STATE_SENSOR_PDR);
+    ASSERT_EQ(pdr->hdr.record_change_num, 0);
+    ASSERT_EQ(pdr->hdr.length, 14);
+    ASSERT_EQ(pdr->terminus_handle, TERMINUS_HANDLE);
+    ASSERT_EQ(pdr->entity_type, PLDM_OEM_IBM_ENTITY_REAL_SAI);
+    ASSERT_EQ(pdr->entity_instance, 1);
+    ASSERT_EQ(pdr->container_id, 1);
+    ASSERT_EQ(pdr->sensor_init, PLDM_NO_INIT);
+    ASSERT_EQ(pdr->sensor_auxiliary_names_pdr, false);
+    ASSERT_EQ(pdr->composite_sensor_count, 1);
+    states =
+        reinterpret_cast<state_sensor_possible_states*>(pdr->possible_states);
+    ASSERT_EQ(states->state_set_id, PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS);
+    ASSERT_EQ(states->possible_states_size, 2);
+    bitfield8_t bf5{};
+    bf5.byte = 6;
+    ASSERT_EQ(states->states[0].byte, bf5.byte);
 
     pldm_pdr_destroy(inPDRRepo);
 }

--- a/pldmtool/oem/ibm/oem_ibm_state_set.hpp
+++ b/pldmtool/oem/ibm/oem_ibm_state_set.hpp
@@ -44,8 +44,9 @@ enum pldm_oem_ibm_boot_state_set_values
 extern const std::map<uint8_t, std::string> OemIBMEntityType{
     {PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE, "OEM IBM Firmware Update"},
     {PLDM_OEM_IBM_ENTITY_TPM, "OEM IBM Trusted Platform Module"},
-    {PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER,
-     "OEM IBM Chassis Power Controller"}};
+    {PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER, "OEM IBM Chassis Power Controller"},
+    {PLDM_OEM_IBM_ENTITY_REAL_SAI, "OEM IBM Real SAI"},
+};
 
 /** @brief Map for PLDM OEM IBM State Sets
  */


### PR DESCRIPTION
Real SAI(Sysytem Attention Indicator) is a physical led indicatori which lights up whenever there is a platform error (originated from BMC) or a partition error that is not mapped to any physical FRU (Field Replaceable Unit)

Real SAI scenarios
1. Real SAI effecter can be turned off by the user OR by host
2. Real SAI sensor is turned on if any of the partition SAI Or platform SAI is turned on
3. Real SAI is turned off if both partition and platform SAI are turned off
4. SAI data should be synced to host when host is up

Testing Data:

Real SAI Effecter:
{
    "nextRecordHandle": 87,
    "responseCount": 30,
    "recordHandle": 86,
    "PDRHeaderVersion": 1,
    "PDRType": "State Effecter PDR",
    "recordChangeNumber": 0,
    "dataLength": 16,
    "PLDMTerminusHandle": 1,
    "effecterID": 5,
    "entityType": "[Physical] OEM IBM Real SAI(OEM)",
    "entityInstanceNumber": 1,
    "containerID": 1,
    "effecterSemanticID": 0,
    "effecterInit": "noInit",
    "effecterDescriptionPDR": false,
    "compositeEffecterCount": 1,
    "stateSetID[0]": "Operational Fault Status(10)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Normal(1)"
    ]
}

Real SAI Sensor:
{
    "nextRecordHandle": 88,
    "responseCount": 28,
    "recordHandle": 87,
    "PDRHeaderVersion": 1,
    "PDRType": "State Sensor PDR",
    "recordChangeNumber": 0,
    "dataLength": 14,
    "PLDMTerminusHandle": 1,
    "sensorID": 1,
    "entityType": "[Physical] OEM IBM Real SAI(OEM)",
    "entityInstanceNumber": 1,
    "containerID": 1,
    "sensorInit": "noInit",
    "sensorAuxiliaryNamesPDR": false,
    "compositeSensorCount": 1,
    "stateSetID[0]": "Operational Fault Status(10)",
    "possibleStatesSize[0]": 2,
    "possibleStates[0]": [
        "Normal(1)",
        "Error(2)"
    ]
}

When Real SAI is OFF:
busctl get-property  xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/platform_system_attention_indicator xyz.openbmc_project.Led.Group Asserted
b false
busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/partition_system_attention_indicator xyz.openbmc_project.Led.Group Asserted
b false

platform GetStateSensorReadings -i 1 -r 0
{
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Normal"
}

Make the Real SAI ON with platform SAI:

busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/platform_system_attention_indicator xyz.openbmc_project.Led.Group Asserted b true

pldmtool platform GetStateSensorReadings -i 1 -r 0 {
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Warning"
}

Turn Off Real SAI using the effecter:

pldmtool platform SetStateEffecterStates -i 5 -c 1 -d 1 1 {
    "Response": "SUCCESS"
}

pldmtool platform GetStateSensorReadings -i 1 -r 0 {
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Normal"
}

Make the Real SAI ON with partition SAI:

busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/partition_system_attention_indicator xyz.openbmc_project.Led.Group Asserted b true

pldmtool platform GetStateSensorReadings -i 1 -r 0 {
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Warning"
}

Turn OFF Real SAI using set-property cmd:

busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/partition_system_attention_indicator xyz.openbmc_project.Led.Group Asserted b false

pldmtool platform GetStateSensorReadings -i 1 -r 0 {
    "compositeSensorCount": 1,
    "sensorOpState[0]": "Sensor Enabled",
    "presentState[0]": "Sensor Normal",
    "previousState[0]": "Sensor Unknown",
    "eventState[0]": "Sensor Normal"
}

Change-Id: Iaa34fbf23bf1fee6076e4a32a24626293b58f1ae