### PR TITLE
1110 marker lid

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -100,10 +100,8 @@ class LidHandler : public FileHandler
         return true;
     }
 
-    int validateMarkerLid(oem_platform::Handler* oemPlatformHandler,
-                          const std::string& lidPath)
+    void validateMarkerLid(oem_platform::Handler* oemPlatformHandler)
     {
-        int rc = PLDM_SUCCESS;
         if (oemPlatformHandler != nullptr)
         {
             pldm::responder::oem_ibm_platform::Handler* oemIbmPlatformHandler =
@@ -114,14 +112,10 @@ class LidHandler : public FileHandler
             using namespace pldm::responder::oem_ibm_platform;
             auto markerLidDirPath = fs::path(LID_STAGING_DIR) / "lid" /
                                     markerLidName;
+            uint8_t validateStatus = VALID;
             try
             {
                 auto& bus = pldm::utils::DBusHandler::getBus();
-                rc = processCodeUpdateLid(lidPath);
-                if (rc != PLDM_SUCCESS)
-                {
-                    return rc;
-                }
                 auto method = bus.new_method_call(
                     "xyz.openbmc_project.Software.BMC.Updater",
                     "/xyz/openbmc_project/software",
@@ -131,7 +125,6 @@ class LidHandler : public FileHandler
             }
             catch (const sdbusplus::exception::exception& e)
             {
-                uint8_t validateStatus = 0;
                 if (strcmp(e.name(), accessKeyExpired) != 0)
                 {
                     validateStatus = ENTITLEMENT_FAIL;
@@ -142,16 +135,10 @@ class LidHandler : public FileHandler
                 }
                 std::cerr << "Marker lid validate error, "
                           << "ERROR=" << e.what() << std::endl;
-                oemIbmPlatformHandler->sendStateSensorEvent(
-                    sensorId, PLDM_STATE_SENSOR_STATE, 0, validateStatus,
-                    VALID);
-                return PLDM_ERROR;
             }
             oemIbmPlatformHandler->sendStateSensorEvent(
-                sensorId, PLDM_STATE_SENSOR_STATE, 0, VALID, VALID);
-            rc = PLDM_SUCCESS;
+                sensorId, PLDM_STATE_SENSOR_STATE, 0, validateStatus, VALID);
         }
-        return rc;
     }
 
     virtual void writeFromMemory(uint32_t offset, uint32_t length,
@@ -210,7 +197,11 @@ class LidHandler : public FileHandler
             markerLIDremainingSize -= length;
             if (markerLIDremainingSize == 0)
             {
-                rc = validateMarkerLid(oemPlatformHandler, lidPath);
+                rc = processCodeUpdateLid(lidPath);
+                if (rc == PLDM_SUCCESS)
+                {
+                    validateMarkerLid(oemPlatformHandler);
+                }
             }
         }
         else if (codeUpdateInProgress)
@@ -365,7 +356,11 @@ class LidHandler : public FileHandler
             markerLIDremainingSize -= length;
             if (markerLIDremainingSize == 0)
             {
-                rc = validateMarkerLid(oemPlatformHandler, lidPath);
+                rc = processCodeUpdateLid(lidPath);
+                if (rc == PLDM_SUCCESS)
+                {
+                    validateMarkerLid(oemPlatformHandler);
+                }
             }
         }
         else if (codeUpdateInProgress)

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -3,6 +3,7 @@
 #include "file_io_by_type.hpp"
 
 #include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Software/Version/error.hpp>
 
 #include <filesystem>
 #include <sstream>
