### PR TITLE
Fixing race condition during file transfer

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -160,15 +160,16 @@ void FileHandler::transferFileData(int fd, bool upstream, uint32_t offset,
         }
         if (static_cast<int>(data.length) == rc)
         {
-            wInterface->setTransferStatus(true);
-            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_SUCCESS,
-                                        origLength);
             if (sharedAIORespDataobj.functionPtr != nullptr)
             {
-                sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
+                rc = sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                     command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY,
                     data.length);
             }
+            auto status = (rc == PLDM_SUCCESS) ? PLDM_SUCCESS : PLDM_ERROR;
+            wInterface->setTransferStatus(true);
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, status,
+                                        origLength);
             deleteAIOobjects(wInterface, sharedAIORespDataobj);
             return;
         }
@@ -216,12 +217,12 @@ void FileHandler::transferFileDataToSocket(
         error(
             "XDMA interface initialization failed while transfering data via socket for fileType:{TYPE}",
             "TYPE", sharedAIORespDataobj.fileType);
-        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
         if (sharedAIORespDataobj.functionPtr != nullptr)
         {
             sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                 command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
         }
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
         deleteAIOobjects(nullptr, sharedAIORespDataobj);
         return;
     }
@@ -238,12 +239,12 @@ void FileHandler::transferFileDataToSocket(
             error(
                 "EventLoop Timeout...Terminating tranfer operation while transfering data via socket for fileType:{TYPE}",
                 "TYPE", sharedAIORespDataobj.fileType);
-            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
             if (sharedAIORespDataobj.functionPtr != nullptr)
             {
                 sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                     command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
             }
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
             deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
         }
         return;
@@ -267,13 +268,13 @@ void FileHandler::transferFileDataToSocket(
                 error(
                     "Failed to transfer muliple chunks of data to host while transfering data via socket for fileType:{TYPE}",
                     "TYPE", sharedAIORespDataobj.fileType);
-                dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR,
-                                            0);
                 if (sharedAIORespDataobj.functionPtr != nullptr)
                 {
                     sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                         command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
                 }
+                dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR,
+                                            0);
                 deleteAIOobjects(wInterface, sharedAIORespDataobj);
                 return;
             }
@@ -285,12 +286,12 @@ void FileHandler::transferFileDataToSocket(
             error(
                 "Failed to transfer single chunks of data to host while transfering data via socket for fileType:{TYPE}",
                 "TYPE", sharedAIORespDataobj.fileType);
-            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
             if (sharedAIORespDataobj.functionPtr != nullptr)
             {
                 sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                     command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
             }
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
             deleteAIOobjects(wInterface, sharedAIORespDataobj);
             return;
         }
@@ -311,12 +312,12 @@ void FileHandler::transferFileDataToSocket(
             error(
                 "Failed to open shared memory location while transfering data via socket for fileType:{TYPE}",
                 "TYPE", sharedAIORespDataobj.fileType);
-            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
             if (sharedAIORespDataobj.functionPtr != nullptr)
             {
                 sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                     command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
             }
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
             deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
             return;
         }
@@ -325,12 +326,12 @@ void FileHandler::transferFileDataToSocket(
             error(
                 "Failed to start the event timer while transfering data via socket for fileType:{TYPE}",
                 "TYPE", sharedAIORespDataobj.fileType);
-            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
             if (sharedAIORespDataobj.functionPtr != nullptr)
             {
                 sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                     command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
             }
+            dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
             deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
             return;
         }
@@ -342,12 +343,12 @@ void FileHandler::transferFileDataToSocket(
         error(
             "Failed to start the event loop while transfering data via socket for fileType:{TYPE} : {ERROR}",
             "TYPE", sharedAIORespDataobj.fileType, "ERROR", e);
-        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
         if (sharedAIORespDataobj.functionPtr != nullptr)
         {
             sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                 command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY, 0);
         }
