### PR TITLE
oem-ibm: PLDM Power down effecter and APR support

### DIFF
--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -54,6 +54,7 @@ class Handler : public CmdHandler
             pldm_pdr* repo, HostPDRHandler* hostPDRHandler,
             pldm::state_sensor::DbusToPLDMEvent* dbusToPLDMEventHandler,
             fru::Handler* fruHandler,
+            pldm_entity_association_tree* bmcEntityTree,
             pldm::responder::oem_platform::Handler* oemPlatformHandler,
             pldm::responder::platform_config::Handler* platformConfigHandler,
             pldm::requester::Handler<pldm::requester::Request>* handler,
@@ -63,7 +64,8 @@ class Handler : public CmdHandler
         instanceIdDb(instanceIdDb), pdrRepo(repo),
         hostPDRHandler(hostPDRHandler),
         dbusToPLDMEventHandler(dbusToPLDMEventHandler), fruHandler(fruHandler),
-        dBusIntf(dBusIntf), oemPlatformHandler(oemPlatformHandler),
+        bmcEntityTree(bmcEntityTree), dBusIntf(dBusIntf),
+        oemPlatformHandler(oemPlatformHandler),
         platformConfigHandler(platformConfigHandler), handler(handler),
         event(event), pdrJsonDir(pdrJsonDir), pdrCreated(false),
         pdrJsonsDir({pdrJsonDir})
@@ -499,6 +501,7 @@ class Handler : public CmdHandler
     HostPDRHandler* hostPDRHandler;
     pldm::state_sensor::DbusToPLDMEvent* dbusToPLDMEventHandler;
     fru::Handler* fruHandler;
+    pldm_entity_association_tree* bmcEntityTree;
     const pldm::utils::DBusHandler* dBusIntf;
     pldm::responder::oem_platform::Handler* oemPlatformHandler;
     pldm::responder::platform_config::Handler* platformConfigHandler;

--- a/libpldmresponder/test/libpldmresponder_pdr_effecter_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_pdr_effecter_test.cpp
@@ -32,7 +32,7 @@ TEST(GeneratePDRByStateEffecter, testGoodJson)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_EFFECTER_PDR);
 
@@ -133,7 +133,7 @@ TEST(GeneratePDRByNumericEffecter, testGoodJson)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_NUMERIC_EFFECTER_PDR);
 
@@ -181,7 +181,7 @@ TEST(GeneratePDR, testMalformedJson)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_EFFECTER_PDR);
 
@@ -204,7 +204,7 @@ TEST(findStateEffecterId, goodJson)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     uint16_t entityType = 33;
     uint16_t entityInstance = 0;
     uint16_t containerId = 0;

--- a/libpldmresponder/test/libpldmresponder_pdr_sensor_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_pdr_sensor_test.cpp
@@ -36,7 +36,7 @@ TEST(GeneratePDRByStateSensor, testGoodJson)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_sensor/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     handler.getPDR(req, requestPayloadLength);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_SENSOR_PDR);
@@ -88,7 +88,7 @@ TEST(GeneratePDR, testMalformedJson)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_sensor/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     handler.getPDR(req, requestPayloadLength);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_SENSOR_PDR);

--- a/libpldmresponder/test/libpldmresponder_platform_test.cpp
+++ b/libpldmresponder/test/libpldmresponder_platform_test.cpp
@@ -43,7 +43,7 @@ TEST(getPDR, testGoodPath)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     pdrRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -82,7 +82,7 @@ TEST(getPDR, testShortRead)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     pdrRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -115,7 +115,7 @@ TEST(getPDR, testBadRecordHandle)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     pdrRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -146,7 +146,7 @@ TEST(getPDR, testNoNextRecord)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     pdrRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -179,7 +179,7 @@ TEST(getPDR, testFindPDR)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     pdrRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo repo(pdrRepo);
     ASSERT_EQ(repo.empty(), false);
     auto response = handler.getPDR(req, requestPayloadLength);
@@ -240,7 +240,7 @@ TEST(setStateEffecterStatesHandler, testGoodRequest)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     handler.getPDR(req, requestPayloadLength);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_EFFECTER_PDR);
@@ -288,7 +288,7 @@ TEST(setStateEffecterStatesHandler, testBadRequest)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     handler.getPDR(req, requestPayloadLength);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_EFFECTER_PDR);
@@ -335,7 +335,7 @@ TEST(setNumericEffecterValueHandler, testGoodRequest)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, numericEffecterPDRs, PLDM_NUMERIC_EFFECTER_PDR);
 
@@ -379,7 +379,7 @@ TEST(setNumericEffecterValueHandler, testBadRequest)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, numericEffecterPDRs, PLDM_NUMERIC_EFFECTER_PDR);
 
@@ -416,7 +416,7 @@ TEST(getNumericEffecterValueHandler, testGoodRequest)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, numericEffecterPDRs, PLDM_NUMERIC_EFFECTER_PDR);
 
@@ -493,7 +493,7 @@ TEST(getNumericEffecterValueHandler, testBadRequest)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_effecter/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, numericEffecterPDRs, PLDM_NUMERIC_EFFECTER_PDR);
 
