### PR TITLE
pdr: Log a PEL only when Host is Running

### DIFF
--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -456,8 +456,8 @@ class HostPDRHandler
 
     bool isHostOff;
 
-    /** @brief true/false based on the host transitioning value */
-    bool isHostTransitioningToOff;
+    /** @brief true/false based on the host is running or not */
+    bool isHostRunning;
 };
 
 } // namespace pldm


### PR DESCRIPTION
When there is a PDR exchange happening with host and we trigger a poweroff we were logging a pel BD8D6026 when the PDR exchange fails. This change is needed check if the host is up or not and then log an error only if host is up.


Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>