### PR TITLE
pdr: Avoid logging PEL when host is transitioning to off

### DIFF
--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -366,6 +366,9 @@ class HostPDRHandler
     uint16_t terminusID = 0;
 
     bool isHostOff;
+
+    /** @brief true/false based on the host transitioning value */
+    bool isHostTransitioningToOff;
 };
 
 } // namespace pldm


### PR DESCRIPTION
When there is a PDR exchange happening with host and we trigger a poweroff we were logging a pel BD8D6026 when the PDR exchange fails. This change is needed check if the host is up or not and then log an error if host is up.