### PR TITLE
oem-ibm: Introducing sensor design for SBE ocmb dump

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -16,8 +16,17 @@
 #include "requester/handler.hpp"
 #include "utils.hpp"
 
-typedef ibm_oem_pldm_state_set_firmware_update_state_values CodeUpdateState;
+enum ibm_oem_pldm_state_set_dimm_dump_state_values
+{
+    RETRY = 0,
+    SUCCESS = 0x1,
+    UNAVAILABLE = 0x2
+};
 
+typedef ibm_oem_pldm_state_set_firmware_update_state_values CodeUpdateState;
+typedef ibm_oem_pldm_state_set_dimm_dump_state_values DimmDumpState;
+
+static std::map<uint16_t, int> dumpStatusMap;
 namespace pldm
 {
 namespace responder
@@ -78,6 +87,7 @@ using BaseBIOSTable = std::map<AttributeName, BIOSTableObj>;
 using PendingObj = std::tuple<AttributeType, CurrentValue>;
 using PendingAttributes = std::map<AttributeName, PendingObj>;
 static constexpr auto PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577;
+static constexpr auto PLDM_OEM_IBM_SBE_DUMP_UPDATE = 24578;
 static constexpr auto PLDM_OEM_IBM_FRONT_PANEL_TRIGGER = 32837;
 static constexpr auto PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER = 24580;
 
@@ -334,7 +344,6 @@ class Handler : public oem_platform::Handler
     {
         return platformHandler->getNextEffecterId();
     }
-
     /** @brief Method to fetch the sensor ID of the code update PDRs
      *
      * @return platformHandler->getNextSensorId() - returns the
@@ -349,7 +358,6 @@ class Handler : public oem_platform::Handler
     {
         return platformHandler->getAssociateEntityMap();
     }
-
     /** @brief Method to Generate the OEM PDRs
      *
      * @param[in] repo - instance of concrete implementation of Repo
@@ -449,6 +457,10 @@ class Handler : public oem_platform::Handler
     void upadteOemDbusPaths(std::string& dbusPath);
     /** @brief update the conatiner ID */
     void updateContainerID();
+
+    int fetchDimmStateSensor(uint16_t entityInstance);
+
+    void setDimmStateSensor(bool status, uint16_t entityInstance);
 
     /** @brief Method to set the host effecter state
      *  @param status - the status of dump creation

--- a/pldmtool/oem/ibm/oem_ibm_state_set.hpp
+++ b/pldmtool/oem/ibm/oem_ibm_state_set.hpp
@@ -70,6 +70,7 @@ extern const std::map<uint16_t, std::string> OemIBMstateSet{
     {PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE, "OEM IBM Firmware Update State"},
     {PLDM_OEM_IBM_BOOT_STATE, "OEM IBM Boot State"},
     {PLDM_OEM_IBM_VERIFICATION_STATE, "OEM IBM Verification State"},
+    {PLDM_OEM_IBM_SBE_DUMP_UPDATE_STATE, "OEM IBM SBE Dump Update State"},
     {PLDM_OEM_IBM_SYSTEM_POWER_STATE, "OEM IBM System Power State"}};
 
 /** @brief Map for PLDM OEM IBM firmware update possible state values


### PR DESCRIPTION
This commit introduces new oem sensor PDRs of state set id - PLDM_OEM_IBM_SBE_DUMP_UPDATE_STATE(32777) whose state will be set for ocmb dump progress status.  This change implements the new sensor based dump design only for ocmb sbe dumps whereas the sbe PROC dump design remains unchanged. As part of this change PLDM will be updating the sensor state with dump progress state. The remote terminus will be using polling mechanism on getStateSensorReadings command for dump status update.

Tested: Used pldmtool to set numeric effecter for triggering dump.