+        dmaResponseToRemoteTerminus(sharedAIORespDataobj, PLDM_ERROR, 0);
         deleteAIOobjects(xdmaInterface, sharedAIORespDataobj);
     }
     return;

--- a/oem/ibm/libpldmresponder/file_io_by_type.hpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.hpp
@@ -230,8 +230,8 @@ class FileHandler
      *  @param[in] length    -  To do post file transfer operation based on
      * length
      */
-    virtual void postDataTransferCallBack(bool IsWriteToMemOp,
-                                          uint32_t length) = 0;
+    virtual int postDataTransferCallBack(bool IsWriteToMemOp,
+                                         uint32_t length) = 0;
 
     /** @brief method to process a new file available metadata notification from
      *  the host

--- a/oem/ibm/libpldmresponder/file_io_type_cert.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.cpp
@@ -46,7 +46,7 @@ void CertHandler::writeFromMemory(uint32_t offset, uint32_t length,
     return;
 }
 
-void CertHandler::postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length)
+int CertHandler::postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length)
 {
     if (IsWriteToMemOp)
     {
@@ -56,14 +56,13 @@ void CertHandler::postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length)
             error(
                 "CertHandler::writeFromMemory:file for type {TYPE} doesn't exist",
                 "TYPE", certType);
-            return;
+            return PLDM_ERROR;
         }
-        // auto fd = std::get<0>(it->second);
+
         auto& remSize = std::get<1>(it->second);
         remSize -= length;
         if (!remSize)
         {
-            // close(fd);
             certMap.erase(it);
         }
     }
@@ -71,7 +70,7 @@ void CertHandler::postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length)
     {
         fs::remove(certfilePath);
     }
-    return;
+    return PLDM_SUCCESS;
 }
 
 void CertHandler::readIntoMemory(uint32_t offset, uint32_t length,

--- a/oem/ibm/libpldmresponder/file_io_type_cert.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_cert.hpp
@@ -63,7 +63,7 @@ class CertHandler : public FileHandler
                                              uint32_t /*metaDataValue3*/,
                                              uint32_t /*metaDataValue4*/);
 
