### PR TITLE
host-bmc: Implemented Enable interface for Core objects

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -139,5 +139,17 @@ void CustomDBus::implementMotherboardInterface(const std::string& path)
                                 pldm::utils::DBusHandler::getBus(), path));
     }
 }
+
+void CustomDBus::implementObjectEnableIface(const std::string& path, bool value)
+{
+    if (!enabledStatus.contains(path))
+    {
+        enabledStatus.emplace(
+            path, std::make_unique<Enable>(pldm::utils::DBusHandler::getBus(),
+                                           path.c_str()));
+    }
+    enabledStatus.at(path)->enabled(value);
+}
+
 } // namespace dbus
 } // namespace pldm

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -4,6 +4,7 @@
 #include "com/ibm/License/Entry/LicenseEntry/server.hpp"
 #include "common/utils.hpp"
 #include "cpu_core.hpp"
+#include "enable.hpp"
 #include "motherboard.hpp"
 
 #include <libpldm/state_set.h>
@@ -168,6 +169,13 @@ class CustomDBus
      */
     void implementMotherboardInterface(const std::string& path);
 
+    /** @brief Implement Enable interface
+     *
+     *  @param[in] path  - The object path
+     *
+     */
+    void implementObjectEnableIface(const std::string& path, bool value);
+
   private:
     std::unordered_map<ObjectPath, std::unique_ptr<LocationIntf>> location;
     std::map<ObjectPath, std::unique_ptr<OperationalStatusIntf>>
@@ -175,6 +183,7 @@ class CustomDBus
     std::map<ObjectPath, std::unique_ptr<AvailabilityIntf>> availabilityState;
     std::unordered_map<ObjectPath, std::unique_ptr<LicIntf>> codLic;
     std::unordered_map<ObjectPath, std::unique_ptr<CPUCore>> cpuCore;
+    std::unordered_map<ObjectPath, std::unique_ptr<Enable>> enabledStatus;
     std::unordered_map<ObjectPath, std::unique_ptr<Motherboard>> motherboard;
     std::unordered_map<ObjectPath, std::unique_ptr<ChapDatas>> chapdata;
 };

--- a/host-bmc/dbus/deserialize.cpp
+++ b/host-bmc/dbus/deserialize.cpp
@@ -35,6 +35,14 @@ std::unordered_map<std::string, callback> dBusInterfaceHandler{
         pldm::dbus::CustomDBus::getCustomDBus().implementCpuCoreInterface(path);
     }
 }},
+    {"Enable",
+     [](const std::string& path, PropertyMap values) {
+    if (values.contains("enabled"))
+    {
+        pldm::dbus::CustomDBus::getCustomDBus().implementObjectEnableIface(
+            path, std::get<bool>(values.at("enabled")));
+    }
+}},
     {"Motherboard", [](const std::string& path, PropertyMap /* values */) {
     pldm::dbus::CustomDBus::getCustomDBus().implementMotherboardInterface(path);
 }}};

--- a/host-bmc/dbus/enable.cpp
+++ b/host-bmc/dbus/enable.cpp
@@ -1,0 +1,25 @@
+#include "enable.hpp"
+
+#include "serialize.hpp"
+
+namespace pldm
+{
+namespace dbus
+{
+
+bool Enable::enabled() const
+{
+    return sdbusplus::xyz::openbmc_project::Object::server::Enable::enabled();
+}
+
+bool Enable::enabled(bool value)
+{
+    pldm::serialize::Serialize::getSerialize().serialize(path, "Enable",
+                                                         "enabled", value);
+
+    return sdbusplus::xyz::openbmc_project::Object::server::Enable::enabled(
+        value);
+}
+
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/dbus/enable.hpp
+++ b/host-bmc/dbus/enable.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "serialize.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <xyz/openbmc_project/Object/Enable/server.hpp>
+
+#include <string>
+
+namespace pldm
+{
+namespace dbus
+{
+using EnableIface = sdbusplus::server::object_t<
+    sdbusplus::xyz::openbmc_project::Object::server::Enable>;
+
+class Enable : public EnableIface
+{
+  public:
+    Enable() = delete;
+    ~Enable() = default;
+    Enable(const Enable&) = delete;
+    Enable& operator=(const Enable&) = delete;
+
+    Enable(sdbusplus::bus_t& bus, const std::string& objPath) :
+        EnableIface(bus, objPath.c_str()), path(objPath)
+    {}
+
+    /** Get value of Enabled */
+    bool enabled() const override;
+
+    /** Set value of Enabled */
+    bool enabled(bool value) override;
+
+  private:
+    std::string path;
+};
+
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1285,6 +1285,8 @@ void HostPDRHandler::createDbusObjects()
             case PLDM_ENTITY_PROC | 0x8000:
                 CustomDBus::getCustomDBus().implementCpuCoreInterface(
                     entity.first);
+                CustomDBus::getCustomDBus().implementObjectEnableIface(
+                    entity.first, false);
                 break;
             case PLDM_ENTITY_SYS_BOARD:
                 CustomDBus::getCustomDBus().implementMotherboardInterface(

--- a/host-bmc/test/meson.build
+++ b/host-bmc/test/meson.build
@@ -7,6 +7,7 @@ test_sources = [
   '../utils.cpp',
   '../dbus/custom_dbus.cpp',
   '../dbus/cpu_core.cpp',
+  '../dbus/enable.cpp',
   '../dbus/serialize.cpp',
   '../dbus/chapdata.cpp',
 ]

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -30,6 +30,7 @@ sources = [
   '../host-bmc/dbus_to_host_effecters.cpp',
   '../host-bmc/host_condition.cpp',
   '../host-bmc/dbus/custom_dbus.cpp',
+  '../host-bmc/dbus/enable.cpp',
   '../host-bmc/dbus/serialize.cpp',
   '../host-bmc/dbus/deserialize.cpp',
   '../host-bmc/dbus/cpu_core.cpp',


### PR DESCRIPTION
Implemented the xyz.openbmc_project.Object.Enable interface to host the "Enabled" D-Bus property which can be used to map the Redfish "Enabled" property which is present in the Processor schema (this schema applies to Core as well) to do either "Enable" or "Disable" the particular Core resource via Redfish client.

Tested:
Power On/Off, Factory Reset