### PR TITLE
oem-ibm: Fix for UAK dbus update

### DIFF
--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -167,6 +167,7 @@ void Handler::dbus_map_update(const std::string& adapterObjPath,
 
 void Handler::setFirmwareUAK(const std::vector<uint8_t>& data)
 {
+    info("Got a SetFRURecordTable cmd from host to set the firmware UAK");
     using VPDManager = sdbusplus::client::com::ibm::vpd::Manager<>;
 
     static constexpr auto uakObjPath = "/com/ibm/VPD/Manager";

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -417,7 +417,7 @@ int createOrUpdateLicenseObjs()
     {
         auto licId = entry.value("Id", empty);
         fs::path l_path = path / licId;
-        licJsonMap.emplace(l_path, entry);
+        licJsonMap.insert_or_assign(l_path, entry);
     }
 
     int rc = createOrUpdateLicenseDbusPaths(createLic);


### PR DESCRIPTION
This commit fixes the issue of UAK date disaplay in the ASMI GUI when installed with changed UAK license with new date.

Tested: Verified that applying the the new UAK license value at power on state is being reflected in the ASM GUI