-    virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
+    virtual int postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
 
     /** @brief CertHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_chap.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_chap.hpp
@@ -78,9 +78,11 @@ class ChapHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
-    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
-                                          uint32_t /*length*/)
-    {}
+    virtual int postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                         uint32_t /*length*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
 
     /** @brief ChapHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -289,13 +289,13 @@ std::string DumpHandler::getOffloadUri(uint32_t fileHandle)
     return socketInterface;
 }
 
-void DumpHandler::postDataTransferCallBack(bool IsWriteToMemOp,
-                                           uint32_t /*length*/)
+int DumpHandler::postDataTransferCallBack(bool IsWriteToMemOp,
+                                          uint32_t /*length*/)
 {
     /// execute when DMA transfer failed.
     if (IsWriteToMemOp)
     {
-        error("DumpHandler::writeFromMemory: transferFileDataToSocket failed");
+        error("Failed transfer dump fileData to socket ");
         if (DumpHandler::fd >= 0)
         {
             close(DumpHandler::fd);
@@ -304,8 +304,8 @@ void DumpHandler::postDataTransferCallBack(bool IsWriteToMemOp,
         auto socketInterface = getOffloadUri(fileHandle);
         std::remove(socketInterface.c_str());
         resetOffloadUri();
-        return;
     }
+    return PLDM_ERROR;
 }
 
 void DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -60,8 +60,8 @@ class DumpHandler : public FileHandler
     std::string getOffloadUri(uint32_t fileHandle);
     void resetOffloadUri();
     uint32_t getDumpIdPrefix(uint16_t dumpType);
-    virtual void postDataTransferCallBack(bool IsWriteToMemOp,
-                                          uint32_t /*length*/);
+    virtual int postDataTransferCallBack(bool IsWriteToMemOp,
+                                         uint32_t /*length*/);
 
     /** @brief DumpHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_lic.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.cpp
@@ -86,8 +86,8 @@ void LicenseHandler::writeFromMemory(
                      sharedAIORespDataobj, event);
 }
 
-void LicenseHandler::postDataTransferCallBack(bool IsWriteToMemOp,
-                                              uint32_t length)
+int LicenseHandler::postDataTransferCallBack(bool IsWriteToMemOp,
+                                             uint32_t length)
 {
     if (IsWriteToMemOp)
     {
@@ -101,10 +101,11 @@ void LicenseHandler::postDataTransferCallBack(bool IsWriteToMemOp,
                 error(
                     "Failed to update bin file and license objs with rc as {RC} while post data transfer callback",
                     "RC", rc);
-                return;
+                return rc;
             }
         }
     }
+    return PLDM_SUCCESS;
 }
 
 int LicenseHandler::write(const char* buffer, uint32_t /*offset*/,

--- a/oem/ibm/libpldmresponder/file_io_type_lic.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.hpp
@@ -67,7 +67,7 @@ class LicenseHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
-    virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
+    virtual int postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
 
     int updateBinFileAndLicObjs(const fs::path& newLicFilePath);
 

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -74,9 +74,11 @@ class PCIeInfoHandler : public FileHandler
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
 
-    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
-                                          uint32_t /*length*/)
-    {}
+    virtual int postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                         uint32_t /*length*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
 
     /** @brief PCIeInfoHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -231,12 +231,13 @@ void PelHandler::writeFromMemory(uint32_t offset, uint32_t length,
                      event);
 }
 
-void PelHandler::postDataTransferCallBack(bool IsWriteToMemOp,
-                                          uint32_t /*length*/)
+int PelHandler::postDataTransferCallBack(bool IsWriteToMemOp,
+                                         uint32_t /*length*/)
 {
+    int rc = PLDM_SUCCESS;
     if (IsWriteToMemOp)
     {
-        auto rc = storePel(Pelpath.string());
+        rc = storePel(Pelpath.string());
         if (rc != PLDM_SUCCESS)
         {
             error(
@@ -244,6 +245,7 @@ void PelHandler::postDataTransferCallBack(bool IsWriteToMemOp,
                 "ERROR", errno, "PEL_PATH", Pelpath);
         }
     }
+    return rc;
 }
 
 int PelHandler::fileAck(uint8_t fileStatus)

--- a/oem/ibm/libpldmresponder/file_io_type_pel.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.hpp
@@ -51,7 +51,7 @@ class PelHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
-    virtual void postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
+    virtual int postDataTransferCallBack(bool IsWriteToMemOp, uint32_t length);
 
     virtual int newFileAvailableWithMetaData(uint64_t /*length*/,
                                              uint32_t /*metaDataValue1*/,

--- a/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_progress_src.hpp
@@ -93,9 +93,11 @@ class ProgressCodeHandler : public FileHandler
      *  @param[in] IsWriteToMemOp - type of operation to decide what operation
      *                              needs to be done after data transfer.
      */
-    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
-                                          uint32_t /*length*/)
-    {}
+    virtual int postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                         uint32_t /*length*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
 
     /** @brief ProgressCodeHandler destructor
      */

--- a/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_vpd.hpp
@@ -78,9 +78,11 @@ class keywordHandler : public FileHandler
      *  @param[in] IsWriteToMemOp - type of operation to decide what operation
      *                              needs to be done after data transfer.
      */
-    virtual void postDataTransferCallBack(bool /*IsWriteToMemOp*/,
-                                          uint32_t /*length*/)
-    {}
+    virtual int postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                         uint32_t /*length*/)
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
 
     /** @brief keywordHandler destructor
      */


### PR DESCRIPTION
there is a race condition occurs between performing post operation and
sending response to Host. When host sends pels then bmc takes some time
to store the pels and meanwhile host is timed-out so it will try again
to transfer the pels and suddenly BMC finishing the storing and sending
failure status to host which causing the problem.