@@ -14,10 +15,15 @@ namespace pldm
 {
 namespace responder
 {
-
 namespace fs = std::filesystem;
 
 using MarkerLIDremainingSize = uint64_t;
+
+constexpr auto markerLidName = "80a00001.lid";
+constexpr auto accessKeyExpired =
+    "sdbusplus::xyz::openbmc_project::Software::Version::Error::ExpiredAccessKey";
+constexpr auto incompatibleErr =
+    "sdbusplus::xyz::openbmc_project::Software::Version::Error::Incompatible";
 
 /** @class LidHandler
  *
@@ -94,6 +100,60 @@ class LidHandler : public FileHandler
         return true;
     }
 
+    int validateMarkerLid(oem_platform::Handler* oemPlatformHandler,
+                          const std::string& lidPath)
+    {
+        int rc = PLDM_SUCCESS;
+        if (oemPlatformHandler != nullptr)
+        {
+            pldm::responder::oem_ibm_platform::Handler* oemIbmPlatformHandler =
+                dynamic_cast<pldm::responder::oem_ibm_platform::Handler*>(
+                    oemPlatformHandler);
+            auto sensorId =
+                oemIbmPlatformHandler->codeUpdate->getMarkerLidSensor();
+            using namespace pldm::responder::oem_ibm_platform;
+            auto markerLidDirPath = fs::path(LID_STAGING_DIR) / "lid" /
+                                    markerLidName;
+            try
+            {
+                auto& bus = pldm::utils::DBusHandler::getBus();
+                rc = processCodeUpdateLid(lidPath);
+                if (rc != PLDM_SUCCESS)
+                {
+                    return rc;
+                }
+                auto method = bus.new_method_call(
+                    "xyz.openbmc_project.Software.BMC.Updater",
+                    "/xyz/openbmc_project/software",
+                    "xyz.openbmc_project.Software.LID", "Validate");
+                method.append(markerLidDirPath.c_str());
+                bus.call(method);
+            }
+            catch (const sdbusplus::exception::exception& e)
+            {
+                uint8_t validateStatus = 0;
+                if (strcmp(e.name(), accessKeyExpired) != 0)
+                {
+                    validateStatus = ENTITLEMENT_FAIL;
+                }
+                else if (strcmp(e.name(), incompatibleErr) != 0)
+                {
+                    validateStatus = MIN_MIF_FAIL;
+                }
+                std::cerr << "Marker lid validate error, "
+                          << "ERROR=" << e.what() << std::endl;
+                oemIbmPlatformHandler->sendStateSensorEvent(
+                    sensorId, PLDM_STATE_SENSOR_STATE, 0, validateStatus,
+                    VALID);
+                return PLDM_ERROR;
+            }
+            oemIbmPlatformHandler->sendStateSensorEvent(
+                sensorId, PLDM_STATE_SENSOR_STATE, 0, VALID, VALID);
+            rc = PLDM_SUCCESS;
+        }
+        return rc;
+    }
+
     virtual void writeFromMemory(uint32_t offset, uint32_t length,
                                  uint64_t address,
                                  oem_platform::Handler* oemPlatformHandler,
@@ -138,8 +198,26 @@ class LidHandler : public FileHandler
             return;
         }
         close(fd);
-        transferFileData(lidPath, false, offset, length, address,
-                         sharedAIORespDataobj, event);
+
+        rc = transferFileData(lidPath, false, offset, length, address);
+        if (rc != PLDM_SUCCESS)
+        {
+            error("writeFileFromMemory failed with rc= {RC}", "RC", rc);
+            return rc;
+        }
+        if (lidType == PLDM_FILE_TYPE_LID_MARKER)
+        {
+            markerLIDremainingSize -= length;
+            if (markerLIDremainingSize == 0)
+            {
+                rc = validateMarkerLid(oemPlatformHandler, lidPath);
+            }
+        }
+        else if (codeUpdateInProgress)
+        {
+            rc = processCodeUpdateLid(lidPath);
+        }
+        return rc;
     }
 
     virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length)
@@ -287,17 +365,7 @@ class LidHandler : public FileHandler
             markerLIDremainingSize -= length;
             if (markerLIDremainingSize == 0)
             {
-                pldm::responder::oem_ibm_platform::Handler*
-                    oemIbmPlatformHandler = dynamic_cast<
-                        pldm::responder::oem_ibm_platform::Handler*>(
-                        oemPlatformHandler);
-                auto sensorId =
-                    oemIbmPlatformHandler->codeUpdate->getMarkerLidSensor();
-                using namespace pldm::responder::oem_ibm_platform;
-                oemIbmPlatformHandler->sendStateSensorEvent(
-                    sensorId, PLDM_STATE_SENSOR_STATE, 0, VALID, VALID);
-                // validate api
-                rc = PLDM_SUCCESS;
+                rc = validateMarkerLid(oemPlatformHandler, lidPath);
             }
         }
         else if (codeUpdateInProgress)


### PR DESCRIPTION
1. Moving fetch activation property (#449)
    
    This commit adds change to move the fetching of activation
    property inside the inband code update path. As it is a no-op
    for out of band updates.
    
 2. Throw Marker Lid validate error (#446)
    
    Commit the marker lid validate errors for the
    min-mif level and access key expiration so that
    it generates an SRC when we hit the error during
    code update.

3. Return proper Success/Error code to host (#442)
    
    This commit adds change to send the right error code
    to host during the marker lid validation. When the marker
    lid validation fails we were trying to send a PLDM_ERROR
    But it was sent as a response to the file write request
    and PHYP assumed that the error code returned was for the
    write operation and did not go ahead to check the sensor
    event sent to indicate the entitlment fail during marker
    lid validation.
    
    Defect: PE00LNC2

4. Marker Lid validate for Inband updates (#407)
    
    This commit adds changes to call the validate API
    from phosphor-software-manager to validate the
    marker lid. And further send the status of the validation
    to PHYP through a sensor event.