### PR TITLE
pldm: Adding exception handling while hosting Dbus path

### DIFF
--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -101,25 +101,23 @@ void addObjectPathEntityAssociations(
             {
                 oemPlatformHandler->updateOemDbusPaths(entity_path);
             }
-            // If the entity obtained from the remote PLDM terminal is not in
-            // the MAP, or there is no auxiliary name PDR, add it directly.
-            // Otherwise, check whether the DBus service of entity_path exists,
-            // and overwrite the entity if it does not exist.
-            if (!objPathMap.contains(entity_path))
+            try
             {
-                objPathMap[entity_path] = node_entity;
-            }
-            else
-            {
-                try
-                {
-                    pldm::utils::DBusHandler().getService(entity_path.c_str(),
-                                                          nullptr);
-                }
-                catch (const std::exception& e)
+                pldm::utils::DBusHandler().getService(entity_path.c_str(),
+                                                      nullptr);
+                // If the entity obtained from the remote PLDM terminal is not
+                // in the MAP, or there is no auxiliary name PDR, add it
+                // directly. Otherwise, check whether the DBus service of
+                // entity_path exists, and overwrite the entity if it does not
+                // exist.
+                if (objPathMap.contains(entity_path))
                 {
                     objPathMap[entity_path] = node_entity;
                 }
+            }
+            catch (const std::exception&)
+            {
+                objPathMap[entity_path] = node_entity;
             }
 
             for (size_t i = 1; i < ev.size(); i++)
@@ -144,8 +142,12 @@ void addObjectPathEntityAssociations(
         try
         {
             pldm::utils::DBusHandler().getService(dbusPath.c_str(), nullptr);
+            if (objPathMap.contains(dbusPath))
+            {
+                objPathMap[dbusPath] = node_entity;
+            }
         }
-        catch (const std::exception& e)
+        catch (const std::exception&)
         {
             objPathMap[dbusPath] = node_entity;
         }


### PR DESCRIPTION
This commit add support to check if Dbus interface are hosted by other application or not.
if Dbus interface hosted by othe app then PLDM will skip the hosting and take existing path.

Tested:
Tested motherboard interface which is hosted by inventory manager:
` DICT_ENTRY "sas" {
                        STRING "xyz.openbmc_project.Inventory.Manager";
                        ARRAY "s" {
                                STRING "xyz.openbmc_project.Inventory.Decorator.LocationCode";
                                STRING "xyz.openbmc_project.Inventory.Item";
                                STRING "**xyz.openbmc_project.Inventory.Item.Board.Motherboard**";
                                STRING "xyz.openbmc_project.Object.Enable";
                                STRING "xyz.openbmc_project.State.Decorator.OperationalStatus";
                        };
                };

 DICT_ENTRY "sas" {
                        STRING "xyz.openbmc_project.PLDM";
                        ARRAY "s" {
                                STRING "org.freedesktop.DBus.Introspectable";
                                STRING "org.freedesktop.DBus.Peer";
                                STRING "org.freedesktop.DBus.Properties";
                        };
                };
        };
};
`