### PR TITLE
pldm: Adding Fix for NVRAM checksum corruption

### DIFF
--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -19,8 +19,7 @@ using Json = nlohmann::json;
 
 /** @struct CustomFD
  *
- *  CustomFD class is created for special purpose using RAII and it wil be
- * useful during AIO file transfer operation.
+ *  CustomFD class is created for special purpose using RAII.
  */
 struct CustomFD
 {
@@ -29,13 +28,11 @@ struct CustomFD
     CustomFD(CustomFD&&) = delete;
     CustomFD& operator=(CustomFD&&) = delete;
 
-    CustomFD(int fd, bool closeOnOutScope = true) :
-        fd(fd), closeOnOutScope(closeOnOutScope)
-    {}
+    CustomFD(int fd) : fd(fd) {}
 
     ~CustomFD()
     {
-        if (fd >= 0 && closeOnOutScope)
+        if (fd >= 0)
         {
             close(fd);
         }
@@ -48,7 +45,6 @@ struct CustomFD
 
   private:
     int fd = -1;
-    bool closeOnOutScope;
 };
 
 /** @brief Setup UNIX socket


### PR DESCRIPTION
When user do chasisoff then power is abruptly down for chassis and NVRAM file transfer is abruptly stops which leads to mismatch NVRAM file checksum and PHYP updated checksum due to data corruption. This commit adds the synchronous file transfer mechanism only for NVRAM and Checksum file to avoid race condition while chassis off.