### PR TITLE
oem-ibm: Adding BIOS attribute for dynamic deallocation of Memory

### DIFF
--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/enum_attrs.json
@@ -61,6 +61,21 @@
             "readOnly": true
         },
         {
+            "attribute_name": "hb_predictive_mem_guard",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard"
+        },
+        {
+            "attribute_name": "hb_predictive_mem_guard_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_stop_at_standby",
             "possible_values": ["Disabled", "Enabled", "ManualOnly"],
             "default_values": ["Disabled"],

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/enum_attrs.json
@@ -75,6 +75,21 @@
             "readOnly": true
         },
         {
+            "attribute_name": "hb_predictive_mem_guard",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard"
+        },
+        {
+            "attribute_name": "hb_predictive_mem_guard_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_stop_at_standby",
             "possible_values": ["Disabled", "Enabled", "ManualOnly"],
             "default_values": ["Disabled"],

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/enum_attrs.json
@@ -75,6 +75,21 @@
             "readOnly": true
         },
         {
+            "attribute_name": "hb_predictive_mem_guard",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard"
+        },
+        {
+            "attribute_name": "hb_predictive_mem_guard_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_stop_at_standby",
             "possible_values": ["Disabled", "Enabled", "ManualOnly"],
             "default_values": ["Disabled"],

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/enum_attrs.json
@@ -75,6 +75,21 @@
             "readOnly": true
         },
         {
+            "attribute_name": "hb_predictive_mem_guard",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard"
+        },
+        {
+            "attribute_name": "hb_predictive_mem_guard_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_stop_at_standby",
             "possible_values": ["Disabled", "Enabled", "ManualOnly"],
             "default_values": ["Disabled"],

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/enum_attrs.json
@@ -75,6 +75,21 @@
             "readOnly": true
         },
         {
+            "attribute_name": "hb_predictive_mem_guard",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard"
+        },
+        {
+            "attribute_name": "hb_predictive_mem_guard_current",
+            "possible_values": ["Enabled", "Disabled"],
+            "default_values": ["Enabled"],
+            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
+            "displayName": "Predictive Memory Guard",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_stop_at_standby",
             "possible_values": ["Disabled", "Enabled", "ManualOnly"],
             "default_values": ["Disabled"],


### PR DESCRIPTION
When a predictive memory fail event occurs, the system dynamically deallocates an entire memory interleave group that includes the failing memory module. This commit adds BIOS attribute for allowing user to enable/disable the dynamic deallocation of memory based on predictive memory fail events.

Tested: Verified the BIOS attribute with get bios attribute command from pldmtool.