### PR TITLE
stdexec: pass scheduler to default_task_context

### DIFF
--- a/requester/test/handler_test.cpp
+++ b/requester/test/handler_test.cpp
@@ -187,7 +187,7 @@ TEST_F(HandlerTest, singleRequestResponseScenarioUsingCoroutine)
 
         EXPECT_EQ(validResponse, true);
     }),
-                exec::default_task_context<void>());
+                exec::default_task_context<void>(exec::inline_scheduler{}));
 
     pldm::Response mockResponse(sizeof(pldm_msg_hdr) + sizeof(uint8_t), 0);
     auto mockResponsePtr =
@@ -220,7 +220,7 @@ TEST_F(HandlerTest, singleRequestCancellationScenarioUsingCoroutine)
 
         EXPECT_TRUE(false); // unreachable
     }) | stdexec::upon_stopped([&] { stopped = true; }),
-                exec::default_task_context<void>());
+                exec::default_task_context<void>(exec::inline_scheduler{}));
 
     scope.request_stop();
 
@@ -273,7 +273,7 @@ TEST_F(HandlerTest, asyncRequestResponseByCoroutine)
 
         EXPECT_EQ(expectedTid, respTid);
     }),
-                exec::default_task_context<void>());
+                exec::default_task_context<void>(exec::inline_scheduler{}));
 
     pldm::Response mockResponse(sizeof(pldm_msg_hdr) + PLDM_GET_TID_RESP_BYTES,
                                 0);


### PR DESCRIPTION
The latest version of stdexec[1] does not allow a default constructed `default_task_context` but requires a scheduler to be passed in.  The previous default was to use an `inline_scheduler` so explicitly pass that in.

[1]: https://github.com/openbmc/sdbusplus/commit/5cee91570368554a7fcbbd9418f65efda449fa70

Change-Id: Id9f24661ec23f87bbe217bc0b1a87dae68efa4b0
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>