### PR TITLE
pldm: Fix for VMI issue

### DIFF
--- a/libpldmresponder/event_parser.cpp
+++ b/libpldmresponder/event_parser.cpp
@@ -119,9 +119,21 @@ StateToDBusValue StateSensorHandler::mapStateToDBusVal(
     return eventStateMap;
 }
 
-int StateSensorHandler::eventAction(const StateSensorEntry& entry,
+int StateSensorHandler::eventAction(StateSensorEntry entry,
                                     pdr::EventState state)
 {
+    for (const auto& kv : eventMap)
+    {
+        if (kv.first.skipContainerId &&
+            kv.first.entityType == entry.entityType &&
+            kv.first.entityInstance == entry.entityInstance &&
+            kv.first.stateSetid == entry.stateSetid &&
+            kv.first.sensorOffset == entry.sensorOffset)
+        {
+            entry.skipContainerId = true;
+            break;
+        }
+    }
     try
     {
         const auto& [dbusMapping, eventStateMap] = eventMap.at(entry);

--- a/libpldmresponder/event_parser.hpp
+++ b/libpldmresponder/event_parser.hpp
@@ -106,7 +106,7 @@ class StateSensorHandler
      *
      *  @return PLDM completion code
      */
-    int eventAction(const StateSensorEntry& entry, pdr::EventState state);
+    int eventAction(StateSensorEntry entry, pdr::EventState state);
 
     /** @brief Helper API to get D-Bus information for a StateSensorEntry
      *


### PR DESCRIPTION
After updation of VMI IP(BIOS Attributes), attribute values are conveyed properly to the PHYP. But the sensor event received from PHYP was not handled properly so PLDM could not update the Dbus accordingly.

After fixing the issue VMI interface is "enabled"

Below are the Commands used to test
Delete existing configuration:
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH -D patch.txt -d '{"IPv4StaticAddresses": [null]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 -H "Content-Type: application/json"

Add configuration
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH -D patch.txt -d '{"IPv4StaticAddresses": [{"Address": "9.41.164.110", "SubnetMask": "255.255.252.0", "Gateway": "9.41.164.1"}]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 -H "Content-Type: application/json"

Output:
busctl introspect xyz.openbmc_project.Network.Hypervisor /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
xyz.openbmc_project.Object.Enable   interface -         -                                        -
.Enabled                            property  b         true                                     emits-change writable