### PR TITLE
Removing extra bytes while responding host

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -39,7 +39,8 @@ void FileHandler::dmaResponseToRemoteTerminus(
     const SharedAIORespData& sharedAIORespDataobj,
     const pldm_completion_codes rStatus, uint32_t length)
 {
-    Response response(sizeof(pldm_msg_hdr) + sharedAIORespDataobj.command, 0);
+    Response response(
+        sizeof(pldm_msg_hdr) + PLDM_RW_FILE_BY_TYPE_MEM_RESP_BYTES, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     encode_rw_file_by_type_memory_resp(sharedAIORespDataobj.instance_id,
                                        sharedAIORespDataobj.command, rStatus,
@@ -54,7 +55,8 @@ void FileHandler::dmaResponseToRemoteTerminus(
     const SharedAIORespData& sharedAIORespDataobj,
     const pldm_fileio_completion_codes rStatus, uint32_t length)
 {
-    Response response(sizeof(pldm_msg_hdr) + sharedAIORespDataobj.command, 0);
+    Response response(
+        sizeof(pldm_msg_hdr) + PLDM_RW_FILE_BY_TYPE_MEM_RESP_BYTES, 0);
     auto responsePtr = reinterpret_cast<pldm_msg*>(response.data());
     encode_rw_file_by_type_memory_resp(sharedAIORespDataobj.instance_id,
                                        sharedAIORespDataobj.command, rStatus,


### PR DESCRIPTION
During File IO operation 3 bytes are getting added extra while responding to host.
minimum command size is 5 bytes but as per new change uint8_t size which is 8 is getting added which cause the issue while responding to PHYP.