### PR TITLE
pldm: Support password prompt for graphical SMS menu

### DIFF
--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -80,7 +80,11 @@ if get_option('oem-ibm').allowed()
     '../oem/ibm/libpldmresponder/file_io_type_vpd.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_pcie.cpp',
     '../oem/ibm/libpldmresponder/file_io_type_lic.cpp',
+    '../oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp',
+    '../oem/ibm/libpldmresponder/file_io_type_smsmenu.cpp',
   ]
+  libpam = cpp.find_library('pam', required: true)
+  libpldmresponder_deps += [libpam]
 endif
 
 libpldmresponder = library(

--- a/meson.build
+++ b/meson.build
@@ -213,6 +213,10 @@ subdir('pldmtool')
 
 subdir('configurations')
 
+if get_option('oem-ibm').enabled()
+  subdir('oem/ibm/pfw-sms-utils')
+endif
+
 if get_option('utilities').allowed()
   subdir('utilities')
 endif

--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -854,10 +854,10 @@ Response Handler::writeFile(const pldm_msg* request, size_t payloadLength)
     return response;
 }
 
-Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
-                                size_t payloadLength,
-                                oem_platform::Handler* oemPlatformHandler,
-                                SharedAIORespData& sharedAIORespDataobj)
+Response Handler::rwFileByTypeIntoMemory(
+    uint8_t cmd, const pldm_msg* request, size_t payloadLength,
+    oem_platform::Handler* oemPlatformHandler,
+    SharedAIORespData& sharedAIORespDataobj, pldm::InstanceIdDb* instanceIdDb)
 {
     Response response(
         sizeof(pldm_msg_hdr) + PLDM_RW_FILE_BY_TYPE_MEM_RESP_BYTES, 0);
@@ -906,7 +906,8 @@ Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
     std::shared_ptr<FileHandler> handler{};
     try
     {
-        handler = getSharedHandlerByType(fileType, fileHandle);
+        handler = getSharedHandlerByType(fileType, fileHandle, instanceIdDb,
+                                         Handler::handler);
     }
     catch (const InternalFailure& e)
     {
@@ -939,7 +940,7 @@ Response Handler::writeFileByTypeFromMemory(const pldm_msg* request,
 {
     return rwFileByTypeIntoMemory(PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, request,
                                   payloadLength, oemPlatformHandler,
-                                  sharedAIORespDataobj);
+                                  sharedAIORespDataobj, instanceIdDb);
 }
 
 Response Handler::readFileByTypeIntoMemory(const pldm_msg* request,
@@ -947,7 +948,30 @@ Response Handler::readFileByTypeIntoMemory(const pldm_msg* request,
 {
     return rwFileByTypeIntoMemory(PLDM_READ_FILE_BY_TYPE_INTO_MEMORY, request,
                                   payloadLength, oemPlatformHandler,
-                                  sharedAIORespDataobj);
+                                  sharedAIORespDataobj, instanceIdDb);
+}
+
+void Handler::postWriteCallBack(
+    const uint16_t& fileType, const uint32_t& fileHandle,
+    const struct fileack_status_metadata& metaDataObj)
+{
+    smsEvent.reset();
+
+    std::unique_ptr<FileHandler> handler{};
+    try
+    {
+        handler = getHandlerByType(fileType, fileHandle, instanceIdDb,
+                                   Handler::handler);
+    }
+    catch (const InternalFailure& e)
+    {
+        error("post write call back failed with file type : {FILE_TYPE} and"
+              " error : {ERR_EXCEP}",
+              "FILE_TYPE", fileType, "ERR_EXCEP", e);
+        return;
+    }
+
+    handler->postWriteAction(fileType, fileHandle, metaDataObj);
 }
 
 Response Handler::writeFileByType(const pldm_msg* request, size_t payloadLength)
@@ -986,7 +1010,8 @@ Response Handler::writeFileByType(const pldm_msg* request, size_t payloadLength)
     std::unique_ptr<FileHandler> handler{};
     try
     {
-        handler = getHandlerByType(fileType, fileHandle);
+        handler = getHandlerByType(fileType, fileHandle, instanceIdDb,
+                                   Handler::handler);
     }
     catch (const InternalFailure& e)
     {
@@ -998,12 +1023,21 @@ Response Handler::writeFileByType(const pldm_msg* request, size_t payloadLength)
         return response;
     }
 
+    fileack_status_metadata metaDataObj;
     rc = handler->write(reinterpret_cast<const char*>(
                             request->payload + PLDM_RW_FILE_BY_TYPE_REQ_BYTES),
-                        offset, length, oemPlatformHandler);
+                        offset, length, oemPlatformHandler, metaDataObj);
     encodeRWTypeResponseHandler(request->hdr.instance_id,
                                 PLDM_WRITE_FILE_BY_TYPE, rc, length,
                                 responsePtr);
+
+    if (rc == PLDM_SUCCESS)
+    {
+        smsEvent = std::make_unique<sdeventplus::source::Defer>(
+            event, std::bind(&Handler::postWriteCallBack, this, fileType,
+                             fileHandle, metaDataObj));
+    }
+
     return response;
 }
 
@@ -1043,7 +1077,8 @@ Response Handler::readFileByType(const pldm_msg* request, size_t payloadLength)
     std::unique_ptr<FileHandler> handler{};
     try
     {
-        handler = getHandlerByType(fileType, fileHandle);
+        handler = getHandlerByType(fileType, fileHandle, instanceIdDb,
+                                   Handler::handler);
     }
     catch (const InternalFailure& e)
     {
@@ -1092,7 +1127,8 @@ Response Handler::fileAck(const pldm_msg* request, size_t payloadLength)
     std::unique_ptr<FileHandler> handler{};
     try
     {
-        handler = getHandlerByType(fileType, fileHandle);
+        handler = getHandlerByType(fileType, fileHandle, instanceIdDb,
+                                   Handler::handler);
     }
 
     catch (const InternalFailure& e)
@@ -1186,7 +1222,8 @@ Response Handler::newFileAvailable(const pldm_msg* request,
     std::unique_ptr<FileHandler> handler{};
     try
     {
-        handler = getHandlerByType(fileType, fileHandle);
+        handler = getHandlerByType(fileType, fileHandle, instanceIdDb,
+                                   Handler::handler);
     }
     catch (const InternalFailure& e)
     {
@@ -1238,7 +1275,8 @@ Response Handler::newFileAvailableWithMetaData(const pldm_msg* request,
     std::unique_ptr<FileHandler> handler{};
     try
     {
-        handler = getHandlerByType(fileType, fileHandle);
+        handler = getHandlerByType(fileType, fileHandle, instanceIdDb,
+                                   Handler::handler);
     }
     catch (const InternalFailure& e)
     {
@@ -1287,7 +1325,8 @@ Response Handler::fileAckWithMetaData(const pldm_msg* request,
     std::unique_ptr<FileHandler> handler{};
     try
     {
-        handler = getHandlerByType(fileType, fileHandle);
+        handler = getHandlerByType(fileType, fileHandle, instanceIdDb,
+                                   Handler::handler);
     }
     catch (const InternalFailure& e)
     {

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -658,10 +658,11 @@ class Handler : public CmdHandler
     Handler(oem_platform::Handler* oemPlatformHandler, int hostSockFd,
             uint8_t hostEid, pldm::InstanceIdDb* instanceIdDb,
             pldm::requester::Handler<pldm::requester::Request>* handler,
-            pldm::response_api::AltResponse* respInterface) :
+            pldm::response_api::AltResponse* respInterface,
+            sdeventplus::Event& event) :
         oemPlatformHandler(oemPlatformHandler), hostSockFd(hostSockFd),
         hostEid(hostEid), instanceIdDb(instanceIdDb), handler(handler),
-        sharedAIORespDataobj({0, 0, nullptr, 0, respInterface})
+        sharedAIORespDataobj({0, 0, nullptr, 0, respInterface}), event(event)
     {
         handlers.emplace(
             PLDM_READ_FILE_INTO_MEMORY,
@@ -993,6 +994,31 @@ class Handler : public CmdHandler
      */
     Response fileAckWithMetaData(const pldm_msg* request, size_t payloadLength);
 
+    /** @brief Handler for read/write file by type into memory command
+     *
+     *  @param[in] request - PLDM read/write command
+     *  @param[in] request - PLDM request msg
+     *  @param[in] payloadLength - length of the message payload
+     *  @param[in] oemPlatformHandler - oem platform handler
+     *  @param[in] instanceIdDb - pldm instance DB requester
+     *
+     *  @return PLDM response messsage
+     */
+    Response rwFileByTypeIntoMemory(uint8_t cmd, const pldm_msg* request,
+                                    size_t payloadLength,
+                                    oem_platform::Handler* oemPlatformHandler,
+                                    SharedAIORespData& sharedAIORespDataobj,
+                                    pldm::InstanceIdDb* instanceIdDb);
+
+    /** @brief Execute the post write call back actions after sending back the
+     *  write command response to the host
+     *  @param[in] fileType - type of the file
+     *  @param[in] fileHandle - file handle
+     *  @param[in] metaDataObj - file ack meta data status and values
+     */
+    void postWriteCallBack(const uint16_t& fileType, const uint32_t& fileHandle,
+                           const struct fileack_status_metadata& metaDataObj);
+
   private:
     oem_platform::Handler* oemPlatformHandler;
     int hostSockFd;
@@ -1017,6 +1043,11 @@ class Handler : public CmdHandler
     std::vector<std::unique_ptr<pldm::requester::oem_ibm::DbusToFileHandler>>
         dbusToFileHandlers;
     SharedAIORespData sharedAIORespDataobj;
+
+    /** @brief sdeventplus event */
+    sdeventplus::Event& event;
+    /** @brief sdeventplus defer event source */
+    std::unique_ptr<sdeventplus::source::Defer> smsEvent;
 };
 
 } // namespace oem_ibm

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -8,6 +8,7 @@
 #include "file_io_type_pcie.hpp"
 #include "file_io_type_pel.hpp"
 #include "file_io_type_progress_src.hpp"
+#include "file_io_type_smsmenu.hpp"
 #include "file_io_type_vpd.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -414,8 +415,9 @@ void FileHandler::transferFileData(const fs::path& path, bool upstream,
                      sharedAIORespDataobj, event);
 }
 
-std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
-                                              uint32_t fileHandle)
+std::unique_ptr<FileHandler> getHandlerByType(
+    uint16_t fileType, uint32_t fileHandle, pldm::InstanceIdDb* instanceIdDb,
+    pldm::requester::Handler<pldm::requester::Request>* handler)
 {
     switch (fileType)
     {
@@ -479,6 +481,12 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
         {
             return std::make_unique<ChapHandler>(fileHandle, fileType);
         }
+        case PLDM_FILE_TYPE_USER_PASSWORD_AUTHENTICATION:
+        case PLDM_FILE_TYPE_USER_PASSWORD_CHANGE:
+        {
+            return std::make_unique<SmsMenuHandler>(fileHandle, fileType,
+                                                    instanceIdDb, handler);
+        }
         default:
         {
             throw InternalFailure();
@@ -488,8 +496,9 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
     return nullptr;
 }
 
-std::shared_ptr<FileHandler> getSharedHandlerByType(uint16_t fileType,
-                                                    uint32_t fileHandle)
+std::shared_ptr<FileHandler> getSharedHandlerByType(
+    uint16_t fileType, uint32_t fileHandle, pldm::InstanceIdDb* instanceIdDb,
+    pldm::requester::Handler<pldm::requester::Request>* handler)
 {
     switch (fileType)
     {
@@ -548,6 +557,12 @@ std::shared_ptr<FileHandler> getSharedHandlerByType(uint16_t fileType,
         case PLDM_FILE_TYPE_PSPD_VPD_PDD_KEYWORD:
         {
             return std::make_shared<keywordHandler>(fileHandle, fileType);
+        }
+        case PLDM_FILE_TYPE_USER_PASSWORD_AUTHENTICATION:
+        case PLDM_FILE_TYPE_USER_PASSWORD_CHANGE:
+        {
+            return std::make_unique<SmsMenuHandler>(fileHandle, fileType,
+                                                    instanceIdDb, handler);
         }
         default:
         {

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -154,10 +154,22 @@ class FileHandler
      *  @param[in/out] length - length to be written
      *  @param[in] oemPlatformHandler - oem handler for PLDM platform related
      *                                  tasks
+     *  @param[out] metaDataObj - file ack meta data status and values
      *  @return PLDM status code
      */
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* oemPlatformHandler) = 0;
+                      oem_platform::Handler* oemPlatformHandler,
+                      struct fileack_status_metadata& metaDataObj) = 0;
+
+    /** @brief Execute the post actions after sending back the write command
+     *  response to the host
+     *  @param[in] fileType - type of the file
+     *  @param[in] fileHandle - file handle
+     *  @param[in] metaDataObj - file ack meta data status and values
+     */
+    virtual void
+        postWriteAction(const uint16_t fileType, const uint32_t fileHandle,
+                        const struct fileack_status_metadata& metaDataObj) = 0;
 
     virtual int fileAck(uint8_t fileStatus) = 0;
 
@@ -282,17 +294,25 @@ class FileHandler
  *
  *  @param[in] fileType - type of file
  *  @param[in] fileHandle - file handle
+ *  @param[in] instanceIdDb - pldm instance DB requester
+ *  @param[in] handler - pldm request handler
+ *
+ *  @return Unique file handler
  */
 
-std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
-                                              uint32_t fileHandle);
+std::unique_ptr<FileHandler> getHandlerByType(
+    uint16_t fileType, uint32_t fileHandle, pldm::InstanceIdDb* instanceIdDb,
+    pldm::requester::Handler<pldm::requester::Request>* handler);
 
 /** @brief Method to create shared file handler objects based on file type
  *
  *  @param[in] fileType - type of file
  *  @param[in] fileHandle - file handle
+ *  @param[in] instanceIdDb - pldm instance DB requester
+ *  @param[in] handler - pldm request handler
  */
-std::shared_ptr<FileHandler> getSharedHandlerByType(uint16_t fileType,
-                                                    uint32_t fileHandle);
+std::shared_ptr<FileHandler> getSharedHandlerByType(
+    uint16_t fileType, uint32_t fileHandle, pldm::InstanceIdDb* instanceIdDb,
+    pldm::requester::Handler<pldm::requester::Request>* handler);
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_cert.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.cpp
@@ -112,7 +112,8 @@ int CertHandler::read(uint32_t offset, uint32_t& length, Response& response,
 }
 
 int CertHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
-                       oem_platform::Handler* /*oemPlatformHandler*/)
+                       oem_platform::Handler* /*oemPlatformHandler*/,
+                       struct fileack_status_metadata& /*metaDataObj*/)
 {
     auto it = certMap.find(certType);
     if (it == certMap.end())

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -42,7 +42,8 @@ class CertHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int fileAck(uint8_t /*fileStatus*/)
     {
@@ -64,6 +65,10 @@ class CertHandler : public FileHandler
                                              uint32_t /*metaDataValue4*/);
 
     virtual int postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) {};
 
     /** @brief CertHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -341,7 +341,8 @@ void DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
 }
 
 int DumpHandler::write(const char* buffer, uint32_t, uint32_t& length,
-                       oem_platform::Handler* /*oemPlatformHandler*/)
+                       oem_platform::Handler* /*oemPlatformHandler*/,
+                       struct fileack_status_metadata& /*metaDataObj*/)
 {
     int rc = writeToUnixSocket(DumpHandler::fd, buffer, length);
     if (rc < 0)

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -38,7 +38,8 @@ class DumpHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int newFileAvailable(uint64_t length);
 
@@ -62,6 +63,10 @@ class DumpHandler : public FileHandler
     uint32_t getDumpIdPrefix(uint16_t dumpType);
     virtual int postDataTransferCallBack(bool IsWriteToMemOp,
                                          uint32_t /*length*/);
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) {};
 
     /** @brief DumpHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_lic.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.cpp
@@ -110,7 +110,8 @@ int LicenseHandler::postDataTransferCallBack(bool IsWriteToMemOp,
 
 int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,
                           uint32_t& length,
-                          oem_platform::Handler* /*oemPlatformHandler*/)
+                          oem_platform::Handler* /*oemPlatformHandler*/,
+                          struct fileack_status_metadata& /*metaDataObj*/)
 {
     int rc = PLDM_SUCCESS;
 

--- a/oem/ibm/libpldmresponder/file_io_type_lic.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.hpp
@@ -44,7 +44,8 @@ class LicenseHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
 
     virtual int write(const char* buffer, uint32_t /*offset*/, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int fileAck(uint8_t /*fileStatus*/)
     {
@@ -70,6 +71,10 @@ class LicenseHandler : public FileHandler
     virtual int postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
 
     int updateBinFileAndLicObjs(const fs::path& newLicFilePath);
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) {};
 
     /** @brief LicenseHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -250,7 +250,8 @@ class LidHandler : public FileHandler
     }
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* oemPlatformHandler)
+                      oem_platform::Handler* oemPlatformHandler,
+                      struct fileack_status_metadata& /*metaDataObj*/)
     {
         int rc = PLDM_SUCCESS;
         bool codeUpdateInProgress = false;
@@ -390,6 +391,10 @@ class LidHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) {};
 
     /** @brief LidHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -71,7 +71,8 @@ void PCIeInfoHandler::writeFromMemory(
 }
 
 int PCIeInfoHandler::write(const char* buffer, uint32_t, uint32_t& length,
-                           oem_platform::Handler* /*oemPlatformHandler*/)
+                           oem_platform::Handler* /*oemPlatformHandler*/,
+                           struct fileack_status_metadata& /*metaDataObj*/)
 {
     fs::path infoFile(fs::path(pciePath) / topologyFile);
     if (infoType == PLDM_FILE_TYPE_CABLE_INFO)

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -29,7 +29,8 @@ class PCIeInfoHandler : public FileHandler
                                  sdeventplus::Event& event);
 
     virtual int write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int fileAck(uint8_t fileStatus);
 