@@ -750,7 +750,7 @@ TEST(TerminusLocatorPDR, BMCTerminusLocatorPDR)
     MockdBusHandler mockedUtils;
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "", inPDRRepo, nullptr, nullptr,
-                    nullptr, nullptr, nullptr, nullptr, event);
+                    nullptr, nullptr, nullptr, nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_TERMINUS_LOCATOR_PDR);
 
@@ -796,7 +796,7 @@ TEST(getStateSensorReadingsHandler, testGoodRequest)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_sensor/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_SENSOR_PDR);
     pdr_utils::PdrEntry e;
@@ -846,7 +846,7 @@ TEST(getStateSensorReadingsHandler, testBadRequest)
     auto event = sdeventplus::Event::get_default();
     Handler handler(&mockedUtils, 0, nullptr, "./pdr_jsons/state_sensor/good",
                     inPDRRepo, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, event);
+                    nullptr, nullptr, event);
     Repo inRepo(inPDRRepo);
     getRepoByType(inRepo, outRepo, PLDM_STATE_SENSOR_PDR);
     pdr_utils::PdrEntry e;

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -250,7 +250,7 @@ int main(int argc, char** argv)
     codeUpdate->clearDirPath(LID_STAGING_DIR);
     oemPlatformHandler = std::make_unique<oem_ibm_platform::Handler>(
         &dbusHandler, codeUpdate.get(), pldmTransport.getEventSource(), hostEID,
-        instanceIdDb, event, &reqHandler);
+        instanceIdDb, event, &reqHandler, bmcEntityTree.get());
     codeUpdate->setOemPlatformHandler(oemPlatformHandler.get());
     oemFruHandler = std::make_unique<oem_ibm_fru::Handler>(pdrRepo.get());
     invoker.registerHandler(PLDM_OEM, std::make_unique<oem_ibm::Handler>(
@@ -290,8 +290,8 @@ int main(int argc, char** argv)
     auto platformHandler = std::make_unique<platform::Handler>(
         &dbusHandler, hostEID, &instanceIdDb, PDR_JSONS_DIR, pdrRepo.get(),
         hostPDRHandler.get(), dbusToPLDMEventHandler.get(), fruHandler.get(),
-        oemPlatformHandler.get(), platformConfigHandler.get(), &reqHandler,
-        event, true);
+        bmcEntityTree.get(), oemPlatformHandler.get(),
+        platformConfigHandler.get(), &reqHandler, event, true);
 #ifdef OEM_IBM
     pldm::responder::oem_ibm_platform::Handler* oemIbmPlatformHandler =
         dynamic_cast<pldm::responder::oem_ibm_platform::Handler*>(

--- a/pldmtool/oem/ibm/oem_ibm_state_set.hpp
+++ b/pldmtool/oem/ibm/oem_ibm_state_set.hpp
@@ -43,7 +43,9 @@ enum pldm_oem_ibm_boot_state_set_values
  */
 extern const std::map<uint8_t, std::string> OemIBMEntityType{
     {PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE, "OEM IBM Firmware Update"},
-    {PLDM_OEM_IBM_ENTITY_TPM, "OEM IBM Trusted Platform Module"}};
+    {PLDM_OEM_IBM_ENTITY_TPM, "OEM IBM Trusted Platform Module"},
+    {PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER,
+     "OEM IBM Chassis Power Controller"}};
 
 /** @brief Map for PLDM OEM IBM State Sets
  */

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -541,8 +541,11 @@ class GetPDR : public CommandInterface
          "Non Recoverable Error"}};
 
     static inline const std::map<uint8_t, std::string> setSysPowerState{
-        {PLDM_STATE_SET_SYS_POWER_STATE_OFF_SOFT_GRACEFUL,
-         "Off-Soft Graceful"}};
+        {PLDM_STATE_SET_SYS_POWER_STATE_OFF_SOFT_GRACEFUL, "Off-Soft Graceful"},
+        {PLDM_STATE_SET_SYS_POWER_CYCLE_OFF_SOFT_GRACEFUL,
+         "Power Cycle Off-Soft Graceful"},
+        {PLDM_STATE_SET_SYS_POWER_STATE_OFF_HARD_GRACEFUL,
+         "Off-Hard Graceful"}};
 
     static inline const std::map<uint8_t, std::string> setSWTerminationStatus{
         {PLDM_SW_TERM_GRACEFUL_RESTART_REQUESTED,


### PR DESCRIPTION
This commit adds a single OEM state effecter with a OEM entity type and with states [7, 9, 10] to perform 3 custom actions ReIPL, PowerDown and ArmAPR.

The defined states are
PLDM_POWER_CYCLE_OFF_SOFT_GRACEFUL= 7,
PLDM_POWER_OFF_SOFT_GRACEFUL= 9 and
PLDM_POWER_OFF_HARD_GRACEFUL= 10

When PHYP toggles the PLDM_POWER_CYCLE_OFF_SOFT_GRACEFUL we set the state manager property RequestedHostTransition to ForceWarmReboot instead of Reboot, this will directly reboot the host firmware without notification and chassis power will remain on throughout the reboot, instead of doing a graceful reboot.