### PR TITLE
oem-ibm: Implement SBE dump support

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -917,6 +917,10 @@ void HostPDRHandler::processHostPDRs(mctp_eid_t /*eid*/,
 void HostPDRHandler::_processPDRRepoChgEvent(
     sdeventplus::source::EventBase& /*source */)
 {
+    if (oemPlatformHandler)
+    {
+        oemPlatformHandler->updateContainerID();
+    }
     deferredPDRRepoChgEvent.reset();
     this->sendPDRRepositoryChgEvent(
         std::move(std::vector<uint8_t>(1, PLDM_PDR_ENTITY_ASSOCIATION)),

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -16,6 +16,30 @@ class Handler : public CmdHandler
   public:
     Handler(const pldm::utils::DBusHandler* dBusIntf) : dBusIntf(dBusIntf) {}
 
+    /** @brief Interface to set the numeric effecter requested by pldm
+     *  requester for OEM types. Each individual oem type should implement
+     *  it's own handler.
+     *
+     *  @param[in] entityType - entity type corresponding to the effecter id
+     *  @param[in] entityInstance - entity instance
+     *  @param[in] effecterSemanticId - effecter semantic id
+     *  @param[in] effecterDataSize - effecter value size.
+     *  @param[in] effecterValue - effecter value.
+     *  @param[in] effecterOffset - offset of the effecter.
+     *  @param[in] effecterResolution - resolution of the effecter.
+     *  @param[in] effecterId - Effecter ID sent by the requester to act on.
+     *
+     *  @return - Success or failure in setting the states.Returns failure in
+     *            terms of PLDM completion codes if atleast one state fails to
+     *            be set
+     *
+     */
+    virtual int oemSetNumericEffecterValueHandler(
+        uint16_t entityType, uint16_t entityInstance,
+        uint16_t effecterSemanticId, uint8_t effecterDataSize,
+        uint8_t* effecterValue, real32_t effecterOffset,
+        real32_t effecterResolution, uint16_t effecterId) = 0;
+
     /** @brief Interface to get the state sensor readings requested by pldm
      *  requester for OEM types. Each specific type should implement a handler
      *  of it's own
@@ -93,6 +117,18 @@ class Handler : public CmdHandler
 
     /** @brief update the dbus object paths */
     virtual void updateOemDbusPaths(std::string& dbusPath) = 0;
+
+    /** @brief Interface to update container ID */
+    virtual void updateContainerID() = 0;
+
+    /** @brief Interface to set the host effecter state
+     *  @param status - the status of dump creation
+     *  @param entityTypeReceived - the entity type
+     *  @param entityInstance - entity instance number
+     *
+     */
+    virtual void setHostEffecterState(bool status, uint16_t entityTypeReceived,
+                                      uint16_t entityInstance) = 0;
 
     /** @brief Interface to fetch the last BMC record from the PDR repository
      *

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -773,9 +773,24 @@ Response Handler::setNumericEffecterValue(const pldm_msg* request,
     int rc = decode_set_numeric_effecter_value_req(
         request, payloadLength, &effecterId, &effecterDataSize, effecterValue);
 
-    if (rc == PLDM_SUCCESS)
+    const pldm::utils::DBusHandler dBusIntf;
+    uint16_t entityType{};
+    uint16_t entityInstance{};
+    uint16_t effecterSemanticId{};
+    real32_t effecterOffset{};
+    real32_t effecterResolution{};
+
+    if (isOemNumericEffecter(*this, effecterId, entityType, entityInstance,
+                             effecterDataSize, effecterSemanticId,
+                             effecterOffset, effecterResolution) &&
+        oemPlatformHandler)
     {
-        const pldm::utils::DBusHandler dBusIntf;
+        rc = oemPlatformHandler->oemSetNumericEffecterValueHandler(
+            entityType, entityInstance, effecterSemanticId, effecterDataSize,
+            effecterValue, effecterOffset, effecterResolution, effecterId);
+    }
+    else
+    {
         rc = platform_numeric_effecter::setNumericEffecterValueHandler<
             pldm::utils::DBusHandler, Handler>(dBusIntf, *this, effecterId,
                                                effecterDataSize, effecterValue,
@@ -891,6 +906,65 @@ void Handler::_processPostGetPDRActions(sdeventplus::source::EventBase&
 {
     deferredGetPDREvent.reset();
     dbusToPLDMEventHandler->listenSensorEvent(pdrRepo, sensorDbusObjMaps);
+}
+
+bool isOemNumericEffecter(Handler& handler, uint16_t effecterId,
+                          uint16_t& entityType, uint16_t& entityInstance,
+                          uint8_t& effecterDataSize,
+                          uint16_t& effecterSemanticId,
+                          real32_t& effecterOffset,
+                          real32_t& effecterResolution)
+{
+    pldm_numeric_effecter_value_pdr* pdr = nullptr;
+
+    std::unique_ptr<pldm_pdr, decltype(&pldm_pdr_destroy)>
+        numericEffecterPdrRepo(pldm_pdr_init(), pldm_pdr_destroy);
+    pldm::responder::pdr_utils::Repo numericEffecterPDRs(
+        numericEffecterPdrRepo.get());
+    pldm::responder::pdr::getRepoByType(handler.getRepo(), numericEffecterPDRs,
+                                        PLDM_NUMERIC_EFFECTER_PDR);
+
+    if (numericEffecterPDRs.empty())
+    {
+        error("Failed to get record by PDR type");
+        return false;
+    }
+
+    PdrEntry pdrEntry{};
+    auto pdrRecord = numericEffecterPDRs.getFirstRecord(pdrEntry);
+    while (pdrRecord)
+    {
+        pdr = reinterpret_cast<pldm_numeric_effecter_value_pdr*>(pdrEntry.data);
+        assert(pdr);
+        if (pdr->effecter_id != effecterId)
+        {
+            pdr = nullptr;
+            pdrRecord = numericEffecterPDRs.getNextRecord(pdrRecord, pdrEntry);
+            continue;
+        }
+
+        auto tmpEntityType = pdr->entity_type;
+        auto tmpEntityInstance = pdr->entity_instance;
+        auto tmpEffecterDataSize = pdr->effecter_data_size;
+        auto tmpEffecterSemanticId = pdr->effecter_semantic_id;
+        auto tmpEffecterOffset = pdr->offset;
+        auto tmpEffecterResolution = pdr->resolution;
+
+        if ((tmpEntityType >= PLDM_OEM_ENTITY_TYPE_START &&
+             tmpEntityType <= PLDM_OEM_ENTITY_TYPE_END) ||
+            (tmpEffecterSemanticId >= PLDM_OEM_STATE_SET_ID_START &&
+             tmpEffecterSemanticId < PLDM_OEM_STATE_SET_ID_END))
+        {
+            entityType = tmpEntityType;
+            entityInstance = tmpEntityInstance;
+            effecterDataSize = tmpEffecterDataSize;
+            effecterSemanticId = tmpEffecterSemanticId;
+            effecterOffset = tmpEffecterOffset;
+            effecterResolution = tmpEffecterResolution;
+            return true;
+        }
+    }
+    return false;
 }
 
 bool isOemStateSensor(Handler& handler, uint16_t sensorId,

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -541,6 +541,29 @@ class Handler : public CmdHandler
     bool clearMexObj = true;
 };
 
+/** @brief Function to check if the effecter falls in OEM range
+ *         An effecter is considered to be oem if either of entity
+ *         type or effecter semantic id or both falls in oem range
+ *
+ *  @param[in] handler - the interface object
+ *  @param[in] effecterId - effecter id
+ *  @param[out] entityType - entity type
+ *  @param[out] entityInstance - entity instance number
+ *  @param[out] effecterDataSize - effecter value size
+ *  @param[out] effecterSemanticId - effecter semantic id
+ *  @param[out] effecterOffset - offset of the effecter
+ *  @param[out] effecterResolution - resolution of the effecter
+ *
+ *  @return true if the effecter is OEM. All out parameters are invalid
+ *                  for a non OEM effecter
+ */
+bool isOemNumericEffecter(Handler& handler, uint16_t effecterId,
+                          uint16_t& entityType, uint16_t& entityInstance,
+                          uint8_t& effecterDataSize,
+                          uint16_t& effecterSemanticId,
+                          real32_t& effecterOffset,
+                          real32_t& effecterResolution);
+
 /** @brief Function to check if a sensor falls in OEM range
  *         A sensor is considered to be oem if either of entity
  *         type or state set or both falls in oem range

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -8,6 +8,7 @@
 #include "libpldmresponder/pdr_utils.hpp"
 #include "libpldmresponder/platform.hpp"
 #include "oem/ibm/requester/dbus_to_file_handler.hpp"
+#include "pldmd/dbus_impl_requester.hpp"
 #include "requester/handler.hpp"
 #include "utils.hpp"
 
@@ -88,6 +89,14 @@ const pldm::pdr::TerminusID HYPERVISOR_TID = 208;
 
 static constexpr uint8_t HEARTBEAT_TIMEOUT_DELTA = 10;
 
+struct InstanceInfo
+{
+    uint8_t procId;
+    uint8_t dcmId;
+};
+using HostEffecterInstanceMap = std::map<pldm::pdr::EffecterID, InstanceInfo>;
+using HostEffecterDimmMap = std::map<pldm::pdr::EffecterID, uint16_t>;
+
 enum SetEventReceiverCount
 {
     SET_EVENT_RECEIVER_SENT = 0x2,
@@ -114,6 +123,7 @@ class Handler : public oem_platform::Handler
         codeUpdate->setVersions();
         pldm::responder::utils::clearLicenseStatus();
         setEventReceiverCnt = 0;
+
         sdbusplus::message::object_path path;
         dbusToFileioIntf =
             std::make_unique<pldm::responder::oem_ibm_fileio::Handler>(
@@ -121,6 +131,7 @@ class Handler : public oem_platform::Handler
         pldm::responder::utils::hostChapDataIntf(dbusToFileioIntf.get());
 
         using namespace sdbusplus::bus::match::rules;
+
         hostOffMatch = std::make_unique<sdbusplus::bus::match_t>(
             pldm::utils::DBusHandler::getBus(),
             propertiesChanged("/xyz/openbmc_project/state/host0",
@@ -295,6 +306,12 @@ class Handler : public oem_platform::Handler
         });
     }
 
+    int oemSetNumericEffecterValueHandler(
+        uint16_t entityType, uint16_t entityInstance,
+        uint16_t effecterSemanticId, uint8_t effecterDataSize,
+        uint8_t* effecterValue, real32_t effecterOffset,
+        real32_t effecterResolution, uint16_t effecterId);
+
     int getOemStateSensorReadingsHandler(
         pldm::pdr::EntityType entityType,
         pldm::pdr::EntityInstance entityInstance,
@@ -342,6 +359,31 @@ class Handler : public oem_platform::Handler
     {
         return platformHandler->getAssociateEntityMap();
     }
+
+    /** @brief Method to generate and populate list of dcm/cpu ids
+     *
+     *  @return a vector of InstanceInfo type containing ids
+     */
+    std::vector<InstanceInfo> generateProcAndDcmIDs();
+
+    /** @brief Method to get and store dcm/cpu paths from dbus using getSubTree
+     * api
+     *
+     *  @return a vector containing cpu object paths
+     */
+    std::vector<std::string> getProcObjectPaths();
+
+    /** @brief Method to get and store dimm paths from dbus using getSubTree api
+     *
+     *  @return a vector containing dimm object paths
+     */
+    std::vector<std::string> getDimmObjectPaths();
+
+    /** @brief Method to generate and populate list of dimm ids
+     *
+     *  @return a vector containing dimm ids
+     */
+    std::vector<uint16_t> generateDimmIds();
 
     /** @brief Method to Generate the OEM PDRs
      *
@@ -418,6 +460,40 @@ class Handler : public oem_platform::Handler
 
     /** @brief update the dbus object paths */
     void updateOemDbusPaths(std::string& dbusPath);
+
+    /** @brief update containerID in PDRs */
+    void updateContainerID();
+
+    /** @brief setNumericEffecter
+     *
+     *  @param[in] entityInstance - the entity Instance
+     *  @param[in] propertyValue - the value to be set
+     *  @param[in] entityType - the type of numeric effecter(entity)
+     *
+     *  @return PLDM completion_code
+     */
+    int setNumericEffecter(uint16_t entityInstance,
+                           const pldm::utils::PropertyValue& propertyValue,
+                           uint16_t entityType);
+
+    /** @brief monitor the dump
+     *
+     *  @param[in] object_path - The object path of the dump to monitor
+     *  @param[in] entityType - the entity type
+     *  @param[in] entityInstance - the entity instance id of the effecter
+     *
+     */
+    void monitorDump(const std::string& obj_path, uint16_t entityType,
+                     uint16_t entityInstance);
+
+    /** @brief Method to set the host effecter state
+     *  @param status - the status of dump creation
+     *  @param entityTypeReceived - the entity type
+     *  @param entityInstance - the entity instance id of the effecter
+     *
+     */
+    void setHostEffecterState(bool status, uint16_t entityTypeReceived,
+                              uint16_t entityInstance);
 
     /** @brief Method to fetch the last BMC record from the PDR repo
      *
@@ -523,6 +599,9 @@ class Handler : public oem_platform::Handler
     pldm::responder::platform::Handler*
         platformHandler; //!< pointer to PLDM platform handler
 
+    /** unique pointer to the SBE dump match */
+    std::unique_ptr<sdbusplus::bus::match_t> sbeDumpMatch;
+
     /** @brief fd of MCTP communications socket */
     int mctp_fd;
 
@@ -599,6 +678,14 @@ class Handler : public oem_platform::Handler
      *  @param[in] value - true or false, to indicate if the timer
      *                    should be reset or turned off*/
     void startStopTimer(bool value);
+
+    /** @brief instanceMap is a lookup data structure to lookup <EffecterID,
+     * InstanceInfo> */
+    HostEffecterInstanceMap instanceMap;
+
+    /** @brief instanceDimmMap is a lookup data structure to lookup <EffecterID,
+     * dimmID> */
+    HostEffecterDimmMap instanceDimmMap;
 };
 
 /** @brief Method to encode code update event msg

--- a/requester/request.hpp
+++ b/requester/request.hpp
@@ -14,7 +14,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 
 PHOSPHOR_LOG2_USING;
 


### PR DESCRIPTION
This commit adds support for building Platform Dump Records (PDRs) related to DIMM and PROC entities. It handles DBus method calls for the respective dump types associated with each entity type. Additionally, it monitors dump progress status and triggers a request to set the host effecter.

Test- Used pldmtool platform command for setNumericEffecter.