@@ -79,6 +80,10 @@ class PCIeInfoHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) {};
 
     /** @brief PCIeInfoHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -365,7 +365,8 @@ int PelHandler::storePel(std::string&& pelFileName)
 }
 
 int PelHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
-                      oem_platform::Handler* /*oemPlatformHandler*/)
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/)
 {
     int rc = PLDM_SUCCESS;
 

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -36,7 +36,8 @@ class PelHandler : public FileHandler
 
     virtual int write(const char* /*buffer*/, uint32_t /*offset*/,
                       uint32_t& /*length*/,
-                      oem_platform::Handler* /*oemPlatformHandler*/);
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/);
 
     virtual int fileAck(uint8_t fileStatus);
 
@@ -70,6 +71,10 @@ class PelHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) {};
 
     /** @brief PelHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.cpp
@@ -50,7 +50,8 @@ int ProgressCodeHandler::setRawBootProperty(
 
 int ProgressCodeHandler::write(const char* buffer, uint32_t /*offset*/,
                                uint32_t& length,
-                               oem_platform::Handler* /*oemPlatformHandler*/)
+                               oem_platform::Handler* /*oemPlatformHandler*/,
+                               struct fileack_status_metadata& /*metaDataObj*/)
 {
     static constexpr auto StartOffset = 40;
     static constexpr auto EndOffset = 48;

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -32,7 +32,8 @@ class ProgressCodeHandler : public FileHandler
     }
 
     int write(const char* buffer, uint32_t offset, uint32_t& length,
-              oem_platform::Handler* oemPlatformHandler) override;
+              oem_platform::Handler* /*oemPlatformHandler*/,
+              struct fileack_status_metadata& /*metaDataObj*/) override;
 
     void readIntoMemory(uint32_t /*offset*/, uint32_t length,
                         uint64_t /*address*/,
@@ -78,6 +79,10 @@ class ProgressCodeHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) {};
 
     /** @brief method to set the dbus Raw value Property with
      * the obtained progress code from the host.

--- a/oem/ibm/libpldmresponder/file_io_type_smsmenu.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_smsmenu.cpp
@@ -1,0 +1,179 @@
+#include "file_io_type_smsmenu.hpp"
+
+#include "pfw-sms-utils/pfw_sms_menu.hpp"
+
+#include <libpldm/base.h>
+#include <libpldm/oem/ibm/file_io.h>
+#include <stdint.h>
+
+#include <iostream>
+
+namespace pldm
+{
+using namespace pldm::responder::utils;
+using namespace ibm_pfw_sms;
+
+namespace responder
+{
+
+uint32_t SmsMenuHandler::readVecContent(std::vector<char>& inputVec,
+                                        const uint32_t startIdx,
+                                        const uint32_t endIdx)
+{
+    uint32_t size = 0;
+    constexpr auto bitPos = 8;
+    std::vector<char> userPassLenArr(inputVec.begin() + startIdx,
+                                     inputVec.begin() + endIdx);
+    for (uint32_t idx = 0; idx < bitPos; idx++)
+    {
+        size |= (uint32_t)userPassLenArr[idx] << bitPos * idx;
+    }
+    return size;
+}
+
+void SmsMenuHandler::postWriteAction(
+    const uint16_t fileType, const uint32_t fileHandle,
+    const struct fileack_status_metadata& metaDataObj)
+{
+    sdbusplus::message::object_path path;
+    auto hostEid = pldm::utils::readHostEID();
+    auto hostSockFd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    dbusToFileHandlers
+        .emplace_back(
+            std::make_unique<pldm::requester::oem_ibm::DbusToFileHandler>(
+                hostSockFd, hostEid, instanceIdDb, path, handler))
+        ->sendFileAckWithMetaDataToHost(
+            fileType, fileHandle, metaDataObj.fileStatus,
+            metaDataObj.fileMetaData1, metaDataObj.fileMetaData2,
+            metaDataObj.fileMetaData3, metaDataObj.fileMetaData4);
+}
+
+int SmsMenuHandler::write(const char* buffer, uint32_t /*offset*/,
+                          uint32_t& length,
+                          oem_platform::Handler* /*oemPlatformHandler*/,
+                          struct fileack_status_metadata& metaDataObj)
+{
+    if (!buffer)
+    {
+        error("SMS Menu buffer is empty");
+        return PLDM_ERROR;
+    }
+
+    std::vector<char> smsBuf(buffer, buffer + length);
+
+    uint32_t userNewPassLen = 0;
+    std::string newPassStr;
+
+    // Format of file type USER_PASSWORD_AUTHENTICATION
+    // <User Name Length><User Name><Password Length><Password>
+
+    // Format of file type USER_PASSWORD_CHANGE
+    // <User Name Length><User Name><Old Password Length><Old Password>
+    // <New Password Length><New Password>
+
+    // Read the size of User Name which is the content of first four bytes
+    auto userNameLen = readVecContent(smsBuf, 0, sizeof(uint32_t));
+
+    // Read the size of Password/Old Password which is the content of four bytes
+    // after User Name
+    auto userPassLen =
+        readVecContent(smsBuf, sizeof(uint32_t) + userNameLen,
+                       sizeof(uint32_t) + userNameLen + sizeof(uint32_t));
+    if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_CHANGE)
+    {
+        // Read the size of New Password which is the content of four bytes
+        // after Old Password
+        userNewPassLen = readVecContent(
+            smsBuf,
+            sizeof(uint32_t) + userNameLen + sizeof(uint32_t) + userPassLen,
+            sizeof(uint32_t) + userNameLen + sizeof(uint32_t) + userPassLen +
+                sizeof(uint32_t));
+    }
+
+    // Split the vector to retrieve the User Name
+    auto result = vecSplit(smsBuf, sizeof(uint32_t),
+                           sizeof(uint32_t) + userNameLen);
+    std::string unameStr(result.begin(), result.end());
+
+    // Split the vector to retrieve the Password/Old Password
+    result = vecSplit(smsBuf, sizeof(uint32_t) + userNameLen + sizeof(uint32_t),
+                      sizeof(uint32_t) + userNameLen + sizeof(uint32_t) +
+                          userPassLen);
+    std::string passStr(result.begin(), result.end());
+
+    if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_CHANGE)
+    {
+        // Split the vector to retrieve the New Password
+        result = vecSplit(smsBuf,
+                          sizeof(uint32_t) + userNameLen + sizeof(uint32_t) +
+                              userPassLen + sizeof(uint32_t),
+                          sizeof(uint32_t) + userNameLen + sizeof(uint32_t) +
+                              userPassLen + sizeof(uint32_t) + userNewPassLen);
+        std::string tempNewPassStr(result.begin(), result.end());
+        newPassStr = tempNewPassStr;
+    }
+
+    metaDataObj.fileStatus = 0x00;
+    metaDataObj.fileMetaData1 = 0xFFFFFFFF;
+    metaDataObj.fileMetaData2 = 0xFFFFFFFF;
+    metaDataObj.fileMetaData3 = 0xFFFFFFFF;
+    metaDataObj.fileMetaData4 = 0xFFFFFFFF;
+
+    bool authenticated = false;
+    bool passwordChangeRequired = false;
+    bool operationAllowed = false;
+    changePasswordReasonCode changePassRc{};
+
+    if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_AUTHENTICATION)
+    {
+        authenticate(unameStr, passStr, authenticated, passwordChangeRequired,
+                     operationAllowed);
+
+        metaDataObj.fileMetaData1 = (authenticated) ? PLDM_AUTHENTICATED
+                                                    : PLDM_NOT_AUTHENTICATED;
+
+        if (passwordChangeRequired)
+        {
+            metaDataObj.fileMetaData1 = PLDM_AUTHENTICATED_BUT_PASSWORD_EXPIRED;
+        }
+    }
+    else if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_CHANGE)
+    {
+        changePassRc = changePassword(unameStr, passStr, newPassStr,
+                                      operationAllowed);
+        if (changePassRc == PASSWORD_CHANGE_SUCCESSFUL)
+        {
+            metaDataObj.fileMetaData1 = PLDM_PASSWORD_CHANGED;
+        }
+        else if (changePassRc == NOT_AUTHENTICATED)
+        {
+            metaDataObj.fileMetaData1 = PLDM_PASSWORD_NOT_CHANGED;
+        }
+        else
+        {
+            metaDataObj.fileMetaData1 = PLDM_PASSWORD_INVALID;
+        }
+
+        metaDataObj.fileMetaData3 = (int)changePassRc;
+    }
+    else
+    {
+        error("SMS Menu type is wrong");
+        return PLDM_ERROR;
+    }
+
+    if (operationAllowed)
+    {
+        metaDataObj.fileMetaData2 = PLDM_ADMIN_OP_ALLOWED;
+    }
+
+    info("SMS PAM authenticated:{USR_AUTH} passwordChangeRequired:{USR_PASS_CR}"
+         " operationAllowed:{OPA}",
+         "USR_AUTH", authenticated, "USR_PASS_CR", passwordChangeRequired,
+         "OPA", operationAllowed);
+
+    return PLDM_SUCCESS;
+}
+
+} // namespace responder
+} // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_smsmenu.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_smsmenu.hpp
@@ -7,23 +7,29 @@ namespace pldm
 namespace responder
 {
 
-/** @class ChapHandler
+/** @class SmsMenuHandler
  *
  *  @brief Inherits and implements FileHandler. This class is used
- *  to read/write chap secret file
+ *  to support password prompt for the graphical SMS(System Management Services)
+ *  menus provided by PFW(Platform Firmware).Supported operations are
+ *  user password authentication and user password change.
  */
-class ChapHandler : public FileHandler
+class SmsMenuHandler : public FileHandler
 {
   public:
-    /** @brief ChapHandler constructor
+    /** @brief Handler constructor
      */
-    ChapHandler(uint32_t fileHandle, uint16_t fileType) :
-        FileHandler(fileHandle), chapType(fileType)
+    SmsMenuHandler(
+        uint32_t fileHandle, uint16_t fileType,
+        pldm::InstanceIdDb* instanceIdDb,
+        pldm::requester::Handler<pldm::requester::Request>* handler) :
+        FileHandler(fileHandle), smsMenuType(fileType),
+        instanceIdDb(instanceIdDb), handler(handler)
     {}
 
     virtual void writeFromMemory(uint32_t /*offset*/, uint32_t length,
                                  uint64_t /*address*/,
-                                 oem_platform::Handler* /*oemPlatformHandle*/,
+                                 oem_platform::Handler* /*oemPlatformHandler*/,
                                  SharedAIORespData& sharedAIORespDataobj,
                                  sdeventplus::Event& /*event*/)
     {
@@ -43,18 +49,21 @@ class ChapHandler : public FileHandler
         FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
     }
 
-    virtual int read(uint32_t offset, uint32_t& length, Response& response,
-                     oem_platform::Handler* /*oemPlatformHandler*/);
-
-    virtual int write(const char* /*buffer*/, uint32_t /*offset*/,
-                      uint32_t& /*length*/,
-                      oem_platform::Handler* /*oemPlatformHandler*/,
-                      struct fileack_status_metadata& /*metaDataObj*/)
+    virtual int read(uint32_t /*offset*/, uint32_t& /*length*/,
+                     Response& /*response*/,
+                     oem_platform::Handler* /*oemPlatformHandler*/)
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
-    virtual int fileAck(uint8_t /*fileStatus*/);
+    virtual int write(const char* buffer, uint32_t /*offset*/, uint32_t& length,
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& metaDataObj);
+
+    virtual int fileAck(uint8_t /*fileStatus*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
 
     virtual int newFileAvailable(uint64_t /*length*/)
     {
@@ -85,16 +94,33 @@ class ChapHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
-    virtual void postWriteAction(
-        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
-        const struct fileack_status_metadata& /*metaDataObj*/) {};
+    virtual void
+        postWriteAction(const uint16_t fileType, const uint32_t fileHandle,
+                        const struct fileack_status_metadata& metaDataObj);
 
-    /** @brief ChapHandler destructor
+    /** @brief Reads the contents of the input vector and returns the value back
+     *  @param[in] inputVec - input vector
+     *  @param[in] startIdx - start index
+     *  @param[in] endIdx - end index
+     *  @return  the value contained in the input vector
      */
-    ~ChapHandler() {}
+    uint32_t readVecContent(std::vector<char>& inputVec,
+                            const uint32_t startIdx, const uint32_t endIdx);
+
+    /** @brief SmsMenuHandler destructor
+     */
+    ~SmsMenuHandler() {}
 
   private:
-    uint16_t chapType; //!< type of the chap secret file
+    uint16_t smsMenuType; //!< type of the SMS menu selection
+
+    // pldm::requester::Handler<pldm::requester::Request>* handler;
+    std::vector<std::unique_ptr<pldm::requester::oem_ibm::DbusToFileHandler>>
+        dbusToFileHandlers;
+    /** @brief pldm instance DB requester */
+    pldm::InstanceIdDb* instanceIdDb;
+    /** @brief PLDM request handler */
+    pldm::requester::Handler<pldm::requester::Request>* handler;
 };
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
@@ -44,7 +44,8 @@ class keywordHandler : public FileHandler
                      oem_platform::Handler* /*oemPlatformHandler*/);
     virtual int write(const char* /*buffer*/, uint32_t /*offset*/,
                       uint32_t& /*length*/,
-                      oem_platform::Handler* /*oemPlatformHandler*/)
+                      oem_platform::Handler* /*oemPlatformHandler*/,
+                      struct fileack_status_metadata& /*metaDataObj*/)
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
@@ -83,6 +84,10 @@ class keywordHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+
+    virtual void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) {};
 
     /** @brief keywordHandler destructor
      */

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -426,6 +426,20 @@ void hostChapDataIntf(
         "/xyz/openbmc_project/pldm", dbusToFilehandlerObj);
 }
 
