### PR TITLE
oem-ibm: Fix in pointer increment in the PCIe Config Data

### DIFF
--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -41,7 +41,9 @@ int pldm::responder::oem_ibm_fru::Handler::processOEMFRUTable(
 
         dataSize += sizeof(pldm_fru_record_data_format) -
                     sizeof(pldm_fru_record_tlv);
-        data += dataSize;
+
+        data += sizeof(pldm_fru_record_data_format) -
+                sizeof(pldm_fru_record_tlv);
 
         for ([[maybe_unused]] const auto& i :
              std::views::iota(0, (int)record->num_fru_fields))
@@ -91,11 +93,8 @@ int pldm::responder::oem_ibm_fru::Handler::processOEMFRUTable(
                                            &tlv->value[tlv->length]);
                 setFirmwareUAK(value);
             }
-            // length of tlv is removed from the structure pldm_fru_record_tlv
-            // and the new tlv length is added back.
-            dataSize += sizeof(pldm_fru_record_tlv) - sizeof(uint8_t) +
-                        tlv->length;
-            data += dataSize;
+            // Increment data pointer by the size of the current TLV
+            data += sizeof(pldm_fru_record_tlv) - sizeof(uint8_t) + tlv->length;
         }
     }
 
@@ -130,8 +129,6 @@ void Handler::updateDBusProperty(
                 {
                     pldm::utils::setFruPresence(key, true);
                 }
-                info("Set PCIe config space information on [{KEY}]", "KEY",
-                     key);
                 dbus_map_update(key, "Function0VendorId", vendorId);
                 dbus_map_update(key, "Function0DeviceId", deviceId);
                 dbus_map_update(key, "Function0RevisionId", revisionId);


### PR DESCRIPTION
The PCIe Config data is a 64 bytes huge data which needs to be parsed and corresponding DBus values needs to be updated. The parsing logic had a pointer increment issue that resulted in some bug w.r.t the values.
Removed a debug trace as it is not having much value.

tested on a rainier and blueridge systems.

Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>