### PR TITLE
oem: ibm: fileTable: Add new lids and update permissions

### DIFF
--- a/oem/ibm/configurations/fileTable.json
+++ b/oem/ibm/configurations/fileTable.json
@@ -305,7 +305,7 @@
     },
     {
         "path": "/usr/local/share/hostfw/running/81e006a7.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006a7.lid",
-        "file_traits": 1
+        "file_traits": 2
     },
     {
         "path": "/usr/local/share/hostfw/running/81e006a8.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006a8.lid",
@@ -337,7 +337,7 @@
     },
     {
         "path": "/usr/local/share/hostfw/running/81e006af.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006af.lid",
-        "file_traits": 1
+        "file_traits": 2
     },
     {
         "path": "/usr/local/share/hostfw/running/81e006b0.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006b0.lid",
@@ -369,7 +369,7 @@
     },
     {
         "path": "/usr/local/share/hostfw/running/81e006b7.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006b7.lid",
-        "file_traits": 1
+        "file_traits": 2
     },
     {
         "path": "/usr/local/share/hostfw/running/81e006b8.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006b8.lid",
@@ -389,6 +389,14 @@
     },
     {
         "path": "/usr/local/share/hostfw/running/81e006bc.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006bc.lid",
+        "file_traits": 1
+    },
+    {
+        "path": "/usr/local/share/hostfw/running/81e006bd.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006bd.lid",
+        "file_traits": 1
+    },
+    {
+        "path": "/usr/local/share/hostfw/running/81e006be.lid,/var/lib/phosphor-software-manager/hostfw/running/81e006be.lid",
         "file_traits": 1
     }
 ]


### PR DESCRIPTION
Add 2 new lids and update the permissions for hostboot's DEVTREE to be read-write.

Change-Id: I95006e2b37d15a148f072f66804950e983ea1aab