### PR TITLE
host-bmc: Logging PEL for PDR Exchange Failure

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -476,6 +476,8 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
     if (response == nullptr || !respMsgLen)
     {
         error("Failed to receive response for the GetPDR command");
+        pldm::utils::reportError(
+            "xyz.openbmc_project.PLDM.Error.GetPDR.PDRExchangeFailure");
         return;
     }
 


### PR DESCRIPTION
This commit logs PEL when BMC fails to collect PDR from host.  GetPDR returns no response because of BMC PDR exchange failure after three tries get exhausted and timeout occurs.

Tested: Functional testing.