+std::vector<char> vecSplit(const std::vector<char>& inputVec,
+                           const uint32_t startIdx, const uint32_t endIdx)
+{
+    // Start and end iterators
+    auto startItr = inputVec.begin() + startIdx;
+    auto endItr = inputVec.begin() + endIdx;
+
+    // Resultant split vector
+    std::vector<char> resultVec(endIdx - startIdx + 1);
+
+    copy(startItr, endItr, resultVec.begin());
+    return resultVec;
+}
+
 } // namespace utils
 
 namespace oem_ibm_utils

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -15,6 +15,18 @@
 
 namespace pldm
 {
+
+/** @brief Holds the file ack with meta data status and values
+ */
+struct fileack_status_metadata
+{
+    uint8_t fileStatus;
+    uint32_t fileMetaData1;
+    uint32_t fileMetaData2;
+    uint32_t fileMetaData3;
+    uint32_t fileMetaData4;
+};
+
 namespace responder
 {
 namespace utils
@@ -144,6 +156,15 @@ int createOrUpdateLicenseObjs();
 void hostChapDataIntf(
     pldm::responder::oem_fileio::Handler* dbusToFilehandlerObj);
 
+/** @brief Split the vector according to the start and end index and return
+ *  back the resultant vector
+ *  @param[in] inputVec - input vector
+ *  @param[in] startIdx - start index
+ *  @param[in] endIdx - end index
+ *  @return  the resultant split vector
+ */
+std::vector<char> vecSplit(const std::vector<char>& inputVec,
+                           const uint32_t startIdx, const uint32_t endIdx);
 } // namespace utils
 
 namespace oem_ibm_utils

--- a/oem/ibm/pfw-sms-utils/meson.build
+++ b/oem/ibm/pfw-sms-utils/meson.build
@@ -1,0 +1,2 @@
+subdir('pam-config')
+

--- a/oem/ibm/pfw-sms-utils/pam-config/ibm-pfw-sms-menu
+++ b/oem/ibm/pfw-sms-utils/pam-config/ibm-pfw-sms-menu
@@ -1,0 +1,8 @@
+# The Linux-PAM config file for IBM Power systems PFW SMS Menu service
+# Authentication and password change is supported.
+
+auth     include  common-auth
+# Fail account management if user is not admin or service
+account  required pam_succeed_if.so quiet_success user ingroup priv-admin:priv-oemibmserviceagent
+account  include  common-account
+password include  common-password

--- a/oem/ibm/pfw-sms-utils/pam-config/meson.build
+++ b/oem/ibm/pfw-sms-utils/pam-config/meson.build
@@ -1,0 +1,4 @@
+install_data(
+  'ibm-pfw-sms-menu',  # Must match name of the PAM application
+  install_dir: '/etc/pam.d/'
+  )

--- a/oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp
+++ b/oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp
@@ -1,0 +1,283 @@
+#include "pfw_sms_menu.hpp"
+
+#include <security/pam_appl.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <ranges>
+
+namespace ibm_pfw_sms
+{
+
+/** @struct Data for the PAM Conversation function
+ *
+ * @note This is passed from our client code through PAM into the conversation
+ * via appdata_ptr
+ *
+ * [in] password - this the password that our application
+ * already has before invoking PAM. For authentication, this is the current
+ * password. For password change, this is the proposed new password.
+ * [out] changePasswordReasonCode - If one of the PAM modules (such as
+ * pam_pwquality) gives a response, we convert it to a reason code and store it
+ * here. The caller will need examine both this code and the return value from
+ * the pam_* function.
+ */
+struct pfw_sms_pam_appdata
+{
+    const char* password;
+    enum changePasswordReasonCode reasonCode;
+};
+
+/** @brief Our PAM Conversation function
+ *
+ * This function handles the following elements of the PAM conversation:
+ *  - For both authentication and password change, when PAM asks for the
+ * password, we supply it.
+ *  - For the change password function, if a module (such as pam_pwquality.so)
+ * complains about the password quality, we translate that message into a reason
+ * code (appdata_ptr->reasonCode). We use struct pfw_sms_pam_appdata (as this
+ * function's appdata_ptr) to pass data to and from our application and PAM:
+ * @note For parameter descriptions, see docs for pam_start and pam_conv
+ * @return PAM status code (int)
+ */
+static int pamConversationFunction(int num_msg,
+                                   const struct pam_message** message_ptr,
+                                   struct pam_response** response_ptr,
+                                   void* appdata_ptr)
+{
+    if ((appdata_ptr == nullptr) || (message_ptr == nullptr) ||
+        (response_ptr == nullptr))
+    {
+        return PAM_CONV_ERR;
+    }
+    if (num_msg <= 0 || num_msg >= PAM_MAX_NUM_MSG)
+    {
+        return PAM_CONV_ERR;
+    }
+
+    struct pfw_sms_pam_appdata* pfw_sms_appdata_ptr =
+        reinterpret_cast<struct pfw_sms_pam_appdata*>(appdata_ptr);
+    // Allocate an array of responses for PAM to free.  Note that PAM
+    // uses malloc/calloc/strdup style memory management.
+    *response_ptr = reinterpret_cast<struct pam_response*>(
+        calloc(num_msg, sizeof(struct pam_response)));
+    if (*response_ptr == nullptr)
+    {
+        return PAM_CONV_ERR;
+    }
+    const struct pam_message* msg_ptr = *message_ptr;
+    for (const int msg_index : std::ranges::iota_view{0, num_msg})
+    {
+        char* local_userpass = nullptr; // for PAM's malloc'd copy
+        std::basic_string_view msg(msg_ptr[msg_index].msg);
+        switch (msg_ptr[msg_index].msg_style)
+        {
+            case PAM_PROMPT_ECHO_OFF:
+                // Assume PAM is asking for the password.
+                // Allocate a response for PAM to free().  Note that PAM
+                // uses malloc/calloc/strdup style memory management.
+                local_userpass = ::strdup(pfw_sms_appdata_ptr->password);
+                if (local_userpass == nullptr)
+                {
+                    return PAM_BUF_ERR; // *authenticated = false
+                }
+                pfw_sms_appdata_ptr->reasonCode =
+                    PASSWORD_CHANGE_SUCCESSFUL; // working assumption
+                response_ptr[msg_index]->resp = local_userpass;
+                break;
+            case PAM_PROMPT_ECHO_ON:
+                // This is not expected
+                // Allocate a response for PAM to free().  Note that PAM
+                // uses malloc/calloc/strdup style memory management.
+                response_ptr[msg_index]->resp = ::strdup("Unexpected");
+                break;
+            case PAM_ERROR_MSG:
+                // fall through
+            case PAM_TEXT_INFO:
+                if (msg.starts_with("BAD USERPASS: "))
+                {
+                    // Handle messages from lib_pwquality
+                    std::basic_string_view detail(msg_ptr[msg_index].msg + 14);
+                    pfw_sms_appdata_ptr->reasonCode =
+                        BAD_PASSWORD_FOR_UNKNOWN_REASON;
+                    if (detail == "The password is a palindrome")
+                    {
+                        pfw_sms_appdata_ptr->reasonCode =
+                            BAD_PASSWORD_IS_PALINDROME;
+                    }
+                    if (detail ==
+                        "The password contains the user name in some form")
+                    {
+                        pfw_sms_appdata_ptr->reasonCode =
+                            BAD_PASSWORD_CONTAINS_USERNAME;
+                    }
+                    if ((detail == "The password is too short") ||
+                        detail.starts_with("The password is shorter than "))
+                    {
+                        pfw_sms_appdata_ptr->reasonCode =
+                            BAD_PASSWORD_TOO_SHORT;
+                    }
+                    if ((detail ==
+                         "The password does not contain enough character classes") ||
+                        detail.starts_with("The password contains less than "))
+                    {
+                        pfw_sms_appdata_ptr->reasonCode =
+                            BAD_PASSWORD_NOT_ENOUGH_CHARACTER_CLASSES;
+                    }
+                    if ((detail ==
+                         "The password contains too long of a monotonic character sequence") ||
+                        detail.starts_with(
+                            "The password contains monotonic sequence longer than "))
+                    {
+                        pfw_sms_appdata_ptr->reasonCode =
+                            BAD_PASSWORD_TOO_LONG_MONOTONIC_SEQUENCE;
+                    }
+                    if (detail == "No password supplied")
+                    {
+                        pfw_sms_appdata_ptr->reasonCode =
+                            BAD_PASSWORD_NO_PASSWORD_SUPPLIED;
+                    }
+                    if (detail.starts_with(
+                            "The password fails the dictionary check"))
+                    {
+                        pfw_sms_appdata_ptr->reasonCode =
+                            BAD_PASSWORD_DICTIONARY_CHECK;
+                    }
+                }
+                else if (msg.starts_with("Username ") &&
+                         (std::string_view::npos != msg.find(" / Password ")) &&
+                         (std::string_view::npos !=
+                          msg.find(" exceeds IPMI 16/20 limit")))
+                {
+                    // Handle messages from
+                    // https://github.com/openbmc/pam-ipmi/blob/master/src/pam_ipmicheck/pam_ipmicheck.c
+                    pfw_sms_appdata_ptr->reasonCode =
+                        PASSWORD_TOO_LONG_FOR_IPMI_USER;
+                }
+                // Ignore other messges, such as: You are required to change
+                // your password immediately (administrator enforced).
+                break;
+            default:
+                // Should never get here
+                return PAM_CONV_ERR;
+                break;
+        }
+    }
+    return PAM_SUCCESS;
+}
+
+/** @brief Common code factored out between authenticate() and changePassword().
+ */
+static void common_authentication_handler(const std::string& username,
+                                          const std::string& password,
+                                          bool& authenticated,
+                                          bool& passwordChangeRequired,
+                                          bool& operationAllowed,
+                                          bool& passwordChangeAllowed)
+{
+    authenticated = false; // default to fail safe (no access)
+    passwordChangeRequired = false;
+    operationAllowed = false;
+    passwordChangeAllowed = false;
+
+    struct pfw_sms_pam_appdata appdata = {
+        password.c_str(), PASSWORD_CHANGE_FAILED_UNKNOWN_REASON};
+    char* appData = reinterpret_cast<char*>(&appdata);
+    const struct pam_conv pamConversation = {pamConversationFunction, appData};
+    pam_handle_t* pamHandle = nullptr; // this gets set by pam_start
+    int retval = pam_start("ibm-pfw-sms-menu", username.c_str(),
+                           &pamConversation, &pamHandle);
+    if (retval != PAM_SUCCESS)
+    {
+        // Note pam_start() failed, so no cleanup is needed.
+        return;
+    }
+
+    retval = pam_authenticate(pamHandle,
+                              PAM_SILENT | PAM_DISALLOW_NULL_AUTHTOK);
+    if (retval != PAM_SUCCESS)
+    {
+        pam_end(pamHandle, retval); // ignore retval
+        return;
+    }
+
+    authenticated = true;
+
+    /* check that the account is healthy */
+    retval = pam_acct_mgmt(pamHandle, PAM_DISALLOW_NULL_AUTHTOK);
+    if (retval == PAM_NEW_AUTHTOK_REQD)
+    {
+        operationAllowed = false;
+        passwordChangeRequired = true;
+        passwordChangeAllowed = true;
+        pam_end(pamHandle, retval); // ignore retval
+        return;
+    }
+    if (retval != PAM_SUCCESS)
+    {
+        pam_end(pamHandle, retval); // ignore retval
+        return;                     // operationAllowed == false
+    }
+    operationAllowed = true;
+    passwordChangeAllowed = true;
+
+    pam_end(pamHandle, retval); // ignore the return value
+}
+
+void authenticate(const std::string& username, const std::string& password,
+                  bool& authenticated, bool& passwordChangeRequired,
+                  bool& operationAllowed)
+{
+    bool passwordChangeAllowed = false;
+    common_authentication_handler(username, password, authenticated,
+                                  passwordChangeRequired, operationAllowed,
+                                  passwordChangeAllowed);
+}
+
+enum changePasswordReasonCode changePassword(const std::string& username,
+                                             const std::string& currentPassword,
+                                             const std::string& newPassword,
+                                             bool& operationAllowed)
+{
+    bool passwordChangeRequired = false;
+    operationAllowed = false;
+    bool authenticated = false;
+    bool passwordChangeAllowed = false;
+    common_authentication_handler(username, currentPassword, authenticated,
+                                  passwordChangeRequired, operationAllowed,
+                                  passwordChangeAllowed);
+    if (!authenticated)
+    {
+        return NOT_AUTHENTICATED;
+    }
+    if (!passwordChangeAllowed)
+    {
+        return NOT_ALLOWED;
+    }
+
+    struct pfw_sms_pam_appdata appdata = {
+        newPassword.c_str(), PASSWORD_CHANGE_FAILED_UNKNOWN_REASON};
+    char* appData = reinterpret_cast<char*>(&appdata);
+    const struct pam_conv pamConversation = {pamConversationFunction, appData};
+    pam_handle_t* pamHandle = nullptr; // this gets set by pam_start
+    int retval = pam_start("ibm-pfw-sms-menu", username.c_str(),
+                           &pamConversation, &pamHandle);
+    if (retval != PAM_SUCCESS)
+    {
+        // Note pam_start() failed, so no cleanup is needed.
+        return PAM_START_FAILED;
+    }
+
+    retval = pam_chauthtok(pamHandle, PAM_SILENT);
+    if (retval != PAM_SUCCESS)
+    {
+        pam_end(pamHandle, retval); // ignore retval
+        // Return the specific reason gathered from the conversation function
+        return appdata.reasonCode;
+    }
+
+    pam_end(pamHandle, retval); // ignore the return value
+    return PASSWORD_CHANGE_SUCCESSFUL;
+}
+
+} /* namespace ibm_pfw_sms */

--- a/oem/ibm/pfw-sms-utils/pfw_sms_menu.hpp
+++ b/oem/ibm/pfw-sms-utils/pfw_sms_menu.hpp
@@ -1,0 +1,83 @@
+#ifndef PFW_SMS_MENU_IBM_HPP
+#define PFW_SMS_MENU_IBM_HPP
+
+#include <string>
+
+namespace ibm_pfw_sms
+{
+
+/** @brief Return code from changePassword
+ *
+ * The "should never happen" codes should be captured for debug/diagnosis.
+ * Comments describe the conditions for which the other codes are used;
+ * these suggest what to tell interactive users.
+ */
+enum changePasswordReasonCode
+{
+    PASSWORD_CHANGE_SUCCESSFUL = 0x00,
+    NOT_AUTHENTICATED = 0x01,            // Username or password was not correct
+    NOT_ALLOWED = 0x02,                  // User is not BMC admin
+    PAM_START_FAILED = 0x03,             // Should never happen
+    LINUX_PAM_CONVERSATION_ERROR = 0x04, // Should never happen
+    PASSWORD_CHANGE_FAILED_UNKNOWN_REASON = 0x0100,
+    // Codes from pam_pwquality.so:
+    BAD_PASSWORD_FOR_UNKNOWN_REASON = 0x0101, // The reason why the new password
+                                              // was not accepted is unknown
+    BAD_PASSWORD_IS_PALINDROME = 0x0102, // The new password is a palindrome
+    BAD_PASSWORD_CONTAINS_USERNAME =
+        0x0103,                      // The new password contains the username
+    BAD_PASSWORD_TOO_SHORT = 0x0104, // The new password is too short
+    BAD_PASSWORD_NOT_ENOUGH_CHARACTER_CLASSES =
+        0x0105,                      // The new password does not have
+                                     // enough different kinds of
+                                     // characters: lowercase, uppercase,
+                                     // numbers, and other
+    BAD_PASSWORD_TOO_LONG_MONOTONIC_SEQUENCE =
+        0x0106,                      // The new password has a monotonic
+                                     // sequence, like 1234
+    BAD_PASSWORD_NO_PASSWORD_SUPPLIED = 0x0107, // The new password is empty
+                                                // (zero length)
+    BAD_PASSWORD_DICTIONARY_CHECK = 0x0108,     // The new password contains a
+                                                // dictionary word
+    // Gap in numbering to accomodate future errors from pam_pwquality
+    // Codes from pam_ipmicheck.so:
+    PASSWORD_TOO_LONG_FOR_IPMI_USER =
+        0x0201, // IPMI users are limited to 20 character passwords
+};
+
+/** @brief Authenticate a password request from PFW SMS
+ *
+ * @param[in] username - the name of the BMC account
+ * @param[in] password - the password associated with the username
+ * @param[out] authenticated - true if password authentication was
+ * successful; note this only reports password authentication, and the
+ * parameters passwordChangeRequired and operationAllowed should be checked
+ * as appropriate.
+ * @param[out] passwordChangeRequired - true if the password needs to be
+ * changed
+ * @param[out] operationAllowed - true if the user should be allowed to
+ * perform the PFW SMS operation
+ *
+ * @note Authentication is to BMC user account
+ */
+void authenticate(const std::string& username, const std::string& password,
+                  bool& authenticated, bool& passwordChangeRequired,
+                  bool& operationAllowed);
+
+/** @brief Handle password change request from PFW SMS
+ *
+ * @param[in] username - the name of the BMC account
+ * @param[in] currentPassword - the password associated with the username
+ * @param[in] newPassword - the proposed new password
+ * @param[out] operationAllowed - true if the user is an authenticated admin
+ * user
+ * @return changePasswordReasonCode
+ */
+enum changePasswordReasonCode changePassword(const std::string& username,
+                                             const std::string& currentPassword,
+                                             const std::string& newPassword,
+                                             bool& operationAllowed);
+
+} /* namespace ibm_pfw_sms */
+
+#endif /* PFW_SMS_MENU_IBM_HPP */

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -1,6 +1,7 @@
 #include "dbus_to_file_handler.hpp"
 
 #include "common/utils.hpp"
+#include "pfw-sms-utils/pfw_sms_menu.hpp"
 
 #include <libpldm/oem/ibm/file_io.h>
 
@@ -16,6 +17,7 @@ namespace oem_ibm
 {
 using namespace pldm::utils;
 using namespace sdbusplus::bus::match::rules;
+using namespace ibm_pfw_sms;
 
 static constexpr auto resDumpProgressIntf =
     "xyz.openbmc_project.Common.Progress";
@@ -374,6 +376,71 @@ void DbusToFileHandler::newFileAvailableSendToHost(const uint32_t fileSize,
         error(
             "Failed to send NewFileAvailable Request to Host for vmi, response code '{RC}'",
             "RC", rc);
+    }
+}
+
+void DbusToFileHandler::sendFileAckWithMetaDataToHost(
+    uint16_t fileType, uint32_t fileHandle, uint8_t fileStatus,
+    uint32_t fileMetaData1, uint32_t fileMetaData2, uint32_t fileMetaData3,
+    uint32_t fileMetaData4)
+{
+    info(
+        "sending acknowledgement with metadata to host where metadata1:{FMD1} metadata2:{FMD2} metadata3:{FMD3} "
+        "metadata4:{FMD4}",
+        "FMD1", fileMetaData1, "FMD2", fileMetaData2, "FMD3", fileMetaData3,
+        "FMD4", fileMetaData4);
+    if (instanceIdDb == NULL)
+    {
+        error("Failed to send sms menu data validation response as "
+              "requester is not set");
+        pldm::utils::reportError(
+            "xyz.openbmc_project.PLDM.Error.sendFileAckWithMetaDataToHost."
+            "SendSmsMenuRespFail");
+        return;
+    }
+    auto instanceId = instanceIdDb->next(mctp_eid);
+    std::vector<uint8_t> requestMsg(sizeof(pldm_msg_hdr) +
+                                    PLDM_FILE_ACK_WITH_META_DATA_REQ_BYTES);
+    auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
+
+    auto rc = encode_file_ack_with_meta_data_req(
+        instanceId, fileType, fileHandle, fileStatus, fileMetaData1,
+        fileMetaData2, fileMetaData3, fileMetaData4, request);
+    if (rc != PLDM_SUCCESS)
+    {
+        instanceIdDb->free(mctp_eid, instanceId);
+        error(
+            "Failed to encode_file_ack_with_meta_data_req, response code:{RC}",
+            "RC", rc);
+        return;
+    }
+
+    auto fileAckWithMetaDataRespHandler = [this](mctp_eid_t /*eid*/,
+                                                 const pldm_msg* response,
+                                                 size_t respMsgLen) {
+        if (response == nullptr || !respMsgLen)
+        {
+            error("Failed to receive response for FileAckWithMetaData command");
+            return;
+        }
+        uint8_t completionCode{};
+        auto rc = decode_file_ack_with_meta_data_resp(response, respMsgLen,
+                                                      &completionCode);
+        if (rc || completionCode)
+        {
+            error(
+                "Failed to decode_file_ack_with_meta_data_resp or Host returned"
+                " error for file_ack_with_meta_data response code:{RC}, "
+                "completion code:{CC}",
+                "RC", rc, "CC", completionCode);
+        }
+    };
+    rc = handler->registerRequest(
+        mctp_eid, instanceId, PLDM_OEM, PLDM_FILE_ACK_WITH_META_DATA,
+        std::move(requestMsg), std::move(fileAckWithMetaDataRespHandler));
+    if (rc)
+    {
+        error("Failed to send FileAckWithMetaData Request to Host");
     }
 }
 

--- a/oem/ibm/requester/dbus_to_file_handler.hpp
+++ b/oem/ibm/requester/dbus_to_file_handler.hpp
@@ -71,6 +71,23 @@ class DbusToFileHandler
      */
     void newLicFileAvailable(const std::string& licenseStr);
 
+    /** @brief Send the file ack with metadata command request to host
+     *  @param[in] fileType - type of the file
+     *  @param[in] fileHandle - file handle
+     *  @param[in] fileStatus - file status
+     *  @param[in] fileMetaData1 - file meta data value 1
+     *  @param[in] fileMetaData2 - file meta data value 2
+     *  @param[in] fileMetaData3 - file meta data value 3
+     *  @param[in] fileMetaData4 - file meta data value 4
+     */
+    void sendFileAckWithMetaDataToHost(const uint16_t fileType,
+                                       const uint32_t fileHandle,
+                                       const uint8_t fileStatus,
+                                       const uint32_t fileMetaData1,
+                                       const uint32_t fileMetaData2,
+                                       const uint32_t fileMetaData3,
+                                       const uint32_t fileMetaData4);
+
   private:
     /** @brief Send the new file available command request to hypervisor
      *  @param[in] fileSize - size of the file

--- a/oem/ibm/test/libpldmresponder_fileio_test.cpp
+++ b/oem/ibm/test/libpldmresponder_fileio_test.cpp
@@ -6,6 +6,7 @@
 #include "libpldmresponder/file_io_type_lid.hpp"
 #include "libpldmresponder/file_io_type_pcie.hpp"
 #include "libpldmresponder/file_io_type_pel.hpp"
+#include "libpldmresponder/file_io_type_smsmenu.hpp"
 #include "libpldmresponder/file_table.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -13,6 +14,7 @@
 #include <libpldm/oem/ibm/file_io.h>
 
 #include <nlohmann/json.hpp>
+#include <sdeventplus/event.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -119,6 +121,7 @@ TEST(ReadFileIntoMemory, BadPath)
     uint64_t address = 0;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_REQ_BYTES>
         requestMsg{};
@@ -134,7 +137,7 @@ TEST(ReadFileIntoMemory, BadPath)
     // Pass invalid payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.readFileIntoMemory(request, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -149,6 +152,7 @@ TEST_F(TestFileTable, ReadFileInvalidFileHandle)
     uint64_t address = 0;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_REQ_BYTES>
         requestMsg{};
@@ -168,7 +172,7 @@ TEST_F(TestFileTable, ReadFileInvalidFileHandle)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.readFileIntoMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_INVALID_FILE_HANDLE);
@@ -185,6 +189,7 @@ TEST_F(TestFileTable, ReadFileInvalidOffset)
     uint64_t address = 0;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_REQ_BYTES>
         requestMsg{};
@@ -203,7 +208,7 @@ TEST_F(TestFileTable, ReadFileInvalidOffset)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.readFileIntoMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_DATA_OUT_OF_RANGE);
@@ -220,6 +225,7 @@ TEST_F(TestFileTable, ReadFileInvalidLength)
     uint64_t address = 0;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_REQ_BYTES>
         requestMsg{};
@@ -238,7 +244,7 @@ TEST_F(TestFileTable, ReadFileInvalidLength)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.readFileIntoMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -258,6 +264,7 @@ TEST_F(TestFileTable, ReadFileInvalidEffectiveLength)
     uint64_t address = 0;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_REQ_BYTES>
         requestMsg{};
@@ -276,7 +283,7 @@ TEST_F(TestFileTable, ReadFileInvalidEffectiveLength)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.readFileIntoMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -292,6 +299,7 @@ TEST(WriteFileFromMemory, BadPath)
     uint64_t address = 0;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_REQ_BYTES>
         requestMsg{};
@@ -308,7 +316,7 @@ TEST(WriteFileFromMemory, BadPath)
     // Pass invalid payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.writeFileFromMemory(request, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -328,6 +336,7 @@ TEST_F(TestFileTable, WriteFileInvalidFileHandle)
     uint64_t address = 0;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_REQ_BYTES>
         requestMsg{};
@@ -347,7 +356,7 @@ TEST_F(TestFileTable, WriteFileInvalidFileHandle)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.writeFileFromMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_INVALID_FILE_HANDLE);
@@ -364,6 +373,7 @@ TEST_F(TestFileTable, WriteFileInvalidOffset)
     uint64_t address = 0;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_RW_FILE_MEM_REQ_BYTES>
         requestMsg{};
@@ -383,7 +393,7 @@ TEST_F(TestFileTable, WriteFileInvalidOffset)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.writeFileFromMemory(request, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_DATA_OUT_OF_RANGE);
@@ -443,6 +453,7 @@ TEST_F(TestFileTable, GetFileTableCommand)
     uint8_t transferFlag = PLDM_START_AND_END;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_GET_FILE_TABLE_REQ_BYTES>
         requestMsg{};
@@ -456,7 +467,7 @@ TEST_F(TestFileTable, GetFileTableCommand)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.getFileTable(requestMsgPtr, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_SUCCESS);
@@ -476,6 +487,7 @@ TEST_F(TestFileTable, GetFileTableCommandReqLengthMismatch)
 {
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_GET_FILE_TABLE_REQ_BYTES>
         requestMsg{};
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
@@ -483,7 +495,7 @@ TEST_F(TestFileTable, GetFileTableCommandReqLengthMismatch)
     // Pass invalid command payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.getFileTable(request, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -496,6 +508,7 @@ TEST_F(TestFileTable, GetFileTableCommandOEMAttrTable)
     uint8_t type = PLDM_OEM_FILE_ATTRIBUTE_TABLE;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_GET_FILE_TABLE_REQ_BYTES>
         requestMsg{};
@@ -509,7 +522,7 @@ TEST_F(TestFileTable, GetFileTableCommandOEMAttrTable)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.getFileTable(requestMsgPtr, requestPayloadLength);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_INVALID_FILE_TABLE_TYPE);
@@ -522,6 +535,7 @@ TEST_F(TestFileTable, ReadFileBadPath)
     uint32_t length = 0x4;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_READ_FILE_REQ_BYTES>
         requestMsg{};
@@ -541,7 +555,7 @@ TEST_F(TestFileTable, ReadFileBadPath)
     // Invalid payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.readFile(requestMsgPtr, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -570,6 +584,7 @@ TEST_F(TestFileTable, ReadFileGoodPath)
     uint32_t length = 0x4;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::array<uint8_t, sizeof(pldm_msg_hdr) + PLDM_READ_FILE_REQ_BYTES>
         requestMsg{};
@@ -595,7 +610,7 @@ TEST_F(TestFileTable, ReadFileGoodPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto responseMsg = handler.readFile(requestMsgPtr, payload_length);
     auto response = reinterpret_cast<pldm_read_file_resp*>(
         responseMsg.data() + sizeof(pldm_msg_hdr));
@@ -630,6 +645,7 @@ TEST_F(TestFileTable, WriteFileBadPath)
     uint32_t length = 0x10;
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::vector<uint8_t> requestMsg(sizeof(pldm_msg_hdr) +
                                     PLDM_WRITE_FILE_REQ_BYTES + length);
@@ -649,7 +665,7 @@ TEST_F(TestFileTable, WriteFileBadPath)
     // Invalid payload length
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.writeFile(requestMsgPtr, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     ASSERT_EQ(responsePtr->payload[0], PLDM_ERROR_INVALID_LENGTH);
@@ -679,6 +695,7 @@ TEST_F(TestFileTable, WriteFileGoodPath)
     uint32_t length = fileData.size();
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     std::vector<uint8_t> requestMsg(sizeof(pldm_msg_hdr) +
                                     PLDM_WRITE_FILE_REQ_BYTES + length);
@@ -700,7 +717,7 @@ TEST_F(TestFileTable, WriteFileGoodPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto responseMsg = handler.writeFile(requestMsgPtr, payload_length);
     auto response = reinterpret_cast<pldm_read_file_resp*>(
         responseMsg.data() + sizeof(pldm_msg_hdr));
@@ -721,6 +738,7 @@ TEST(writeFileByTypeFromMemory, testBadPath)
 {
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
 
     const auto hdr_size = sizeof(pldm_msg_hdr);
     std::array<uint8_t, hdr_size + PLDM_RW_FILE_BY_TYPE_MEM_REQ_BYTES>
@@ -738,7 +756,7 @@ TEST(writeFileByTypeFromMemory, testBadPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.writeFileByTypeFromMemory(req, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
 
@@ -758,59 +776,84 @@ TEST(writeFileByTypeFromMemory, testBadPath)
 TEST(getHandlerByType, allPaths)
 {
     uint32_t fileHandle{};
-    auto handler = getHandlerByType(PLDM_FILE_TYPE_PEL, fileHandle);
+    pldm::InstanceIdDb* instanceIdDb = nullptr;
+    pldm::requester::Handler<pldm::requester::Request>* reqHandler = nullptr;
+    auto handler = getHandlerByType(PLDM_FILE_TYPE_PEL, fileHandle,
+                                    instanceIdDb, reqHandler);
     auto pelType = dynamic_cast<PelHandler*>(handler.get());
     ASSERT_TRUE(pelType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_LID_PERM, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_LID_PERM, fileHandle,
+                               instanceIdDb, reqHandler);
     auto lidType = dynamic_cast<LidHandler*>(handler.get());
     ASSERT_TRUE(lidType != nullptr);
     pelType = dynamic_cast<PelHandler*>(handler.get());
     ASSERT_TRUE(pelType == nullptr);
-    handler = getHandlerByType(PLDM_FILE_TYPE_LID_TEMP, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_LID_TEMP, fileHandle,
+                               instanceIdDb, reqHandler);
     lidType = dynamic_cast<LidHandler*>(handler.get());
     ASSERT_TRUE(lidType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_DUMP, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_DUMP, fileHandle, instanceIdDb,
+                               reqHandler);
     auto dumpType = dynamic_cast<DumpHandler*>(handler.get());
     ASSERT_TRUE(dumpType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS, fileHandle,
+                               instanceIdDb, reqHandler);
     dumpType = dynamic_cast<DumpHandler*>(handler.get());
     ASSERT_TRUE(dumpType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_RESOURCE_DUMP, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_RESOURCE_DUMP, fileHandle,
+                               instanceIdDb, reqHandler);
     dumpType = dynamic_cast<DumpHandler*>(handler.get());
     ASSERT_TRUE(dumpType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_CERT_SIGNING_REQUEST, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_CERT_SIGNING_REQUEST, fileHandle,
+                               instanceIdDb, reqHandler);
     auto certType = dynamic_cast<CertHandler*>(handler.get());
     ASSERT_TRUE(certType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_SIGNED_CERT, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_SIGNED_CERT, fileHandle,
+                               instanceIdDb, reqHandler);
     certType = dynamic_cast<CertHandler*>(handler.get());
     ASSERT_TRUE(certType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_PCIE_TOPOLOGY, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_PCIE_TOPOLOGY, fileHandle,
+                               instanceIdDb, reqHandler);
     auto pcieTopologyType = dynamic_cast<PCIeInfoHandler*>(handler.get());
     ASSERT_TRUE(pcieTopologyType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_CABLE_INFO, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_CABLE_INFO, fileHandle,
+                               instanceIdDb, reqHandler);
     auto cableInfoType = dynamic_cast<PCIeInfoHandler*>(handler.get());
     ASSERT_TRUE(cableInfoType != nullptr);
 
-    handler = getHandlerByType(PLDM_FILE_TYPE_ROOT_CERT, fileHandle);
+    handler = getHandlerByType(PLDM_FILE_TYPE_ROOT_CERT, fileHandle,
+                               instanceIdDb, reqHandler);
     certType = dynamic_cast<CertHandler*>(handler.get());
     ASSERT_TRUE(certType != nullptr);
 
+    handler = getHandlerByType(PLDM_FILE_TYPE_USER_PASSWORD_AUTHENTICATION,
+                               fileHandle, instanceIdDb, reqHandler);
+    auto smsMenuType = dynamic_cast<SmsMenuHandler*>(handler.get());
+    ASSERT_TRUE(smsMenuType != nullptr);
+
+    handler = getHandlerByType(PLDM_FILE_TYPE_USER_PASSWORD_CHANGE, fileHandle,
+                               instanceIdDb, reqHandler);
+    smsMenuType = dynamic_cast<SmsMenuHandler*>(handler.get());
+    ASSERT_TRUE(smsMenuType != nullptr);
+
     using namespace sdbusplus::xyz::openbmc_project::Common::Error;
-    ASSERT_THROW(getHandlerByType(0xFFFF, fileHandle), InternalFailure);
+    ASSERT_THROW(getHandlerByType(0xFFFF, fileHandle, instanceIdDb, reqHandler),
+                 InternalFailure);
 }
 
 TEST(readFileByTypeIntoMemory, testBadPath)
 {
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
     const auto hdr_size = sizeof(pldm_msg_hdr);
     std::array<uint8_t, hdr_size + PLDM_RW_FILE_BY_TYPE_MEM_REQ_BYTES>
         requestMsg{};
@@ -826,7 +869,7 @@ TEST(readFileByTypeIntoMemory, testBadPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.readFileByTypeIntoMemory(req, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     struct pldm_read_write_file_by_type_memory_resp* resp =
@@ -854,6 +897,7 @@ TEST(readFileByType, testBadPath)
 {
     uint8_t host_eid = 0;
     int hostSocketFd = 0;
+    auto event = sdeventplus::Event::get_default();
     const auto hdr_size = sizeof(pldm_msg_hdr);
     std::array<uint8_t, hdr_size + PLDM_RW_FILE_BY_TYPE_REQ_BYTES> requestMsg{};
     auto payloadLength = requestMsg.size() - hdr_size;
@@ -868,7 +912,7 @@ TEST(readFileByType, testBadPath)
 
     std::unique_ptr<oem_platform::Handler> oemPlatformHandler{};
     oem_ibm::Handler handler(oemPlatformHandler.get(), hostSocketFd, host_eid,
-                             nullptr, nullptr, nullptr);
+                             nullptr, nullptr, nullptr, event);
     auto response = handler.readFileByType(req, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     struct pldm_read_write_file_by_type_resp* resp =

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -265,11 +265,11 @@ int main(int argc, char** argv)
     slotHandler->setOemPlatformHandler(oemPlatformHandler.get());
     oemFruHandler = std::make_unique<oem_ibm_fru::Handler>(pdrRepo.get());
 
-    invoker.registerHandler(PLDM_OEM, std::make_unique<oem_ibm::Handler>(
-                                          oemPlatformHandler.get(),
-                                          pldmTransport.getEventSource(),
-                                          hostEID, &instanceIdDb, &reqHandler,
-                                          respInterface.responseObj.get()));
+    invoker.registerHandler(
+        PLDM_OEM, std::make_unique<oem_ibm::Handler>(
+                      oemPlatformHandler.get(), pldmTransport.getEventSource(),
+                      hostEID, &instanceIdDb, &reqHandler,
+                      respInterface.responseObj.get(), event));
 #endif
     if (hostEID)
     {


### PR DESCRIPTION
This supports the following password prompts for PFW (Platform Firmware) provided graphical SMS (System Management Services (SMS) menu

In system configurations that include a graphics adapter assigned to a partition, PFW can display the SMS menus on the console allowing users to interact with PFW using a keybaord. This menu requires as they can be used to change partition configurations (e.g. Boot option, I/O device info etc.)

Supported password prompt functions:
1. The ability to prompt for a username/password and provide authentication
2. The ability to change a password when the current password is expired

Change-Id: Ie42c5306e6447f65064bb8cb9480a3cde0e4ed4e