### PR TITLE
1110 codeupdate- inbound and Concurrent update rebase

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -889,9 +889,9 @@ void setBiosAttr(const BiosAttributeList& biosAttrList)
         {
             auto service = pldm::utils::DBusHandler().getService(
                 biosConfigPath, biosConfigIntf);
-            auto method =
-                bus.new_method_call(service.c_str(), biosConfigPath,
-                                    SYSTEMD_PROPERTY_INTERFACE, "Set");
+            auto method = bus.new_method_call(service.c_str(), biosConfigPath,
+                                              SYSTEMD_PROPERTY_INTERFACE,
+                                              "Set");
             method.append(
                 biosConfigIntf, "PendingAttributes",
                 std::variant<PendingAttributesType>(pendingAttributes));

--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -835,5 +835,77 @@ std::vector<pldm::pdr::EffecterID>
     return effecterIDs;
 }
 
+std::string getBiosAttrValue(const std::string& dbusAttrName)
+{
+    constexpr auto biosConfigPath = "/xyz/openbmc_project/bios_config/manager";
+    constexpr auto biosConfigIntf = "xyz.openbmc_project.BIOSConfig.Manager";
+
+    std::string var1;
+    std::variant<std::string> var2;
+    std::variant<std::string> var3;
+
+    auto& bus = DBusHandler::getBus();
+    try
+    {
+        auto service = pldm::utils::DBusHandler().getService(biosConfigPath,
+                                                             biosConfigIntf);
+        auto method = bus.new_method_call(
+            service.c_str(), biosConfigPath,
+            "xyz.openbmc_project.BIOSConfig.Manager", "GetAttribute");
+        method.append(dbusAttrName);
+        auto reply = bus.call(method);
+        reply.read(var1, var2, var3);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cout << "Error getting the bios attribute"
+                  << "ERROR=" << e.what() << "ATTRIBUTE=" << dbusAttrName
+                  << std::endl;
+        return {};
+    }
+
+    return std::get<std::string>(var2);
+}
+
+void setBiosAttr(const BiosAttributeList& biosAttrList)
+{
+    static constexpr auto SYSTEMD_PROPERTY_INTERFACE =
+        "org.freedesktop.DBus.Properties";
+    constexpr auto biosConfigPath = "/xyz/openbmc_project/bios_config/manager";
+    constexpr auto biosConfigIntf = "xyz.openbmc_project.BIOSConfig.Manager";
+
+    constexpr auto dbusAttrType =
+        "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration";
+    for (const auto& [dbusAttrName, biosAttrStr] : biosAttrList)
+    {
+        using PendingAttributesType = std::vector<std::pair<
+            std::string, std::tuple<std::string, std::variant<std::string>>>>;
+        PendingAttributesType pendingAttributes;
+        pendingAttributes.emplace_back(std::make_pair(
+            dbusAttrName, std::make_tuple(dbusAttrType, biosAttrStr)));
+
+        auto& bus = DBusHandler::getBus();
+        try
+        {
+            auto service = pldm::utils::DBusHandler().getService(
+                biosConfigPath, biosConfigIntf);
+            auto method =
+                bus.new_method_call(service.c_str(), biosConfigPath,
+                                    SYSTEMD_PROPERTY_INTERFACE, "Set");
+            method.append(
+                biosConfigIntf, "PendingAttributes",
+                std::variant<PendingAttributesType>(pendingAttributes));
+            bus.call_noreply(method);
+        }
+        catch (const sdbusplus::exception::SdBusError& e)
+        {
+            std::cout << "Error setting the bios attribute"
+                      << "ERROR=" << e.what() << "ATTRIBUTE=" << dbusAttrName
+                      << "ATTRIBUTE VALUE=" << biosAttrStr << std::endl;
+            return;
+        }
+    }
+}
+
 } // namespace utils
 } // namespace pldm

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -133,7 +133,6 @@ using DBusInterfaceAdded = std::vector<
     std::pair<pldm::dbus::Interface,
               std::vector<std::pair<pldm::dbus::Property,
                                     std::variant<pldm::dbus::Property>>>>>;
-
 using ObjectPath = std::string;
 using EntityName = std::string;
 using Entities = std::vector<pldm_entity_node*>;
@@ -149,6 +148,7 @@ using GetSubTreePathsResponse = std::vector<std::string>;
 using PropertyMap = std::map<std::string, PropertyValue>;
 using InterfaceMap = std::map<std::string, PropertyMap>;
 using ObjectValueTree = std::map<sdbusplus::message::object_path, InterfaceMap>;
+using BiosAttributeList = std::vector<std::pair<std::string, std::string>>;
 
 /**
  * @brief The interface for DBusHandler
@@ -546,5 +546,21 @@ std::vector<pldm::pdr::EffecterID> findEffecterIds(const pldm_pdr* pdrRepo,
                                                    uint16_t entityInstance,
                                                    uint16_t containerId);
 
+/** @brief Method to get the value from a bios attribute
+ *
+ *  @param[in] dbusAttrName - the bios attribute name from
+ *             which the value must be retrieved
+ *
+ *  @return the attribute value
+ */
+std::string getBiosAttrValue(const std::string& dbusAttrName);
+
+/** @brief Method to set the specified bios attribute with
+ *         specified value
+ *
+ *  @param[in] BiosAttributeList - the list of bios attribute and values
+ *             to be set
+ */
+void setBiosAttr(const BiosAttributeList& biosAttrList);
 } // namespace utils
 } // namespace pldm

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -153,10 +153,6 @@ HostPDRHandler::HostPDRHandler(
                 isHostTransitioningToOff = false;
                 this->sensorIndex = stateSensorPDRs.begin();
                 this->modifiedCounter = 0;
-                if (oemPlatformHandler != nullptr)
-                {
-                    oemPlatformHandler->startStopTimer(false);
-                }
 
                 // After a power off , the remote nodes will be deleted
                 // from the entity association tree, making the nodes point
@@ -166,13 +162,13 @@ HostPDRHandler::HostPDRHandler(
                     pldm_entity obj{};
                     this->objPathMap[element.first] = obj;
                 }
-                else if (propVal ==
-                         "xyz.openbmc_project.State.Host.HostState.Running")
+            {
+            else if (propVal ==
+                     "xyz.openbmc_project.State.Host.HostState.Running")
+            {
+                if (oemPlatformHandler != nullptr)
                 {
-                    if (oemPlatformHandler != nullptr)
-                    {
-                        oemPlatformHandler->handleBootTypesAtPowerOn();
-                    }
+                    oemPlatformHandler->handleBootTypesAtPowerOn();
                 }
             }
             else if (
@@ -209,6 +205,7 @@ HostPDRHandler::HostPDRHandler(
             {
                 if (oemPlatformHandler)
                 {
+                    oemPlatformHandler->startStopTimer(false);
                     oemPlatformHandler->handleBootTypesAtChassisOff();
                 }
                 static constexpr auto searchpath =

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -119,17 +119,18 @@ HostPDRHandler::HostPDRHandler(
         pldm::utils::DBusHandler::getBus(),
         propertiesChanged("/xyz/openbmc_project/state/host0",
                           "xyz.openbmc_project.State.Host"),
-        [this, repo, entityTree, bmcEntityTree](sdbusplus::message_t& msg) {
-        DbusChangedProps props{};
-        std::string intf;
-        msg.read(intf, props);
-        const auto itr = props.find("CurrentHostState");
-        if (itr != props.end())
-        {
-            pldm::utils::PropertyValue value = itr->second;
-            auto propVal = std::get<std::string>(value);
-            if (propVal == "xyz.openbmc_project.State.Host.HostState.Off")
+        [this, repo, entityTree, bmcEntityTree,
+         oemPlatformHandler](sdbusplus::message::message& msg) {
+            DbusChangedProps props{};
+            std::string intf;
+            msg.read(intf, props);
+            const auto itr = props.find("CurrentHostState");
+            if (itr != props.end())
             {
+                pldm::utils::PropertyValue value = itr->second;
+                auto propVal = std::get<std::string>(value);
+                if (propVal == "xyz.openbmc_project.State.Host.HostState.Off")
+                {
                 // Delete all the remote terminus information
                 std::erase_if(tlPDRInfo, [](const auto& item) {
                     auto const& [key, value] = item;
@@ -160,6 +161,14 @@ HostPDRHandler::HostPDRHandler(
                 {
                     pldm_entity obj{};
                     this->objPathMap[element.first] = obj;
+                }
+                else if (propVal ==
+                         "xyz.openbmc_project.State.Host.HostState.Running")
+                {
+                    if (oemPlatformHandler != nullptr)
+                    {
+                        oemPlatformHandler->handleBootTypesAtPowerOn();
+                    }
                 }
             }
             else if (

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -153,6 +153,10 @@ HostPDRHandler::HostPDRHandler(
                 isHostTransitioningToOff = false;
                 this->sensorIndex = stateSensorPDRs.begin();
                 this->modifiedCounter = 0;
+                    if (oemPlatformHandler != nullptr)
+                    {
+                        oemPlatformHandler->startStopTimer(false);
+                    }
 
                 // After a power off , the remote nodes will be deleted
                 // from the entity association tree, making the nodes point

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -456,8 +456,8 @@ class HostPDRHandler
 
     bool isHostOff;
 
-    /** @brief true/false based on the host transitioning value */
-    bool isHostTransitioningToOff;
+    /** @brief true/false based on the host is running or not */
+    bool isHostRunning;
 };
 
 } // namespace pldm

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -523,6 +523,28 @@ void BIOSConfig::updateBaseBIOSTableProperty()
         auto method = bus.new_method_call(service.c_str(), biosConfigPath,
                                           dbusProperties, "Set");
         std::variant<BaseBIOSTable> value = baseBIOSTableMaps;
+#ifdef OEM_IBM
+        const fs::path bootSideDirPath = "/var/lib/pldm/bootSide";
+        for (const auto& [attrName, biostabObj] : baseBIOSTableMaps)
+        {
+            // The additional check to see if /var/lib/pldm/bootSide file exists
+            // is added to make sure we are doing the fw_boot_side setting after
+            // the base bios table is initialised.
+            if ((attrName == "fw_boot_side") && fs::exists(bootSideDirPath))
+            {
+                BiosAttributeList biosAttrList;
+                std::string nextBootSide =
+                    std::get<std::string>(std::get<5>(biostabObj));
+                std::string currNextBootSide = getBiosAttrValue("fw_boot_side");
+                if (currNextBootSide != nextBootSide)
+                {
+                    biosAttrList.push_back(
+                        std::make_pair(attrName, nextBootSide));
+                    setBiosAttr(biosAttrList);
+                }
+            }
+        }
+#endif
         method.append(biosConfigInterface, biosConfigPropertyName, value);
         bus.call_noreply(method, dbusTimeout);
     }

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -116,14 +116,6 @@ class Handler : public CmdHandler
     /** @brief Interface to the process setEventReceiver*/
     virtual void processSetEventReceiver() = 0;
 
-    /** @brief Interface to monitor the surveillance pings from remote terminus
-     *
-     * @param[in] tid - TID of the remote terminus
-     * @param[in] value - true or false, to indicate if the timer is
-     *                   running or not
-     * */
-    virtual void setSurvTimer(uint8_t tid, bool value) = 0;
-
     /** @brief Interface to perform OEM actions*/
     virtual void modifyPDROemActions(uint16_t entityType,
                                      uint16_t stateSetId) = 0;
@@ -133,6 +125,13 @@ class Handler : public CmdHandler
 
     /** @brief To handle the boot types bios attributes at shutdown*/
     virtual void handleBootTypesAtChassisOff() = 0;
+
+    /** @brief Interface to monitor the surveillance pings from host
+     *
+     * @param[in] value - true or false, to indicate if the timer is
+     *                    running or not
+     */
+    virtual void setSurvTimer(bool value) = 0;
 
     virtual ~Handler() = default;
 

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -126,6 +126,11 @@ class Handler : public CmdHandler
     /** @brief To handle the boot types bios attributes at shutdown*/
     virtual void handleBootTypesAtChassisOff() = 0;
 
+    /** @brief Interface to reset or stop the surveillance timer
+     *  @param[in] value - true or false, to indicate if the timer
+     *                     should be reset or turned off*/
+    virtual void startStopTimer(bool value) = 0;
+
     /** @brief Interface to monitor the surveillance pings from host
      *
      * @param[in] tid - TID of the host

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -128,6 +128,12 @@ class Handler : public CmdHandler
     virtual void modifyPDROemActions(uint16_t entityType,
                                      uint16_t stateSetId) = 0;
 
+    /** @brief To handle the boot types bios attributes at power on*/
+    virtual void handleBootTypesAtPowerOn() = 0;
+
+    /** @brief To handle the boot types bios attributes at shutdown*/
+    virtual void handleBootTypesAtChassisOff() = 0;
+
     virtual ~Handler() = default;
 
   protected:

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -128,10 +128,11 @@ class Handler : public CmdHandler
 
     /** @brief Interface to monitor the surveillance pings from host
      *
+     * @param[in] tid - TID of the host
      * @param[in] value - true or false, to indicate if the timer is
      *                    running or not
      */
-    virtual void setSurvTimer(bool value) = 0;
+    virtual void setSurvTimer(uint8_t tid, bool value) = 0;
 
     virtual ~Handler() = default;
 

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -416,7 +416,7 @@ Response Handler::platformEventMessage(const pldm_msg* request,
             }
             else
             {
-                oemPlatformHandler->setSurvTimer(true);
+                oemPlatformHandler->setSurvTimer(tid, true);
             }
         }
     }

--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -416,7 +416,7 @@ Response Handler::platformEventMessage(const pldm_msg* request,
             }
             else
             {
-                oemPlatformHandler->setSurvTimer(tid, true);
+                oemPlatformHandler->setSurvTimer(true);
             }
         }
     }

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -465,11 +465,6 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
         {
             return std::make_unique<LicenseHandler>(fileHandle, fileType);
         }
-        case PLDM_FILE_TYPE_LID_RUNNING:
-        {
-            return std::make_unique<LidHandler>(fileHandle, false,
-                                                PLDM_FILE_TYPE_LID_RUNNING);
-        }
         case PLDM_FILE_TYPE_PSPD_VPD_PDD_KEYWORD:
         {
             return std::make_unique<keywordHandler>(fileHandle, fileType);

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -435,6 +435,11 @@ std::unique_ptr<FileHandler> getHandlerByType(uint16_t fileType,
             return std::make_unique<LidHandler>(fileHandle, false,
                                                 PLDM_FILE_TYPE_LID_MARKER);
         }
+        case PLDM_FILE_TYPE_LID_RUNNING:
+        {
+            return std::make_unique<LidHandler>(fileHandle, false,
+                                                PLDM_FILE_TYPE_LID_RUNNING);
+        }
         case PLDM_FILE_TYPE_DUMP:
         case PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS:
         case PLDM_FILE_TYPE_RESOURCE_DUMP:

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -47,12 +47,30 @@ class LidHandler : public FileHandler
     {
         sideToRead = permSide ? Pside : Tside;
         isPatchDir = false;
-        std::string dir = permSide ? LID_ALTERNATE_DIR : LID_RUNNING_DIR;
+        currBootSide =
+            (getBiosAttrValue("fw_boot_side_current") == "Perm" ? Pside
+                                                                : Tside);
+        std::string dir;
+        if (currBootSide == sideToRead)
+        {
+            dir = LID_RUNNING_DIR;
+        }
+        else
+        {
+            dir = LID_ALTERNATE_DIR;
+        }
         std::stringstream stream;
         stream << std::hex << fileHandle;
         auto lidName = stream.str() + ".lid";
-        std::string patchDir = permSide ? LID_ALTERNATE_PATCH_DIR
-                                        : LID_RUNNING_PATCH_DIR;
+        std::string patchDir;
+        if (currBootSide == sideToRead)
+        {
+            patchDir = LID_RUNNING_PATCH_DIR;
+        }
+        else
+        {
+            patchDir = LID_ALTERNATE_PATCH_DIR;
+        }
         auto patch = fs::path(patchDir) / lidName;
         if (fs::is_regular_file(patch))
         {
@@ -422,6 +440,7 @@ class LidHandler : public FileHandler
   protected:
     std::string lidPath;
     std::string sideToRead;
+    std::string currBootSide;
     bool isPatchDir;
     static inline MarkerLIDremainingSize markerLIDremainingSize;
     uint8_t lidType;

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -47,9 +47,9 @@ class LidHandler : public FileHandler
     {
         sideToRead = permSide ? Pside : Tside;
         isPatchDir = false;
-        currBootSide =
-            (getBiosAttrValue("fw_boot_side_current") == "Perm" ? Pside
-                                                                : Tside);
+        currBootSide = (getBiosAttrValue("fw_boot_side_current") == "Perm"
+                            ? Pside
+                            : Tside);
         std::string dir;
         if ((currBootSide == sideToRead) ||
             (lidType == PLDM_FILE_TYPE_LID_RUNNING))

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -101,8 +101,9 @@ class LidHandler : public FileHandler
             {
                 dir = LID_ALTERNATE_PATCH_DIR;
             }
-            if (oemIbmPlatformHandler->codeUpdate->fetchCurrentBootSide() ==
-                sideToRead)
+            if ((oemIbmPlatformHandler->codeUpdate->fetchCurrentBootSide() ==
+                 sideToRead) ||
+                (lidType == PLDM_FILE_TYPE_LID_RUNNING))
             {
                 if (isPatchDir)
                 {

--- a/oem/ibm/libpldmresponder/file_io_type_lid.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lid.hpp
@@ -51,7 +51,8 @@ class LidHandler : public FileHandler
             (getBiosAttrValue("fw_boot_side_current") == "Perm" ? Pside
                                                                 : Tside);
         std::string dir;
-        if (currBootSide == sideToRead)
+        if ((currBootSide == sideToRead) ||
+            (lidType == PLDM_FILE_TYPE_LID_RUNNING))
         {
             dir = LID_RUNNING_DIR;
         }
@@ -63,7 +64,8 @@ class LidHandler : public FileHandler
         stream << std::hex << fileHandle;
         auto lidName = stream.str() + ".lid";
         std::string patchDir;
-        if (currBootSide == sideToRead)
+        if ((currBootSide == sideToRead) ||
+            (lidType == PLDM_FILE_TYPE_LID_RUNNING))
         {
             patchDir = LID_RUNNING_PATCH_DIR;
         }

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -207,7 +207,9 @@ void CodeUpdate::setVersions()
             pldmBootSideData.running_version_object = runningVersion.c_str();
 
             writeBootSideFile(pldmBootSideData);
-            setBootSideBiosAttr(pldmBootSideData.current_boot_side);
+            biosAttrList.push_back(std::make_pair(
+                bootSideAttrName, pldmBootSideData.current_boot_side));
+            setBiosAttr(biosAttrList);
         }
         else
         {
@@ -222,12 +224,18 @@ void CodeUpdate::setVersions()
                     (pldmBootSideData.next_boot_side == "Temp" ? "Perm"
                                                                : "Temp");
                 pldmBootSideData.next_boot_side = next_boot_side;
+                pldmBootSideData.running_version_object = runningVersion;
                 writeBootSideFile(pldmBootSideData);
-                setBootSideBiosAttr(pldmBootSideData.current_boot_side);
+                biosAttrList.push_back(
+                    std::make_pair(bootSideAttrName, current_boot_side));
+                setBiosAttr(biosAttrList);
             }
             else
             {
-                setBootSideBiosAttr(pldmBootSideData.current_boot_side);
+                pldm_boot_side_data pldmBootSideData = readBootSideFile();
+                biosAttrList.push_back(std::make_pair(
+                    bootSideAttrName, pldmBootSideData.current_boot_side));
+                setBiosAttr(biosAttrList);
             }
         }
     }

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -230,10 +230,7 @@ void CodeUpdate::setVersions()
                     (pldmBootSideData.current_boot_side == "Temp" ? "Perm"
                                                                   : "Temp");
                 pldmBootSideData.current_boot_side = current_boot_side;
-                auto next_boot_side =
-                    (pldmBootSideData.next_boot_side == "Temp" ? "Perm"
-                                                               : "Temp");
-                pldmBootSideData.next_boot_side = next_boot_side;
+                pldmBootSideData.next_boot_side = current_boot_side;
                 pldmBootSideData.running_version_object = runningVersion;
                 writeBootSideFile(pldmBootSideData);
                 biosAttrList.push_back(
@@ -248,12 +245,19 @@ void CodeUpdate::setVersions()
                     "BMC have booted with the previous image runningPath={RUNN_PATH}",
                     "RUNN_PATH", pldmBootSideData.running_version_object);
                 pldm_boot_side_data pldmBootSideData = readBootSideFile();
+                pldmBootSideData.next_boot_side =
+                    pldmBootSideData.current_boot_side;
+                writeBootSideFile(pldmBootSideData);
                 biosAttrList.push_back(std::make_pair(
                     bootSideAttrName, pldmBootSideData.current_boot_side));
                 biosAttrList.push_back(std::make_pair(
                     bootNextSideAttrName, pldmBootSideData.next_boot_side));
                 setBiosAttr(biosAttrList);
             }
+            currBootSide =
+                (pldmBootSideData.current_boot_side == "Temp" ? Tside : Pside);
+            nextBootSide =
+                (pldmBootSideData.next_boot_side == "Temp" ? Tside : Pside);
         }
     }
     catch (const std::exception& e)
@@ -491,8 +495,15 @@ void CodeUpdate::processPriorityChangeNotification(
         return;
     }
     uint8_t newVal = std::get<uint8_t>(it->second);
-    nextBootSide = (newVal == 0) ? currBootSide
-                                 : ((currBootSide == Tside) ? Pside : Tside);
+
+    pldm_boot_side_data pldmBootSideData = readBootSideFile();
+    pldmBootSideData.next_boot_side =
+        (newVal == 0)
+            ? pldmBootSideData.current_boot_side
+            : ((pldmBootSideData.current_boot_side == "Temp") ? "Perm"
+                                                              : "Temp");
+    writeBootSideFile(pldmBootSideData);
+    nextBootSide = (pldmBootSideData.next_boot_side == "Temp" ? Tside : Pside);
 }
 
 void CodeUpdate::setOemPlatformHandler(

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -216,6 +216,11 @@ void CodeUpdate::setVersions()
             pldm_boot_side_data pldmBootSideData = readBootSideFile();
             if (pldmBootSideData.running_version_object != runningVersion)
             {
+                info(
+                    "BMC have booted with the new image runningPath={RUNN_PATH}",
+                    "RUNN_PATH", runningPath.c_str());
+                info("Previous Image was: {RUNN_VERS}", "RUNN_VERS",
+                     pldmBootSideData.running_version_object);
                 auto current_boot_side =
                     (pldmBootSideData.current_boot_side == "Temp" ? "Perm"
                                                                   : "Temp");
@@ -232,6 +237,9 @@ void CodeUpdate::setVersions()
             }
             else
             {
+                info(
+                    "BMC have booted with the previous image runningPath={RUNN_PATH}",
+                    "RUNN_PATH", pldmBootSideData.running_version_object);
                 pldm_boot_side_data pldmBootSideData = readBootSideFile();
                 biosAttrList.push_back(std::make_pair(
                     bootSideAttrName, pldmBootSideData.current_boot_side));

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -283,6 +283,16 @@ void CodeUpdate::setVersions()
         error(
             "Failed to make a d-bus call to Object Mapper Association, error - {ERROR}",
             "ERROR", e);
+        if (retrySetVersion < maxVersionRetry)
+        {
+            retrySetVersion++;
+            usleep(500 * 1000);
+            setVersions();
+        }
+        else
+        {
+            throw std::runtime_error("Failed to fetch Update Software Object");
+        }
         return;
     }
 

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -329,56 +329,64 @@ void CodeUpdate::setVersions()
                         {
                             imageActivationMatch =
                                 std::make_unique<sdbusplus::bus::match_t>(
-                                    pldm::utils::DBusHandler::getBus(),
-                                    propertiesChanged(newImageId,
-                                                      "xyz.openbmc_project."
-                                                      "Software.Activation"),
-                                    [this](sdbusplus::message_t& msg) {
-                                DbusChangedProps props;
-                                std::string iface;
-                                msg.read(iface, props);
-                                const auto itr = props.find("Activation");
-                                if (itr != props.end())
-                                {
-                                    PropertyValue value = itr->second;
-                                    auto propVal = std::get<std::string>(value);
-                                    if (propVal ==
-                                        "xyz.openbmc_project.Software."
-                                        "Activation.Activations.Active")
+                                pldm::utils::DBusHandler::getBus(),
+                                propertiesChanged(newImageId,
+                                                  "xyz.openbmc_project."
+                                                  "Software.Activation"),
+                                [this](sdbusplus::message::message& msg) {
+                                    DbusChangedProps props;
+                                    std::string iface;
+                                    msg.read(iface, props);
+                                    const auto itr =
+                                        props.find("Activation");
+                                    if (itr != props.end())
                                     {
-                                        CodeUpdateState state =
-                                            CodeUpdateState::END;
-                                        setCodeUpdateProgress(false);
-                                        auto sensorId =
-                                            getFirmwareUpdateSensor();
-                                        sendStateSensorEvent(
-                                            sensorId, PLDM_STATE_SENSOR_STATE,
-                                            0, uint8_t(state),
-                                            uint8_t(CodeUpdateState::START));
-                                        newImageId.clear();
-                                    }
-                                    else if (propVal == "xyz.openbmc_project."
-                                                        "Software.Activation."
-                                                        "Activations.Failed" ||
-                                             propVal == "xyz.openbmc_"
-                                                        "project.Software."
-                                                        "Activation."
-                                                        "Activations."
-                                                        "Invalid")
-                                    {
-                                        CodeUpdateState state =
-                                            CodeUpdateState::FAIL;
-                                        setCodeUpdateProgress(false);
-                                        auto sensorId =
-                                            getFirmwareUpdateSensor();
-                                        sendStateSensorEvent(
-                                            sensorId, PLDM_STATE_SENSOR_STATE,
-                                            0, uint8_t(state),
-                                            uint8_t(CodeUpdateState::START));
-                                        newImageId.clear();
-                                    }
-                                }
-                            });
+                                        PropertyValue value = itr->second;
+                                        auto propVal =
+                                                std::get<std::string>(value);
+                                        if (propVal ==
+                                            "xyz.openbmc_project.Software."
+                                            "Activation.Activations.Active")
+                                            {
+                                                CodeUpdateState state =
+                                                    CodeUpdateState::END;
+                                                setCodeUpdateProgress(false);
+                                                auto sensorId =
+                                                    getFirmwareUpdateSensor();
+                                                sendStateSensorEvent(
+                                                    sensorId,
+                                                    PLDM_STATE_SENSOR_STATE, 0,
+                                                    uint8_t(state),
+                                                    uint8_t(CodeUpdateState::
+                                                                START));
+                                                newImageId.clear();
+                                            }
+                                            else if (propVal ==
+                                                         "xyz.openbmc_project."
+                                                         "Software.Activation."
+                                                         "Activations.Failed" ||
+                                                     propVal ==
+                                                         "xyz.openbmc_"
+                                                         "project.Software."
+                                                         "Activation."
+                                                         "Activations."
+                                                         "Invalid")
+                                            {
+                                                CodeUpdateState state =
+                                                    CodeUpdateState::FAIL;
+                                                setCodeUpdateProgress(false);
+                                                auto sensorId =
+                                                    getFirmwareUpdateSensor();
+                                                sendStateSensorEvent(
+                                                    sensorId,
+                                                    PLDM_STATE_SENSOR_STATE, 0,
+                                                    uint8_t(state),
+                                                    uint8_t(CodeUpdateState::
+                                                                START));
+                                                newImageId.clear();
+                                            }
+                                        }
+                                    });
                         }
                         auto rc = setRequestedActivation();
                         if (rc != PLDM_SUCCESS)

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -525,6 +525,11 @@ void CodeUpdate::processPriorityChangeNotification(
                                                               : "Temp");
     writeBootSideFile(pldmBootSideData);
     nextBootSide = (pldmBootSideData.next_boot_side == "Temp" ? Tside : Pside);
+    std::string currNextBootSide = getBiosAttrValue(bootNextSideAttrName);
+    if (currNextBootSide == nextBootSide)
+    {
+        return;
+    }
     BiosAttributeList biosAttrList;
     biosAttrList.push_back(
         std::make_pair(bootNextSideAttrName, pldmBootSideData.next_boot_side));

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -331,6 +331,13 @@ void CodeUpdate::setVersions()
                         }
                         break;
                     }
+                    else if (imageProp == "xyz.openbmc_project.Software."
+                                          "Activation.Activations.Ready" &&
+                             !isOutOfBandCodeUpdateInProgress())
+                    {
+                        outOfBandCodeUpdateInProgress = true;
+                        processRenameEvent();
+                    }
                 }
                 catch (const sdbusplus::exception_t& e)
                 {
@@ -342,6 +349,15 @@ void CodeUpdate::setVersions()
             }
         }
     }));
+}
+
+void CodeUpdate::processRenameEvent()
+{
+    currBootSide = Pside;
+    auto sensorId = getBootSideRenameStateSensor();
+    sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
+                         PLDM_BOOT_SIDE_HAS_BEEN_RENAMED,
+                         PLDM_BOOT_SIDE_NOT_RENAMED);
 }
 
 void CodeUpdate::processPriorityChangeNotification(

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -413,6 +413,7 @@ void CodeUpdate::setVersions()
                                                                 START));
                                                 newImageId.clear();
                                             }
+                                            imageActivationMatch.reset();
                                         }
                                     });
                         }

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -214,8 +214,14 @@ void CodeUpdate::setVersions()
             pldm_boot_side_data pldmBootSideData = readBootSideFile();
             if (pldmBootSideData.running_version_object != runningVersion)
             {
-                pldmBootSideData.current_boot_side = "Temp" ? "Perm" : "Temp";
-                pldmBootSideData.next_boot_side = "Temp" ? "Perm" : "Temp";
+                auto current_boot_side =
+                    (pldmBootSideData.current_boot_side == "Temp" ? "Perm"
+                                                                  : "Temp");
+                pldmBootSideData.current_boot_side = current_boot_side;
+                auto next_boot_side =
+                    (pldmBootSideData.next_boot_side == "Temp" ? "Perm"
+                                                               : "Temp");
+                pldmBootSideData.next_boot_side = next_boot_side;
                 writeBootSideFile(pldmBootSideData);
                 setBootSideBiosAttr(pldmBootSideData.current_boot_side);
             }

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -212,6 +212,8 @@ void CodeUpdate::setVersions()
             writeBootSideFile(pldmBootSideData);
             biosAttrList.push_back(std::make_pair(
                 bootSideAttrName, pldmBootSideData.current_boot_side));
+            biosAttrList.push_back(std::make_pair(
+                bootNextSideAttrName, pldmBootSideData.next_boot_side));
             setBiosAttr(biosAttrList);
         }
         else
@@ -236,6 +238,8 @@ void CodeUpdate::setVersions()
                 writeBootSideFile(pldmBootSideData);
                 biosAttrList.push_back(
                     std::make_pair(bootSideAttrName, current_boot_side));
+                biosAttrList.push_back(std::make_pair(
+                    bootNextSideAttrName, pldmBootSideData.next_boot_side));
                 setBiosAttr(biosAttrList);
             }
             else
@@ -246,6 +250,8 @@ void CodeUpdate::setVersions()
                 pldm_boot_side_data pldmBootSideData = readBootSideFile();
                 biosAttrList.push_back(std::make_pair(
                     bootSideAttrName, pldmBootSideData.current_boot_side));
+                biosAttrList.push_back(std::make_pair(
+                    bootNextSideAttrName, pldmBootSideData.next_boot_side));
                 setBiosAttr(biosAttrList);
             }
         }
@@ -437,6 +443,8 @@ void CodeUpdate::processRenameEvent()
     writeBootSideFile(pldmBootSideData);
     biosAttrList.push_back(
         std::make_pair(bootSideAttrName, pldmBootSideData.current_boot_side));
+    biosAttrList.push_back(
+        std::make_pair(bootNextSideAttrName, pldmBootSideData.next_boot_side));
     setBiosAttr(biosAttrList);
 }
 

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -376,6 +376,10 @@ void CodeUpdate::setVersions()
                                             "xyz.openbmc_project.Software."
                                             "Activation.Activations.Active")
                                             {
+                                                std::cout
+                                                    << "Received Active signal, Sending "
+                                                    << "success on End update sensor event "
+                                                    << "to PHYP\n";
                                                 CodeUpdateState state =
                                                     CodeUpdateState::END;
                                                 setCodeUpdateProgress(false);
@@ -388,6 +392,7 @@ void CodeUpdate::setVersions()
                                                     uint8_t(CodeUpdateState::
                                                                 START));
                                                 newImageId.clear();
+                                                imageActivationMatch.reset();
                                             }
                                             else if (propVal ==
                                                          "xyz.openbmc_project."
@@ -400,6 +405,10 @@ void CodeUpdate::setVersions()
                                                          "Activations."
                                                          "Invalid")
                                             {
+                                                std::cout
+                                                    << "Image activation Failed or image "
+                                                    << "Invalid, sending Failure on End "
+                                                    << "update to PHYP\n";
                                                 CodeUpdateState state =
                                                     CodeUpdateState::FAIL;
                                                 setCodeUpdateProgress(false);
@@ -412,8 +421,8 @@ void CodeUpdate::setVersions()
                                                     uint8_t(CodeUpdateState::
                                                                 START));
                                                 newImageId.clear();
+                                                imageActivationMatch.reset();
                                             }
-                                            imageActivationMatch.reset();
                                         }
                                     });
                         }
@@ -746,35 +755,52 @@ int CodeUpdate::assembleCodeUpdateImage()
         pid_t nextPid = fork();
         if (nextPid == 0)
         {
+            auto rc = 0;
             // Create the hostfw squashfs image from the LID files without
             // header
-            auto rc = executeCmd("/usr/sbin/mksquashfs", lidDirPath.c_str(),
-                                 hostfwImagePath.c_str(), "-all-root",
-                                 "-no-recovery");
-            if (rc < 0)
+                rc = executeCmd("/usr/sbin/mksquashfs", lidDirPath.c_str(),
+                                hostfwImagePath.c_str(), "-all-root",
+                                "-no-recovery", "-no-xattrs", "-noI",
+                                "-mkfs-time", "0", "-all-time", "0");
+                if (rc < 0)
+                {
+                    error("Error occurred during the mksqusquashfs call");
+                    setCodeUpdateProgress(false);
+                    auto sensorId = getFirmwareUpdateSensor();
+                    sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
+                                         uint8_t(CodeUpdateState::FAIL),
+                                         uint8_t(CodeUpdateState::START));
+                    exit(EXIT_FAILURE);
+                }
+            }
+            catch (const std::exception& e)
             {
-                error("Error occurred during the mksqusquashfs call");
-                setCodeUpdateProgress(false);
-                auto sensorId = getFirmwareUpdateSensor();
-                sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
-                                     uint8_t(CodeUpdateState::FAIL),
-                                     uint8_t(CodeUpdateState::START));
-                exit(EXIT_FAILURE);
+                return PLDM_ERROR;
             }
 
             fs::create_directories(updateDirPath);
 
             // Extract the BMC tarball content
-            rc = executeCmd("/bin/tar", "-xf", tarImagePath.c_str(), "-C",
-                            updateDirPath);
-            if (rc < 0)
+            try
             {
-                setCodeUpdateProgress(false);
-                auto sensorId = getFirmwareUpdateSensor();
-                sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
-                                     uint8_t(CodeUpdateState::FAIL),
-                                     uint8_t(CodeUpdateState::START));
-                exit(EXIT_FAILURE);
+                rc = executeCmd("/bin/tar", "-xf", tarImagePath.c_str(), "-C",
+                                updateDirPath);
+                if (rc < 0)
+                {
+                    setCodeUpdateProgress(false);
+                    auto sensorId = getFirmwareUpdateSensor();
+                    sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
+                                         uint8_t(CodeUpdateState::FAIL),
+                                         uint8_t(CodeUpdateState::START));
+                    exit(EXIT_FAILURE);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << "Failed to Extract the BMC tarball content, "
+                             "ERROR="
+                          << e.what() << "\n";
+                return PLDM_ERROR;
             }
 
             // Add the hostfw image to the directory where the contents were
@@ -786,17 +812,30 @@ int CodeUpdate::assembleCodeUpdateImage()
             // Remove the tarball file, then re-generate it with so that the
             // hostfw image becomes part of the tarball
             fs::remove(tarImagePath);
-            rc = executeCmd("/bin/tar", "-cf", tarImagePath, ".", "-C",
-                            updateDirPath);
-            if (rc < 0)
+            try
             {
-                error("Error occurred during the generation of the tarball");
-                setCodeUpdateProgress(false);
-                auto sensorId = getFirmwareUpdateSensor();
-                sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
-                                     uint8_t(CodeUpdateState::FAIL),
-                                     uint8_t(CodeUpdateState::START));
-                exit(EXIT_FAILURE);
+                rc = executeCmd("/bin/tar", "-cf", tarImagePath, ".", "-C",
+                                updateDirPath);
+                if (rc < 0)
+                {
+                    std::cerr
+                        << "Error occurred during the generation of the tarball"
+                        << std::endl;
+                    setCodeUpdateProgress(false);
+                    auto sensorId = getFirmwareUpdateSensor();
+                    sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
+                                         uint8_t(CodeUpdateState::FAIL),
+                                         uint8_t(CodeUpdateState::START));
+                    exit(EXIT_FAILURE);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr
+                    << "Failed to Remove the tarball file, then re-generate it, "
+                       "ERROR="
+                    << e.what() << "\n";
+                return PLDM_ERROR;
             }
 
             // Copy the tarball to the update directory to trigger the phosphor

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -42,6 +42,8 @@ constexpr auto hostfwImageName = "image-hostfw";
 /** @brief The filename of the file where bootside data will be saved */
 constexpr auto bootSideFileName = "bootSide";
 
+constexpr auto bootSideAttrName = "fw_boot_side_current";
+
 /** @brief The path to the code update tarball file */
 auto tarImagePath = fs::path(imageDirPath) / tarImageName;
 
@@ -162,6 +164,7 @@ int CodeUpdate::setRequestedActivation()
 
 void CodeUpdate::setVersions()
 {
+    BiosAttributeList biosAttrList;
     static constexpr auto mapperService = "xyz.openbmc_project.ObjectMapper";
     static constexpr auto functionalObjPath =
         "/xyz/openbmc_project/software/functional";
@@ -201,7 +204,7 @@ void CodeUpdate::setVersions()
         {
             pldm_boot_side_data pldmBootSideData;
             std::string nextBootSideBiosValue =
-                getBootSideBiosAttr("fw_boot_side");
+                getBiosAttrValue("fw_boot_side");
             pldmBootSideData.current_boot_side = nextBootSideBiosValue;
             pldmBootSideData.next_boot_side = nextBootSideBiosValue;
             pldmBootSideData.running_version_object = runningVersion.c_str();
@@ -413,6 +416,7 @@ void CodeUpdate::setVersions()
 
 void CodeUpdate::processRenameEvent()
 {
+    BiosAttributeList biosAttrList;
     pldm_boot_side_data pldmBootSideData = readBootSideFile();
     pldmBootSideData.current_boot_side = "Perm";
 
@@ -423,7 +427,9 @@ void CodeUpdate::processRenameEvent()
                          PLDM_BOOT_SIDE_HAS_BEEN_RENAMED,
                          PLDM_BOOT_SIDE_NOT_RENAMED);
     writeBootSideFile(pldmBootSideData);
-    setBootSideBiosAttr(pldmBootSideData.current_boot_side);
+    biosAttrList.push_back(
+        std::make_pair(bootSideAttrName, pldmBootSideData.current_boot_side));
+    setBiosAttr(biosAttrList);
 }
 
 void CodeUpdate::writeBootSideFile(const pldm_boot_side_data& pldmBootSideData)
@@ -784,77 +790,6 @@ int CodeUpdate::assembleCodeUpdateImage()
     }
 
     return PLDM_SUCCESS;
-}
-
-std::string getBootSideBiosAttr(const std::string& bootSideAttr)
-{
-    constexpr auto biosConfigPath = "/xyz/openbmc_project/bios_config/manager";
-    constexpr auto biosConfigIntf = "xyz.openbmc_project.BIOSConfig.Manager";
-
-    std::string var1;
-    std::variant<std::string> var2;
-    std::variant<std::string> var3;
-
-    auto bus = sdbusplus::bus::new_default();
-    try
-    {
-        auto service = pldm::utils::DBusHandler().getService(biosConfigPath,
-                                                             biosConfigIntf);
-        auto method = bus.new_method_call(
-            service.c_str(), biosConfigPath,
-            "xyz.openbmc_project.BIOSConfig.Manager", "GetAttribute");
-        method.append(bootSideAttr);
-        auto reply = bus.call(method);
-        reply.read(var1, var2, var3);
-    }
-    catch (const sdbusplus::exception::SdBusError& e)
-    {
-        std::cout << "Error getting the bios attribute"
-                  << "ERROR=" << e.what() << "ATTRIBUTE=" << bootSideAttr
-                  << std::endl;
-        return {};
-    }
-
-    return std::get<std::string>(var2);
-}
-
-void setBootSideBiosAttr(const std::string& bootSide)
-{
-    static constexpr auto SYSTEMD_PROPERTY_INTERFACE =
-        "org.freedesktop.DBus.Properties";
-
-    std::string biosAttrStr = bootSide;
-
-    constexpr auto biosConfigPath = "/xyz/openbmc_project/bios_config/manager";
-    constexpr auto biosConfigIntf = "xyz.openbmc_project.BIOSConfig.Manager";
-    constexpr auto dbusAttrName = "fw_boot_side_current";
-    constexpr auto dbusAttrType =
-        "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration";
-
-    using PendingAttributesType = std::vector<std::pair<
-        std::string, std::tuple<std::string, std::variant<std::string>>>>;
-    PendingAttributesType pendingAttributes;
-    pendingAttributes.emplace_back(std::make_pair(
-        dbusAttrName, std::make_tuple(dbusAttrType, biosAttrStr)));
-
-    auto bus = sdbusplus::bus::new_default();
-    try
-    {
-        auto service = pldm::utils::DBusHandler().getService(biosConfigPath,
-                                                             biosConfigIntf);
-        auto method = bus.new_method_call(service.c_str(), biosConfigPath,
-                                          SYSTEMD_PROPERTY_INTERFACE, "Set");
-        method.append(biosConfigIntf, "PendingAttributes",
-                      std::variant<PendingAttributesType>(pendingAttributes));
-        bus.call(method);
-    }
-    catch (const sdbusplus::exception::SdBusError& e)
-    {
-        std::cout << "Error setting the bios attribute"
-                  << "ERROR=" << e.what() << "ATTRIBUTE=" << dbusAttrName
-                  << std::endl;
-        return;
-    }
 }
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -39,6 +39,9 @@ constexpr auto tarImageName = "image.tar";
 /** @brief The file name of the hostfw image */
 constexpr auto hostfwImageName = "image-hostfw";
 
+/** @brief The filename of the file where bootside data will be saved */
+constexpr auto bootSideFileName = "bootSide";
+
 /** @brief The path to the code update tarball file */
 auto tarImagePath = fs::path(imageDirPath) / tarImageName;
 
@@ -48,6 +51,9 @@ auto hostfwImagePath = fs::path(imageDirPath) / hostfwImageName;
 /** @brief The path to the tarball file expected by the phosphor software
  *         manager */
 auto updateImagePath = fs::path("/tmp/images") / tarImageName;
+
+/** @brief The filepath of file where bootside data will be saved */
+auto bootSideDirPath = fs::path("/var/lib/pldm/") / bootSideFileName;
 
 std::string CodeUpdate::fetchCurrentBootSide()
 {
@@ -67,7 +73,10 @@ int CodeUpdate::setCurrentBootSide(const std::string& currSide)
 
 int CodeUpdate::setNextBootSide(const std::string& nextSide)
 {
+    pldm_boot_side_data pldmBootSideData = readBootSideFile();
+    currBootSide = pldmBootSideData.current_boot_side;
     nextBootSide = nextSide;
+    pldmBootSideData.next_boot_side = nextSide;
     std::string objPath{};
     if (nextBootSide == currBootSide)
     {
@@ -97,6 +106,7 @@ int CodeUpdate::setNextBootSide(const std::string& nextSide)
               "PATH", objPath, "ERROR", e);
         return PLDM_ERROR;
     }
+    writeBootSideFile(pldmBootSideData);
     return PLDM_SUCCESS;
 }
 
@@ -184,6 +194,34 @@ void CodeUpdate::setVersions()
             {
                 nonRunningVersion = path;
                 break;
+            }
+        }
+
+        if (!fs::exists(bootSideDirPath))
+        {
+            pldm_boot_side_data pldmBootSideData;
+            std::string nextBootSideBiosValue =
+                getBootSideBiosAttr("fw_boot_side");
+            pldmBootSideData.current_boot_side = nextBootSideBiosValue;
+            pldmBootSideData.next_boot_side = nextBootSideBiosValue;
+            pldmBootSideData.running_version_object = runningVersion.c_str();
+
+            writeBootSideFile(pldmBootSideData);
+            setBootSideBiosAttr(pldmBootSideData.current_boot_side);
+        }
+        else
+        {
+            pldm_boot_side_data pldmBootSideData = readBootSideFile();
+            if (pldmBootSideData.running_version_object != runningVersion)
+            {
+                pldmBootSideData.current_boot_side = "Temp" ? "Perm" : "Temp";
+                pldmBootSideData.next_boot_side = "Temp" ? "Perm" : "Temp";
+                writeBootSideFile(pldmBootSideData);
+                setBootSideBiosAttr(pldmBootSideData.current_boot_side);
+            }
+            else
+            {
+                setBootSideBiosAttr(pldmBootSideData.current_boot_side);
             }
         }
     }
@@ -353,11 +391,50 @@ void CodeUpdate::setVersions()
 
 void CodeUpdate::processRenameEvent()
 {
+    pldm_boot_side_data pldmBootSideData = readBootSideFile();
+    pldmBootSideData.current_boot_side = "Perm";
+
     currBootSide = Pside;
+
     auto sensorId = getBootSideRenameStateSensor();
     sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
                          PLDM_BOOT_SIDE_HAS_BEEN_RENAMED,
                          PLDM_BOOT_SIDE_NOT_RENAMED);
+    writeBootSideFile(pldmBootSideData);
+    setBootSideBiosAttr(pldmBootSideData.current_boot_side);
+}
+
+void CodeUpdate::writeBootSideFile(const pldm_boot_side_data& pldmBootSideData)
+{
+    std::ofstream writeFile(bootSideDirPath.string(),
+                            std::ios::out | std::ios::binary);
+    if (writeFile)
+    {
+        writeFile << pldmBootSideData.current_boot_side << std::endl;
+        writeFile << pldmBootSideData.next_boot_side << std::endl;
+        writeFile << pldmBootSideData.running_version_object << std::endl;
+
+        writeFile.close();
+    }
+}
+
+pldm_boot_side_data CodeUpdate::readBootSideFile()
+{
+    pldm_boot_side_data pldmBootSideDataRead{};
+
+    std::ifstream readFile(bootSideDirPath.string(),
+                           std::ios::in | std::ios::binary);
+
+    if (readFile)
+    {
+        readFile >> pldmBootSideDataRead.current_boot_side;
+        readFile >> pldmBootSideDataRead.next_boot_side;
+        readFile >> pldmBootSideDataRead.running_version_object;
+
+        readFile.close();
+    }
+
+    return pldmBootSideDataRead;
 }
 
 void CodeUpdate::processPriorityChangeNotification(
@@ -685,6 +762,77 @@ int CodeUpdate::assembleCodeUpdateImage()
     }
 
     return PLDM_SUCCESS;
+}
+
+std::string getBootSideBiosAttr(const std::string& bootSideAttr)
+{
+    constexpr auto biosConfigPath = "/xyz/openbmc_project/bios_config/manager";
+    constexpr auto biosConfigIntf = "xyz.openbmc_project.BIOSConfig.Manager";
+
+    std::string var1;
+    std::variant<std::string> var2;
+    std::variant<std::string> var3;
+
+    auto bus = sdbusplus::bus::new_default();
+    try
+    {
+        auto service = pldm::utils::DBusHandler().getService(biosConfigPath,
+                                                             biosConfigIntf);
+        auto method = bus.new_method_call(
+            service.c_str(), biosConfigPath,
+            "xyz.openbmc_project.BIOSConfig.Manager", "GetAttribute");
+        method.append(bootSideAttr);
+        auto reply = bus.call(method);
+        reply.read(var1, var2, var3);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cout << "Error getting the bios attribute"
+                  << "ERROR=" << e.what() << "ATTRIBUTE=" << bootSideAttr
+                  << std::endl;
+        return {};
+    }
+
+    return std::get<std::string>(var2);
+}
+
+void setBootSideBiosAttr(const std::string& bootSide)
+{
+    static constexpr auto SYSTEMD_PROPERTY_INTERFACE =
+        "org.freedesktop.DBus.Properties";
+
+    std::string biosAttrStr = bootSide;
+
+    constexpr auto biosConfigPath = "/xyz/openbmc_project/bios_config/manager";
+    constexpr auto biosConfigIntf = "xyz.openbmc_project.BIOSConfig.Manager";
+    constexpr auto dbusAttrName = "fw_boot_side_current";
+    constexpr auto dbusAttrType =
+        "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration";
+
+    using PendingAttributesType = std::vector<std::pair<
+        std::string, std::tuple<std::string, std::variant<std::string>>>>;
+    PendingAttributesType pendingAttributes;
+    pendingAttributes.emplace_back(std::make_pair(
+        dbusAttrName, std::make_tuple(dbusAttrType, biosAttrStr)));
+
+    auto bus = sdbusplus::bus::new_default();
+    try
+    {
+        auto service = pldm::utils::DBusHandler().getService(biosConfigPath,
+                                                             biosConfigIntf);
+        auto method = bus.new_method_call(service.c_str(), biosConfigPath,
+                                          SYSTEMD_PROPERTY_INTERFACE, "Set");
+        method.append(biosConfigIntf, "PendingAttributes",
+                      std::variant<PendingAttributesType>(pendingAttributes));
+        bus.call(method);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cout << "Error setting the bios attribute"
+                  << "ERROR=" << e.what() << "ATTRIBUTE=" << dbusAttrName
+                  << std::endl;
+        return;
+    }
 }
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/inband_code_update.hpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.hpp
@@ -225,8 +225,7 @@ class CodeUpdate
      *         bootside information */
     pldm_boot_side_data readBootSideFile();
 
-    virtual ~CodeUpdate()
-    {}
+    virtual ~CodeUpdate() {}
 
   private:
     std::string currBootSide;      //!< current boot side
@@ -237,7 +236,6 @@ class CodeUpdate
     uint8_t retrySetVersion = 0;
 
     bool codeUpdateInProgress =
-    std::vector<std::unique_ptr<sdbusplus::bus::match_t>>
         false; //!< indicates whether codeupdate is going on
     bool outOfBandCodeUpdateInProgress = false; //!< indicates whether
                                                 //!< out of band codeupdate

--- a/oem/ibm/libpldmresponder/inband_code_update.hpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.hpp
@@ -19,6 +19,13 @@ static constexpr auto Tside = "T";
 static constexpr auto redundancyIntf =
     "xyz.openbmc_project.Software.RedundancyPriority";
 
+struct pldm_boot_side_data
+{
+    std::string current_boot_side;
+    std::string next_boot_side;
+    std::string running_version_object;
+};
+
 /** @class CodeUpdate
  *
  *  @brief This class performs the necessary operation in pldm for
@@ -203,6 +210,20 @@ class CodeUpdate
      * rename event notification to host when code update is initiated*/
     void processRenameEvent();
 
+    /* @brief Method to write the bootside information into mapping
+     *        file which would be stored on host
+     * @param[in] pldmBootSideData - bootside information such as
+     *        current boot side and running version
+     */
+    void writeBootSideFile(const pldm_boot_side_data& pldmBootSideData);
+
+    /* @brief Method to read the mapping file containing bootside
+     *        which is stored on host and stores that information
+     *        in a structure
+     * @return[] - the structure which holds information regarding
+     *         bootside information */
+    pldm_boot_side_data readBootSideFile();
+
     virtual ~CodeUpdate()
     {}
 
@@ -213,9 +234,12 @@ class CodeUpdate
     std::string nonRunningVersion; //!< alternate image
     std::string newImageId;        //!< new image id
     bool codeUpdateInProgress =
-        false;                     //!< indicates whether codeupdate is going on
-    bool outOfBandCodeUpdateInProgress = false;
-    const pldm::utils::DBusHandler* dBusIntf; //!< D-Bus handler
+    std::vector<std::unique_ptr<sdbusplus::bus::match_t>>
+        false; //!< indicates whether codeupdate is going on
+    bool outOfBandCodeUpdateInProgress = false; //!< indicates whether
+                                                //!< out of band codeupdate
+                                                //!< is in progress
+    const pldm::utils::DBusHandler* dBusIntf;   //!< D-Bus handler
     std::vector<std::unique_ptr<sdbusplus::bus::match_t>>
         captureNextBootSideChange; //!< vector to catch the D-Bus property
                                    //!< change for next boot side
@@ -227,6 +251,7 @@ class CodeUpdate
     uint16_t markerLidSensorId;
     uint16_t firmwareUpdateSensorId;
     uint16_t bootSideRenameStateSensorId;
+
     /** @brief D-Bus property changed signal match for image activation */
     std::unique_ptr<sdbusplus::bus::match_t> imageActivationMatch;
 
@@ -264,5 +289,24 @@ int setBootSide(uint16_t entityInstance, uint8_t currState,
  */
 int processCodeUpdateLid(const std::string& filePath);
 
+/** @brief Method to assemble the code update tarball and trigger the
+ *         phosphor software manager to create a version interface
+ *  @return - PLDM_SUCCESS codes
+ */
+int assembleCodeUpdateImage();
+
+/* @brief Method to get the value from the fw_boot_side attribute which
+ *        is set by host, this is next boot side
+ * @param[in] bootSideAttr - the bios attribute from which the value needs
+ *        to be retrieved(fw_boot_side)
+ * @return - the next boot side value
+ */
+std::string getBootSideBiosAttr(const std::string& bootSideAttr);
+
+/* @brief Method to set the fw_boot_side_current property with the current
+ *        boot side
+ * @param[in] bootSide - the current boot side needed to set the bios
+ *        attribute*/
+void setBootSideBiosAttr(const std::string& bootSide);
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/inband_code_update.hpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.hpp
@@ -96,6 +96,14 @@ class CodeUpdate
         codeUpdateInProgress = progress;
     }
 
+    /* @brief Method to indicate whether out of band code update
+     *        is going on
+     */
+    bool isOutOfBandCodeUpdateInProgress()
+    {
+        return outOfBandCodeUpdateInProgress;
+    }
+
     /** @brief Method to clear contents the LID staging directory that contains
      *  images such as host firmware and BMC.
      *  @param[in] dirPath - directory system path that has to be cleared
@@ -151,6 +159,23 @@ class CodeUpdate
         return firmwareUpdateSensorId;
     }
 
+    /* @brief Method to set the sensor id for boot side rename state
+     * @param[in] sensorId - sensor id for boot side rename update
+     *                       state
+     */
+    void setBootSideRenameStateSensor(uint16_t sensorId)
+    {
+        bootSideRenameStateSensorId = sensorId;
+    }
+
+    /* @brief Method to fetch the sensor id for boot side rename state
+     * @return - sensor id
+     */
+    uint16_t getBootSideRenameStateSensor()
+    {
+        return bootSideRenameStateSensorId;
+    }
+
     /* @brief Method to send a state sensor event to Host from CodeUpdate class
      * @param[in] sensorId - sensor id for the event
      * @param[in] sensorEventClass - sensor event class wrt DSP0248
@@ -174,7 +199,12 @@ class CodeUpdate
      */
     int assembleCodeUpdateImage();
 
-    virtual ~CodeUpdate() {}
+    /* @brief Method to process the bootside rename event, sends a boot side
+     * rename event notification to host when code update is initiated*/
+    void processRenameEvent();
+
+    virtual ~CodeUpdate()
+    {}
 
   private:
     std::string currBootSide;      //!< current boot side
@@ -184,6 +214,7 @@ class CodeUpdate
     std::string newImageId;        //!< new image id
     bool codeUpdateInProgress =
         false;                     //!< indicates whether codeupdate is going on
+    bool outOfBandCodeUpdateInProgress = false;
     const pldm::utils::DBusHandler* dBusIntf; //!< D-Bus handler
     std::vector<std::unique_ptr<sdbusplus::bus::match_t>>
         captureNextBootSideChange; //!< vector to catch the D-Bus property
@@ -195,7 +226,7 @@ class CodeUpdate
         oemPlatformHandler; //!< oem platform handler
     uint16_t markerLidSensorId;
     uint16_t firmwareUpdateSensorId;
-
+    uint16_t bootSideRenameStateSensorId;
     /** @brief D-Bus property changed signal match for image activation */
     std::unique_ptr<sdbusplus::bus::match_t> imageActivationMatch;
 

--- a/oem/ibm/libpldmresponder/inband_code_update.hpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.hpp
@@ -295,18 +295,5 @@ int processCodeUpdateLid(const std::string& filePath);
  */
 int assembleCodeUpdateImage();
 
-/* @brief Method to get the value from the fw_boot_side attribute which
- *        is set by host, this is next boot side
- * @param[in] bootSideAttr - the bios attribute from which the value needs
- *        to be retrieved(fw_boot_side)
- * @return - the next boot side value
- */
-std::string getBootSideBiosAttr(const std::string& bootSideAttr);
-
-/* @brief Method to set the fw_boot_side_current property with the current
- *        boot side
- * @param[in] bootSide - the current boot side needed to set the bios
- *        attribute*/
-void setBootSideBiosAttr(const std::string& bootSide);
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/inband_code_update.hpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.hpp
@@ -13,6 +13,7 @@ namespace responder
 
 static constexpr uint8_t pSideNum = 1;
 static constexpr uint8_t tSideNum = 2;
+static constexpr uint8_t maxVersionRetry = 20;
 static constexpr auto Pside = "P";
 static constexpr auto Tside = "T";
 
@@ -233,6 +234,8 @@ class CodeUpdate
     std::string runningVersion;    //!< currently running image
     std::string nonRunningVersion; //!< alternate image
     std::string newImageId;        //!< new image id
+    uint8_t retrySetVersion = 0;
+
     bool codeUpdateInProgress =
     std::vector<std::unique_ptr<sdbusplus::bus::match_t>>
         false; //!< indicates whether codeupdate is going on

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -78,7 +78,7 @@ int pldm::responder::oem_ibm_platform::Handler::
 
 int pldm::responder::oem_ibm_platform::Handler::
     oemSetStateEffecterStatesHandler(
-        uint16_t entityType, uint16_t entityInstance, uint16_t stateSetId,
+        uint16_t entityType, uint16_t /*entityInstance*/, uint16_t stateSetId,
         uint8_t compEffecterCnt,
         std::vector<set_effecter_state_field>& stateField, uint16_t effecterId)
 {
@@ -90,13 +90,7 @@ int pldm::responder::oem_ibm_platform::Handler::
         if (stateField[currState].set_request == PLDM_REQUEST_SET)
         {
             if (entityType == PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE &&
-                stateSetId == PLDM_OEM_IBM_BOOT_STATE)
-            {
-                rc = setBootSide(entityInstance, currState, stateField,
-                                 codeUpdate);
-            }
-            else if (entityType == PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE &&
-                     stateSetId == PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE)
+                stateSetId == PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE)
             {
                 if (stateField[currState].effecter_state ==
                     uint8_t(CodeUpdateState::START))
@@ -353,8 +347,7 @@ void buildAllCodeUpdateEffecterPDR(oem_ibm_platform::Handler* platformHandler,
     possibleStates->possible_states_size = 2;
     auto state =
         reinterpret_cast<state_effecter_possible_states*>(possibleStates);
-    if ((stateSetID == PLDM_OEM_IBM_BOOT_STATE) ||
-        (stateSetID == PLDM_OEM_IBM_BOOT_SIDE_RENAME))
+    if (stateSetID == PLDM_OEM_IBM_BOOT_SIDE_RENAME)
         state->states[0].byte = 6;
     else if (stateSetID == PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE)
         state->states[0].byte = 126;
@@ -470,8 +463,7 @@ void buildAllCodeUpdateSensorPDR(oem_ibm_platform::Handler* platformHandler,
     possibleStates->possible_states_size = 2;
     auto state =
         reinterpret_cast<state_sensor_possible_states*>(possibleStates);
-    if ((stateSetID == PLDM_OEM_IBM_BOOT_STATE) ||
-        (stateSetID == PLDM_OEM_IBM_VERIFICATION_STATE) ||
+    if ((stateSetID == PLDM_OEM_IBM_VERIFICATION_STATE) ||
         (stateSetID == PLDM_OEM_IBM_BOOT_SIDE_RENAME))
         state->states[0].byte = 6;
     else if (stateSetID == PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE)
@@ -641,12 +633,6 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     pdr_utils::Repo& repo)
 {
     buildAllCodeUpdateEffecterPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
-                                  ENTITY_INSTANCE_0, PLDM_OEM_IBM_BOOT_STATE,
-                                  repo);
-    buildAllCodeUpdateEffecterPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
-                                  ENTITY_INSTANCE_1, PLDM_OEM_IBM_BOOT_STATE,
-                                  repo);
-    buildAllCodeUpdateEffecterPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
                                   ENTITY_INSTANCE_0,
                                   PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE, repo);
     buildAllCodeUpdateEffecterPDR(this, PLDM_ENTITY_SYSTEM_CHASSIS,
@@ -664,12 +650,6 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     auto slotPaths = dBusIntf->getSubTreePaths(objectPath, 0, slotInterface);
     buildAllSlotEnableEffecterPDR(this, repo, slotPaths);
     buildAllSlotEnableSensorPDR(this, repo, slotPaths);
-    buildAllCodeUpdateSensorPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
-                                ENTITY_INSTANCE_0, PLDM_OEM_IBM_BOOT_STATE,
-                                repo);
-    buildAllCodeUpdateSensorPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
-                                ENTITY_INSTANCE_1, PLDM_OEM_IBM_BOOT_STATE,
-                                repo);
     buildAllCodeUpdateSensorPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
                                 ENTITY_INSTANCE_0,
                                 PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE, repo);

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -851,6 +851,9 @@ void pldm::responder::oem_ibm_platform::Handler::updateOemDbusPaths(
 void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
     sdeventplus::source::EventBase& /*source */)
 {
+    BiosAttributeList biosAttrList;
+    biosAttrList.push_back(std::make_pair("pvm_boot_initiator", "Host"));
+    setBiosAttr(biosAttrList);
     pldm::utils::PropertyValue value =
         "xyz.openbmc_project.State.Chassis.Transition.Off";
     pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/chassis0",
@@ -1267,7 +1270,8 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtPowerOn()
     BiosAttributeList biosAttrList;
     auto bootInitiator = getBiosAttrValue("pvm_boot_initiator_current");
     std::string restartCause;
-    if (bootInitiator != "HMC" && !bootInitiator.empty())
+    if (((bootInitiator != "HMC") || (bootInitiator != "Host")) &&
+        !bootInitiator.empty())
     {
         try
         {
@@ -1321,30 +1325,7 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtChassisOff()
             << "ERROR in fetching the pvm_boot_initiator and pvm_boot_type BIOS attribute values\n";
         return;
     }
-    else if ((bootInitiator == "Auto") && (bootType == "IPL"))
-    {
-        std::cerr << "Setting the APR to AlwaysOn as pvm_boot_initiator="
-                  << bootInitiator << " and pvm_boot_type=" << bootType
-                  << std::endl;
-        pldm::utils::DBusMapping dbusMapping{
-            "/xyz/openbmc_project/control/host0/"
-            "power_restore_policy/one_time",
-            "xyz.openbmc_project.Control.Power.RestorePolicy",
-            "PowerRestorePolicy", "string"};
-        PropertyValue value = "xyz.openbmc_project.Control.Power.RestorePolicy."
-                              "Policy.AlwaysOn";
-        try
-        {
-            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
-        }
-        catch (const std::exception& e)
-        {
-            std::cerr << "Setting one-time restore policy failed,"
-                      << "unable to set property PowerRestorePolicy"
-                      << "ERROR=" << e.what() << "\n";
-        }
-    }
-    else
+    else if (bootInitiator != "Host")
     {
         biosAttrList.push_back(std::make_pair("pvm_boot_initiator", "User"));
         biosAttrList.push_back(std::make_pair("pvm_boot_type", "IPL"));

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -901,41 +901,30 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                         "Policy.AlwaysOn";
                 try
                 {
-                    pldm::utils::DBusMapping dbusMapping{
-                        "/xyz/openbmc_project/control/host0/"
-                        "power_restore_policy/one_time",
-                        "xyz.openbmc_project.Control.Power.RestorePolicy",
-                        "PowerRestorePolicy", "string"};
-                    value = "xyz.openbmc_project.Control.Power.RestorePolicy."
-                            "Policy.AlwaysOn";
-                    try
-                    {
-                        info(
-                            "InbandCodeUpdate: Setting the one time APR policy");
-                        dBusIntf->setDbusProperty(dbusMapping, value);
-                    }
-                    catch (const std::exception& e)
-                    {
-                        error(
-                            "Setting one-time restore policy failed, unable to set property PowerRestorePolicy ERROR={ERR_EXCEP}",
-                            "ERR_EXCEP", e.what());
-                    }
-                    dbusMapping = pldm::utils::DBusMapping{
-                        "/xyz/openbmc_project/state/bmc0",
-                        "xyz.openbmc_project.State.BMC",
-                        "RequestedBMCTransition", "string"};
-                    value = "xyz.openbmc_project.State.BMC.Transition.Reboot";
-                    try
-                    {
-                        info("InbandCodeUpdate: Rebooting the BMC");
-                        dBusIntf->setDbusProperty(dbusMapping, value);
-                    }
-                    catch (const std::exception& e)
-                    {
-                        error(
-                            "BMC state transition to reboot failed, unable to set property RequestedBMCTransition ERROR={ERR_EXCEP}",
-                            "ERR_EXCEP", e);
-                    }
+                    info("InbandCodeUpdate: Setting the one time APR policy");
+                    dBusIntf->setDbusProperty(dbusMapping, value);
+                }
+                catch (const std::exception& e)
+                {
+                    error(
+                        "Setting one-time restore policy failed, unable to set property PowerRestorePolicy ERROR={ERR_EXCEP}",
+                        "ERR_EXCEP", e.what());
+                }
+                dbusMapping = pldm::utils::DBusMapping{
+                    "/xyz/openbmc_project/state/bmc0",
+                    "xyz.openbmc_project.State.BMC", "RequestedBMCTransition",
+                    "string"};
+                value = "xyz.openbmc_project.State.BMC.Transition.Reboot";
+                try
+                {
+                    info("InbandCodeUpdate: Rebooting the BMC");
+                    dBusIntf->setDbusProperty(dbusMapping, value);
+                }
+                catch (const std::exception& e)
+                {
+                    error(
+                        "BMC state transition to reboot failed, unable to set property RequestedBMCTransition ERROR={ERR_EXCEP}",
+                        "ERR_EXCEP", e);
                 }
             }
         }
@@ -1352,14 +1341,13 @@ void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
     }
     else if (!value && timer.isEnabled())
     {
-         info(
+        info(
             "setSurvTimer:LogginPel:hostOff={HOST_OFF} hostTransitioningToOff={HOST_TRANST_OFF} tid={TID}",
             "HOST_OFF", (bool)hostOff, "HOST_TRANST_OFF",
             (bool)hostTransitioningToOff, "TID", (uint16_t)tid);
         startStopTimer(false);
         pldm::utils::reportError(
-            "xyz.openbmc_project.bmc.PLDM.setSurvTimer.RecvSurveillancePingFail",
-            pldm::PelSeverity::INFORMATIONAL);
+            "xyz.openbmc_project.bmc.PLDM.setSurvTimer.RecvSurveillancePingFail");
     }
 }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1322,11 +1322,17 @@ void pldm::responder::oem_ibm_platform::Handler::setBootTypesBiosAttr(
         (restartCause ==
          "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyAlwaysOn") ||
         (restartCause ==
-         "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyPreviousState") ||
-        (restartCause ==
-         "xyz.openbmc_project.State.Host.RestartCause.HostCrash"))
+         "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyPreviousState"))
     {
         biosAttrList.push_back(std::make_pair("pvm_boot_initiator", "Auto"));
+        setBiosAttr(biosAttrList);
+        stateManagerMatch.reset();
+    }
+    else if (restartCause ==
+             "xyz.openbmc_project.State.Host.RestartCause.HostCrash")
+    {
+        biosAttrList.push_back(std::make_pair("pvm_boot_initiator", "Auto"));
+        biosAttrList.push_back(std::make_pair("pvm_boot_type", "ReIPL"));
         setBiosAttr(biosAttrList);
         stateManagerMatch.reset();
     }

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -461,7 +461,8 @@ void buildAllCodeUpdateSensorPDR(oem_ibm_platform::Handler* platformHandler,
     auto state =
         reinterpret_cast<state_sensor_possible_states*>(possibleStates);
     if ((stateSetID == PLDM_OEM_IBM_BOOT_STATE) ||
-        (stateSetID == PLDM_OEM_IBM_VERIFICATION_STATE))
+        (stateSetID == PLDM_OEM_IBM_VERIFICATION_STATE) ||
+        (stateSetID == PLDM_OEM_IBM_BOOT_SIDE_RENAME))
         state->states[0].byte = 6;
     else if (stateSetID == PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE)
         state->states[0].byte = 126;
@@ -682,6 +683,9 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     realSAISensorId = findStateSensorId(
         repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_REAL_SAI, ENTITY_INSTANCE_1, 1,
         PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS);
+    buildAllCodeUpdateSensorPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
+                                ENTITY_INSTANCE_0,
+                                PLDM_OEM_IBM_BOOT_SIDE_RENAME, repo);
     auto sensorId = findStateSensorId(
         repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
         ENTITY_INSTANCE_0, 1, PLDM_OEM_IBM_VERIFICATION_STATE);
@@ -690,6 +694,10 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
         repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
         ENTITY_INSTANCE_0, 1, PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE);
     codeUpdate->setFirmwareUpdateSensor(sensorId);
+    sensorId =
+        findStateSensorId(repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
+                          ENTITY_INSTANCE_0, 0, PLDM_OEM_IBM_BOOT_SIDE_RENAME);
+    codeUpdate->setBootSideRenameStateSensor(sensorId);
 }
 
 void pldm::responder::oem_ibm_platform::Handler::setPlatformHandler(

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -197,6 +197,15 @@ int pldm::responder::oem_ibm_platform::Handler::
             {
                 turnOffRealSAIEffecter();
             }
+            else if (entityType == PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE &&
+                     stateSetId == PLDM_OEM_IBM_BOOT_SIDE_RENAME)
+            {
+                if (stateField[currState].effecter_state ==
+                    PLDM_BOOT_SIDE_HAS_BEEN_RENAMED)
+                {
+                    codeUpdate->processRenameEvent();
+                }
+            }
             else
             {
                 rc = PLDM_PLATFORM_SET_EFFECTER_UNSUPPORTED_SENSORSTATE;
@@ -344,7 +353,8 @@ void buildAllCodeUpdateEffecterPDR(oem_ibm_platform::Handler* platformHandler,
     possibleStates->possible_states_size = 2;
     auto state =
         reinterpret_cast<state_effecter_possible_states*>(possibleStates);
-    if (stateSetID == PLDM_OEM_IBM_BOOT_STATE)
+    if ((stateSetID == PLDM_OEM_IBM_BOOT_STATE) ||
+        (stateSetID == PLDM_OEM_IBM_BOOT_SIDE_RENAME))
         state->states[0].byte = 6;
     else if (stateSetID == PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE)
         state->states[0].byte = 126;
@@ -647,6 +657,9 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     static constexpr auto objectPath = "/xyz/openbmc_project/inventory/system";
     const std::vector<std::string> slotInterface = {
         "xyz.openbmc_project.Inventory.Item.PCIeSlot"};
+    buildAllCodeUpdateEffecterPDR(this, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
+                                  ENTITY_INSTANCE_0,
+                                  PLDM_OEM_IBM_BOOT_SIDE_RENAME, repo);
 
     auto slotPaths = dBusIntf->getSubTreePaths(objectPath, 0, slotInterface);
     buildAllSlotEnableEffecterPDR(this, repo, slotPaths);

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1266,32 +1266,47 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtPowerOn()
 {
     BiosAttributeList biosAttrList;
     auto bootInitiator = getBiosAttrValue("pvm_boot_initiator_current");
+    std::string restartCause;
     if (bootInitiator != "HMC" && !bootInitiator.empty())
     {
-        auto restartCause =
-            pldm::utils::DBusHandler().getDbusProperty<std::string>(
-                "/xyz/openbmc_project/state/host0", "RestartCause",
-                "xyz.openbmc_project.State.Host");
+        try
+        {
+            restartCause =
+                pldm::utils::DBusHandler().getDbusProperty<std::string>(
+                    "/xyz/openbmc_project/state/host0", "RestartCause",
+                    "xyz.openbmc_project.State.Host");
+            setBootTypesBiosAttr(restartCause);
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "Failed to fetch the restartCause, ERROR=" << e.what()
+                      << "\n";
+        }
+    }
+}
 
-        if (restartCause ==
-            "xyz.openbmc_project.State.Host.RestartCause.ScheduledPowerOn")
-        {
-            biosAttrList.push_back(
-                std::make_pair("pvm_boot_initiator", "Host"));
-            setBiosAttr(biosAttrList);
-        }
-        else if (
-            (restartCause ==
-             "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyAlwaysOn") ||
-            (restartCause ==
-             "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyPreviousState") ||
-            (restartCause ==
-             "xyz.openbmc_project.State.Host.RestartCause.HostCrash"))
-        {
-            biosAttrList.push_back(
-                std::make_pair("pvm_boot_initiator", "Auto"));
-            setBiosAttr(biosAttrList);
-        }
+void pldm::responder::oem_ibm_platform::Handler::setBootTypesBiosAttr(
+    const std::string& restartCause)
+{
+    BiosAttributeList biosAttrList;
+    if (restartCause ==
+        "xyz.openbmc_project.State.Host.RestartCause.ScheduledPowerOn")
+    {
+        biosAttrList.push_back(std::make_pair("pvm_boot_initiator", "Host"));
+        setBiosAttr(biosAttrList);
+        stateManagerMatch.reset();
+    }
+    else if (
+        (restartCause ==
+         "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyAlwaysOn") ||
+        (restartCause ==
+         "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyPreviousState") ||
+        (restartCause ==
+         "xyz.openbmc_project.State.Host.RestartCause.HostCrash"))
+    {
+        biosAttrList.push_back(std::make_pair("pvm_boot_initiator", "Auto"));
+        setBiosAttr(biosAttrList);
+        stateManagerMatch.reset();
     }
 }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1262,6 +1262,81 @@ void pldm::responder::oem_ibm_platform::Handler::modifyPDROemActions(
     }
 }
 
+void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtPowerOn()
+{
+    BiosAttributeList biosAttrList;
+    auto bootInitiator = getBiosAttrValue("pvm_boot_initiator_current");
+    if (bootInitiator != "HMC" && !bootInitiator.empty())
+    {
+        auto restartCause =
+            pldm::utils::DBusHandler().getDbusProperty<std::string>(
+                "/xyz/openbmc_project/state/host0", "RestartCause",
+                "xyz.openbmc_project.State.Host");
+
+        if (restartCause ==
+            "xyz.openbmc_project.State.Host.RestartCause.ScheduledPowerOn")
+        {
+            biosAttrList.push_back(
+                std::make_pair("pvm_boot_initiator", "Host"));
+            setBiosAttr(biosAttrList);
+        }
+        else if (
+            (restartCause ==
+             "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyAlwaysOn") ||
+            (restartCause ==
+             "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyPreviousState") ||
+            (restartCause ==
+             "xyz.openbmc_project.State.Host.RestartCause.HostCrash"))
+        {
+            biosAttrList.push_back(
+                std::make_pair("pvm_boot_initiator", "Auto"));
+            setBiosAttr(biosAttrList);
+        }
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtChassisOff()
+{
+    BiosAttributeList biosAttrList;
+    auto bootInitiator = getBiosAttrValue("pvm_boot_initiator");
+    auto bootType = getBiosAttrValue("pvm_boot_type");
+    if (bootInitiator.empty() || bootType.empty())
+    {
+        std::cerr
+            << "ERROR in fetching the pvm_boot_initiator and pvm_boot_type BIOS attribute values\n";
+        return;
+    }
+    else if ((bootInitiator == "Auto") && (bootType == "IPL"))
+    {
+        std::cerr << "Setting the APR to AlwaysOn as pvm_boot_initiator="
+                  << bootInitiator << " and pvm_boot_type=" << bootType
+                  << std::endl;
+        pldm::utils::DBusMapping dbusMapping{
+            "/xyz/openbmc_project/control/host0/"
+            "power_restore_policy/one_time",
+            "xyz.openbmc_project.Control.Power.RestorePolicy",
+            "PowerRestorePolicy", "string"};
+        PropertyValue value = "xyz.openbmc_project.Control.Power.RestorePolicy."
+                              "Policy.AlwaysOn";
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "Setting one-time restore policy failed,"
+                      << "unable to set property PowerRestorePolicy"
+                      << "ERROR=" << e.what() << "\n";
+        }
+    }
+    else
+    {
+        biosAttrList.push_back(std::make_pair("pvm_boot_initiator", "User"));
+        biosAttrList.push_back(std::make_pair("pvm_boot_type", "IPL"));
+        setBiosAttr(biosAttrList);
+    }
+}
+
 } // namespace oem_ibm_platform
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -910,14 +910,15 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                             "Policy.AlwaysOn";
                     try
                     {
-                        info("InbandCodeUpdate: Setting the one time APR policy");
+                        info(
+                            "InbandCodeUpdate: Setting the one time APR policy");
                         dBusIntf->setDbusProperty(dbusMapping, value);
                     }
                     catch (const std::exception& e)
                     {
                         error(
-                        "Setting one-time restore policy failed, unable to set property PowerRestorePolicy ERROR={ERR_EXCEP}",
-                        "ERR_EXCEP", e.what());
+                            "Setting one-time restore policy failed, unable to set property PowerRestorePolicy ERROR={ERR_EXCEP}",
+                            "ERR_EXCEP", e.what());
                     }
                     dbusMapping = pldm::utils::DBusMapping{
                         "/xyz/openbmc_project/state/bmc0",
@@ -932,8 +933,8 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                     catch (const std::exception& e)
                     {
                         error(
-                        "BMC state transition to reboot failed, unable to set property RequestedBMCTransition ERROR={ERR_EXCEP}",
-                        "ERR_EXCEP", e);
+                            "BMC state transition to reboot failed, unable to set property RequestedBMCTransition ERROR={ERR_EXCEP}",
+                            "ERR_EXCEP", e);
                     }
                 }
             }

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1358,6 +1358,267 @@ void pldm::responder::oem_ibm_platform::Handler::handleBootTypesAtChassisOff()
     }
 }
 
+void pldm::responder::oem_ibm_platform::Handler::turnOffRealSAIEffecter()
+{
+    try
+    {
+        pldm::utils::DBusMapping dbuspartitionMapping{
+            "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group", "Asserted", "bool"};
+        pldm::utils::DBusHandler().setDbusProperty(dbuspartitionMapping, false);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to turn off partition SAI effecter"
+                  << "ERROR=" << e.what() << "\n";
+    }
+    try
+    {
+        pldm::utils::DBusMapping dbusplatformMapping{
+            "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group", "Asserted", "bool"};
+        pldm::utils::DBusHandler().setDbusProperty(dbusplatformMapping, false);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to turn off platform SAI effecter"
+                  << "ERROR=" << e.what() << "\n";
+    }
+}
+
+uint8_t pldm::responder::oem_ibm_platform::Handler::fetchRealSAIStatus()
+{
+    static constexpr auto partitionSAIObjectPath =
+        "/xyz/openbmc_project/led/groups/partition_system_attention_indicator";
+    static constexpr auto platformSAIObjectPath =
+        "/xyz/openbmc_project/led/groups/platform_system_attention_indicator";
+    static constexpr auto saiInterface = "xyz.openbmc_project.Led.Group";
+    static constexpr auto saiPropertyName = "Asserted";
+    uint8_t isPartitionSAIOn = 0;
+    uint8_t isPlatformSAIOn = 0;
+
+    try
+    {
+        isPartitionSAIOn = pldm::utils::DBusHandler().getDbusProperty<bool>(
+            partitionSAIObjectPath, saiPropertyName, saiInterface);
+        isPlatformSAIOn = pldm::utils::DBusHandler().getDbusProperty<bool>(
+            platformSAIObjectPath, saiPropertyName, saiInterface);
+
+        if (isPartitionSAIOn || isPlatformSAIOn)
+        {
+            return PLDM_SENSOR_WARNING;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Failed to fetch Real SAI sensor status"
+                  << "ERROR=" << e.what() << "\n";
+    }
+    return PLDM_SENSOR_NORMAL;
+}
+
+void pldm::responder::oem_ibm_platform::Handler::
+    updateIdentifyEffecterAndSensorPDRs()
+{
+    pldm::pdr::EntityType entityType = PLDM_ENTITY_PROC;
+
+    auto stateEffecterPDRs = pldm::utils::findStateEffecterPDR(
+        mctp_eid, entityType,
+        static_cast<uint16_t>(PLDM_STATE_SET_IDENTIFY_STATE), pdrRepo);
+
+    if (stateEffecterPDRs.empty())
+    {
+        std::cerr << "The State effecter PDR cannot be found, entityType = "
+                  << entityType << std::endl;
+        return;
+    }
+
+    for (auto& effecterPDR : stateEffecterPDRs)
+    {
+        for (auto& [key, value] : instanceMap)
+        {
+            auto instNumber = (value.dcmId * 2) + value.procId;
+            auto pdr =
+                reinterpret_cast<pldm_state_effecter_pdr*>(effecterPDR.data());
+            if (instNumber == ((pdr->entity_instance) - 1))
+            {
+                uint16_t newContainerID = pldm_find_container_id(
+                    pdrRepo, PLDM_ENTITY_PROC_MODULE, value.dcmId);
+                pldm_change_container_id_of_effecter(pdrRepo, pdr->effecter_id,
+                                                     newContainerID);
+                pldm_change_instance_number_of_effecter(
+                    pdrRepo, pdr->effecter_id, (instNumber % 2));
+                break;
+            }
+        }
+    }
+
+    auto stateSensorIdentifyPDRs = findStateSensorPDR(
+        mctp_eid, entityType,
+        static_cast<uint16_t>(PLDM_STATE_SET_IDENTIFY_STATE), pdrRepo);
+    for (auto& identifySensorPDR : stateSensorIdentifyPDRs)
+    {
+        for (auto& [key, value] : instanceMap)
+        {
+            auto instanceNumber = (value.dcmId * 2) + value.procId;
+            auto pdr = reinterpret_cast<pldm_state_sensor_pdr*>(
+                identifySensorPDR.data());
+            if (instanceNumber == ((pdr->entity_instance) - 1))
+            {
+                uint16_t newContainerID = pldm_find_container_id(
+                    pdrRepo, PLDM_ENTITY_PROC_MODULE, value.dcmId);
+                pldm_change_container_id_of_sensor(pdrRepo, pdr->sensor_id,
+                                                   newContainerID);
+                pldm_change_instance_number_of_sensor(pdrRepo, pdr->sensor_id,
+                                                      (instanceNumber % 2));
+                break;
+            }
+        }
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::
+    updateFaultEffecterAndSensorPDRs()
+{
+    pldm::pdr::EntityType entityType = PLDM_ENTITY_PROC;
+    auto stateEffecterFaultPDRs = pldm::utils::findStateEffecterPDR(
+        mctp_eid, entityType,
+        static_cast<uint16_t>(PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS),
+        pdrRepo);
+    for (auto& faultEffecterPDR : stateEffecterFaultPDRs)
+    {
+        for (auto& [key, value] : instanceMap)
+        {
+            auto instanceNumber = (value.dcmId * 2) + value.procId;
+            auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(
+                faultEffecterPDR.data());
+            if (instanceNumber == (pdr->entity_instance) - 1)
+            {
+                uint16_t newContainerID = pldm_find_container_id(
+                    pdrRepo, PLDM_ENTITY_PROC_MODULE, value.dcmId);
+                pldm_change_container_id_of_effecter(pdrRepo, pdr->effecter_id,
+                                                     newContainerID);
+                pldm_change_instance_number_of_effecter(
+                    pdrRepo, pdr->effecter_id, (instanceNumber % 2));
+                break;
+            }
+        }
+    }
+
+    auto stateSensorFaultPDRs = findStateSensorPDR(
+        mctp_eid, entityType,
+        static_cast<uint16_t>(PLDM_STATE_SET_OPERATIONAL_FAULT_STATUS),
+        pdrRepo);
+    for (auto& faultSensorPDR : stateSensorFaultPDRs)
+    {
+        for (auto& [key, value] : instanceMap)
+        {
+            auto instanceNumber = (value.dcmId * 2) + value.procId;
+            auto pdr =
+                reinterpret_cast<pldm_state_sensor_pdr*>(faultSensorPDR.data());
+            if (instanceNumber == (pdr->entity_instance) - 1)
+            {
+                uint16_t newContainerID = pldm_find_container_id(
+                    pdrRepo, PLDM_ENTITY_PROC_MODULE, value.dcmId);
+                pldm_change_container_id_of_sensor(pdrRepo, pdr->sensor_id,
+                                                   newContainerID);
+                pldm_change_instance_number_of_sensor(pdrRepo, pdr->sensor_id,
+                                                      (instanceNumber % 2));
+                break;
+            }
+        }
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::updateContainerIDofProcLed()
+{
+    if (update)
+    {
+        updateIdentifyEffecterAndSensorPDRs();
+        updateFaultEffecterAndSensorPDRs();
+        update = false;
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::
+    processPowerCycleOffSoftGraceful()
+{
+    pldm::utils::PropertyValue value =
+        "xyz.openbmc_project.State.Host.Transition.ForceWarmReboot";
+    pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/host0",
+                                         "xyz.openbmc_project.State.Host",
+                                         "RequestedHostTransition", "string"};
+    try
+    {
+        dBusIntf->setDbusProperty(dbusMapping, value);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr
+            << "Error to do a ForceWarmReboot, chassis power remains on, and boot the host back up. Unable to set property RequestedHostTransition. ERROR="
+            << e.what() << "\n";
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::processPowerOffSoftGraceful()
+{
+    pldm::utils::PropertyValue value =
+        "xyz.openbmc_project.State.Chassis.Transition.Off";
+    pldm::utils::DBusMapping dbusMapping{"/xyz/openbmc_project/state/chassis0",
+                                         "xyz.openbmc_project.State.Chassis",
+                                         "RequestedPowerTransition", "string"};
+    try
+    {
+        dBusIntf->setDbusProperty(dbusMapping, value);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr
+            << "Error in powering down the host. Unable to set property RequestedPowerTransition. ERROR="
+            << e.what() << "\n";
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
+{
+    pldm::utils::PropertyValue value =
+        "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn";
+    pldm::utils::DBusMapping dbusMapping{
+        "/xyz/openbmc_project/control/host0/power_restore_policy/one_time",
+        "xyz.openbmc_project.Control.Power.RestorePolicy", "PowerRestorePolicy",
+        "string"};
+    try
+    {
+        dBusIntf->setDbusProperty(dbusMapping, value);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr
+            << "Setting one-time restore policy failed, Unable to set property PowerRestorePolicy. ERROR="
+            << e.what() << "\n";
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(bool value)
+{
+    if (hostOff)
+    {
+        return;
+    }
+    if (value)
+    {
+        timer.restart(
+            std::chrono::seconds(HEARTBEAT_TIMEOUT + HEARTBEAT_TIMEOUT_DELTA));
+    }
+    else
+    {
+        timer.setEnabled(false);
+        pldm::utils::reportError(
+            "xyz.openbmc_project.bmc.PLDM.setSurvTimer.RecvSurveillancePingFail",
+            pldm::PelSeverity::INFORMATIONAL);
+    }
+}
+
 } // namespace oem_ibm_platform
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1599,9 +1599,10 @@ void pldm::responder::oem_ibm_platform::Handler::processPowerOffHardGraceful()
     }
 }
 
-void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(bool value)
+void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
+                                                              bool value)
 {
-    if (hostOff)
+    if (tid != HYPERVISOR_TID)
     {
         return;
     }

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -689,7 +689,7 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
     codeUpdate->setFirmwareUpdateSensor(sensorId);
     sensorId =
         findStateSensorId(repo.getPdr(), 0, PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE,
-                          ENTITY_INSTANCE_0, 0, PLDM_OEM_IBM_BOOT_SIDE_RENAME);
+                          ENTITY_INSTANCE_0, 1, PLDM_OEM_IBM_BOOT_SIDE_RENAME);
     codeUpdate->setBootSideRenameStateSensor(sensorId);
 }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -32,21 +32,6 @@ using AssociatedEntityMap = std::map<ObjectPath, pldm_entity>;
 
 namespace oem_ibm_fileio
 {
-using AttributeName = std::string;
-using AttributeType = std::string;
-using ReadonlyStatus = bool;
-using DisplayName = std::string;
-using Description = std::string;
-using MenuPath = std::string;
-using CurrentValue = std::variant<int64_t, std::string>;
-using DefaultValue = std::variant<int64_t, std::string>;
-using OptionString = std::string;
-using OptionValue = std::variant<int64_t, std::string>;
-using Option = std::vector<std::tuple<OptionString, OptionValue>>;
-using BIOSTableObj =
-    std::tuple<AttributeType, ReadonlyStatus, DisplayName, Description,
-               MenuPath, CurrentValue, DefaultValue, Option>;
-using BaseBIOSTable = std::map<AttributeName, BIOSTableObj>;
 
 class Handler : public oem_fileio::Handler
 {
@@ -78,6 +63,22 @@ class Handler : public oem_fileio::Handler
 
 namespace oem_ibm_platform
 {
+using AttributeName = std::string;
+using AttributeType = std::string;
+using ReadonlyStatus = bool;
+using DisplayName = std::string;
+using Description = std::string;
+using MenuPath = std::string;
+using CurrentValue = std::variant<int64_t, std::string>;
+using DefaultValue = std::variant<int64_t, std::string>;
+using OptionString = std::string;
+using OptionValue = std::variant<int64_t, std::string>;
+using Option = std::vector<std::tuple<OptionString, OptionValue>>;
+using BIOSTableObj =
+    std::tuple<AttributeType, ReadonlyStatus, DisplayName, Description,
+               MenuPath, CurrentValue, DefaultValue, Option>;
+using BaseBIOSTable = std::map<AttributeName, BIOSTableObj>;
+
 using PendingObj = std::tuple<AttributeType, CurrentValue>;
 using PendingAttributes = std::map<AttributeName, PendingObj>;
 static constexpr auto PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577;
@@ -147,477 +148,471 @@ class Handler : public oem_platform::Handler
                 else if (propVal ==
                          "xyz.openbmc_project.State.Host.HostState.Running")
                     hostTransitioningToOff = false;
-                }
-                else if (
-                    propVal ==
-                    "xyz.openbmc_project.State.Host.HostState.TransitioningToOff")
-                {
-                    hostTransitioningToOff = true;
-                }
             }
-        });
-
-        powerStateOffMatch = std::make_unique<sdbusplus::bus::match::match>(
-            pldm::utils::DBusHandler::getBus(),
-            propertiesChanged("/xyz/openbmc_project/state/chassis0",
-                              "xyz.openbmc_project.State.Chassis"),
-            [this](sdbusplus::message_t& msg) {
-            pldm::utils::DbusChangedProps props{};
-            std::string intf;
-            msg.read(intf, props);
-            const auto itr = props.find("CurrentPowerState");
-            if (itr != props.end())
+            else if (
+                propVal ==
+                "xyz.openbmc_project.State.Host.HostState.TransitioningToOff")
             {
-                pldm::utils::PropertyValue value = itr->second;
-                auto propVal = std::get<std::string>(value);
-                if (propVal ==
-                    "xyz.openbmc_project.State.Chassis.PowerState.Off")
+                hostTransitioningToOff = true;
+            }
+            }
+    });
+
+    powerStateOffMatch = std::make_unique<sdbusplus::bus::match::match>(
+        pldm::utils::DBusHandler::getBus(),
+        propertiesChanged("/xyz/openbmc_project/state/chassis0",
+                          "xyz.openbmc_project.State.Chassis"),
+        [this](sdbusplus::message_t& msg) {
+        pldm::utils::DbusChangedProps props{};
+        std::string intf;
+        msg.read(intf, props);
+        const auto itr = props.find("CurrentPowerState");
+        if (itr != props.end())
+        {
+            pldm::utils::PropertyValue value = itr->second;
+            auto propVal = std::get<std::string>(value);
+            if (propVal == "xyz.openbmc_project.State.Chassis.PowerState.Off")
+            {
+                static constexpr auto searchpath =
+                    "/xyz/openbmc_project/inventory/system/chassis/motherboard";
+                int depth = 0;
+                std::vector<std::string> powerInterface = {
+                    "xyz.openbmc_project.State.Decorator.PowerState"};
+                pldm::utils::GetSubTreeResponse response =
+                    pldm::utils::DBusHandler().getSubtree(searchpath, depth,
+                                                          powerInterface);
+                for (const auto& [objPath, serviceMap] : response)
                 {
-                    static constexpr auto searchpath =
-                        "/xyz/openbmc_project/inventory/system/chassis/motherboard";
-                    int depth = 0;
-                    std::vector<std::string> powerInterface = {
-                        "xyz.openbmc_project.State.Decorator.PowerState"};
-                    pldm::utils::GetSubTreeResponse response =
-                        pldm::utils::DBusHandler().getSubtree(searchpath, depth,
-                                                              powerInterface);
-                    for (const auto& [objPath, serviceMap] : response)
+                    pldm::utils::DBusMapping dbusMapping{
+                        objPath,
+                        "xyz.openbmc_project.State.Decorator.PowerState",
+                        "PowerState", "string"};
+                    value =
+                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off";
+                    try
                     {
-                        pldm::utils::DBusMapping dbusMapping{
-                            objPath,
-                            "xyz.openbmc_project.State.Decorator.PowerState",
-                            "PowerState", "string"};
-                        value =
-                            "xyz.openbmc_project.State.Decorator.PowerState.State.Off";
-                        try
-                        {
-                            pldm::utils::DBusHandler().setDbusProperty(
-                                dbusMapping, value);
-                        }
-                        catch (const std::exception& e)
-                        {
-                            error(
-                                "Unable to set the slot power state to Off error - {ERROR}",
-                                "ERROR", e);
-                        }
+                        pldm::utils::DBusHandler().setDbusProperty(dbusMapping,
+                                                                   value);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        error(
+                            "Unable to set the slot power state to Off error - {ERROR}",
+                            "ERROR", e);
                     }
                 }
             }
-        });
+        }
+    });
 
-        platformSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
-            pldm::utils::DBusHandler::getBus(),
-            propertiesChanged(
-                "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
-                "xyz.openbmc_project.Led.Group"),
-            [this](sdbusplus::message_t& msg) {
-            pldm::utils::DbusChangedProps props{};
-            std::string intf;
-            msg.read(intf, props);
-            const auto itr = props.find("Asserted");
-            if (itr != props.end())
+    platformSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
+        pldm::utils::DBusHandler::getBus(),
+        propertiesChanged(
+            "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group"),
+        [this](sdbusplus::message_t& msg) {
+        pldm::utils::DbusChangedProps props{};
+        std::string intf;
+        msg.read(intf, props);
+        const auto itr = props.find("Asserted");
+        if (itr != props.end())
+        {
+            processSAIUpdate();
+        }
+    });
+
+    partitionSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
+        pldm::utils::DBusHandler::getBus(),
+        propertiesChanged(
+            "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+            "xyz.openbmc_project.Led.Group"),
+        [this](sdbusplus::message_t& msg) {
+        pldm::utils::DbusChangedProps props{};
+        std::string intf;
+        msg.read(intf, props);
+        const auto itr = props.find("Asserted");
+        if (itr != props.end())
+        {
+            processSAIUpdate();
+        }
+    });
+    updateBIOSMatch = std::make_unique<sdbusplus::bus::match::match>(
+        pldm::utils::DBusHandler::getBus(),
+        propertiesChanged("/xyz/openbmc_project/bios_config/manager",
+                          "xyz.openbmc_project.BIOSConfig.Manager"),
+        [this, codeUpdate](sdbusplus::message::message& msg) {
+        constexpr auto propertyName = "PendingAttributes";
+        using Value =
+            std::variant<std::string, PendingAttributes, BaseBIOSTable>;
+        using Properties = std::map<pldm::utils::DbusProp, Value>;
+        Properties props{};
+        std::string intf;
+        msg.read(intf, props);
+
+        auto valPropMap = props.find(propertyName);
+        if (valPropMap == props.end())
+        {
+            return;
+        }
+
+        PendingAttributes pendingAttributes =
+            std::get<PendingAttributes>(valPropMap->second);
+        for (auto it : pendingAttributes)
+        {
+            if (it.first == "fw_boot_side")
             {
-                processSAIUpdate();
+                auto& [attributeType, attributevalue] = it.second;
+                std::string nextBootSide =
+                    std::get<std::string>(attributevalue);
+                codeUpdate->setNextBootSide(nextBootSide);
             }
-        });
-
-        partitionSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
-            pldm::utils::DBusHandler::getBus(),
-            propertiesChanged(
-                "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
-                "xyz.openbmc_project.Led.Group"),
-            [this](sdbusplus::message_t& msg) {
-            pldm::utils::DbusChangedProps props{};
-            std::string intf;
-            msg.read(intf, props);
-            const auto itr = props.find("Asserted");
-            if (itr != props.end())
-            {
-                processSAIUpdate();
-            }
-        });
-        updateBIOSMatch = std::make_unique<sdbusplus::bus::match::match>(
-            pldm::utils::DBusHandler::getBus(),
-            propertiesChanged("/xyz/openbmc_project/bios_config/manager",
-                              "xyz.openbmc_project.BIOSConfig.Manager"),
-            [this, codeUpdate](sdbusplus::message::message& msg) {
-                constexpr auto propertyName = "PendingAttributes";
-                using Value =
-                    std::variant<std::string, PendingAttributes, BaseBIOSTable>;
-                using Properties = std::map<pldm::utils::DbusProp, Value>;
-                Properties props{};
-                std::string intf;
-                msg.read(intf, props);
-
-                auto valPropMap = props.find(propertyName);
-                if (valPropMap == props.end())
-                {
-                    return;
-                }
-
-                PendingAttributes pendingAttributes =
-                    std::get<PendingAttributes>(valPropMap->second);
-                for (auto it : pendingAttributes)
-                {
-                    if (it.first == "fw_boot_side")
-                    {
-                        auto& [attributeType, attributevalue] = it.second;
-                        std::string nextBootSide =
-                            std::get<std::string>(attributevalue);
-                        codeUpdate->setNextBootSide(nextBootSide);
-                    }
-                }
-            });
-        ibmCompatibleMatch = std::make_unique<sdbusplus::bus::match::match>(
-            pldm::utils::DBusHandler::getBus(),
-            sdbusplus::bus::match::rules::interfacesAdded() +
-                sdbusplus::bus::match::rules::sender(
-                    "xyz.openbmc_project.EntityManager"),
-            std::bind(&Handler::ibmCompatibleAddedCallback, this,
-                      std::placeholders::_1));
-
-        stateManagerMatch = std::make_unique<sdbusplus::bus::match::match>(
-            pldm::utils::DBusHandler::getBus(),
-            sdbusplus::bus::match::rules::interfacesAdded() +
-                sdbusplus::bus::match::rules::argNpath(
-                    0, "/xyz/openbmc_project/state/host0"),
-            [this](sdbusplus::message::message& msg) {
-                sdbusplus::message::object_path path;
-                std::map<std::string, std::map<std::string, dbus::Value>>
-                    interfaces;
-                msg.read(path, interfaces);
-
-                for (auto interface : interfaces)
-                {
-                    std::cout << interface.first;
-                }
-                if (!interfaces.contains("xyz.openbmc_project.State.Host"))
-                {
-                    return;
-                }
-
-                const auto& properties =
-                    interfaces.at("xyz.openbmc_project.State.Host");
-
-                if (!properties.contains("RestartCause"))
-                {
-                    return;
-                }
-
-                restartCause =
-                    std::get<std::string>(properties.at("RestartCause"));
-                setBootTypesBiosAttr(restartCause);
-            });
-    }
-
-    int getOemStateSensorReadingsHandler(
-        pldm::pdr::EntityType entityType,
-        pldm::pdr::EntityInstance entityInstance,
-        pldm::pdr::ContainerID containerId, pldm::pdr::StateSetId stateSetId,
-        pldm::pdr::CompositeCount compSensorCnt, uint16_t sensorId,
-        std::vector<get_sensor_state_field>& stateField);
-
-    int oemSetStateEffecterStatesHandler(
-        uint16_t entityType, uint16_t entityInstance, uint16_t stateSetId,
-        uint8_t compEffecterCnt,
-        std::vector<set_effecter_state_field>& stateField, uint16_t effecterId);
-
-    /** @brief Method to set the platform handler in the
-     *         oem_ibm_handler class
-     *  @param[in] handler - pointer to PLDM platform handler
-     */
-    void setPlatformHandler(pldm::responder::platform::Handler* handler);
-
-    /** @brief Method to fetch the effecter ID of the code update PDRs
-     *
-     * @return platformHandler->getNextEffecterId() - returns the
-     *             effecter ID from the platform handler
-     */
-    virtual uint16_t getNextEffecterId()
-    {
-        return platformHandler->getNextEffecterId();
-    }
-
-    /** @brief Method to fetch the sensor ID of the code update PDRs
-     *
-     * @return platformHandler->getNextSensorId() - returns the
-     *             Sensor ID from the platform handler
-     */
-    virtual uint16_t getNextSensorId()
-    {
-        return platformHandler->getNextSensorId();
-    }
-
-    /** @brief Get std::map associated with the entity
-     *         key: object path
-     *         value: pldm_entity
-     *
-     *  @return std::map<ObjectPath, pldm_entity>
-     */
-    virtual const AssociatedEntityMap& getAssociateEntityMap()
-    {
-        return platformHandler->getAssociateEntityMap();
-    }
-
-    /** @brief Method to Generate the OEM PDRs
-     *
-     * @param[in] repo - instance of concrete implementation of Repo
-     */
-    void buildOEMPDR(pdr_utils::Repo& repo);
-
-    /** @brief Method to send code update event to host
-     * @param[in] sensorId - sendor ID
-     * @param[in] sensorEventClass - event class of sensor
-     * @param[in] sensorOffset - sensor offset
-     * @param[in] eventState - new code update event state
-     * @param[in] prevEventState - previous code update event state
-     * @return none
-     */
-    void sendStateSensorEvent(uint16_t sensorId,
-                              enum sensor_event_class_states sensorEventClass,
-                              uint8_t sensorOffset, uint8_t eventState,
-                              uint8_t prevEventState);
-
-    /** @brief Method to send encoded request msg of code update event to host
-     *  @param[in] requestMsg - encoded request msg
-     *  @param[in] instanceId - instance id of the message
-     *  @return PLDM status code
-     */
-    int sendEventToHost(std::vector<uint8_t>& requestMsg, uint8_t instanceId);
-
-    /** @brief _processEndUpdate processes the actual work that needs
-     *  to be carried out after EndUpdate effecter is set. This is done async
-     *  after sending response for EndUpdate set effecter
-     *  @param[in] source - sdeventplus event source
-     */
-    void _processEndUpdate(sdeventplus::source::EventBase& source);
-
-    /** @brief _processStartUpdate processes the actual work that needs
-     *  to be carried out after StartUpdate effecter is set. This is done async
-     *  after sending response for StartUpdate set effecter
-     *  @param[in] source - sdeventplus event source
-     */
-    void _processStartUpdate(sdeventplus::source::EventBase& source);
-
-    /** @brief _processSystemReboot processes the actual work that needs to be
-     *  carried out after the System Power State effecter is set to reboot
-     *  the system
-     *  @param[in] source - sdeventplus event source
-     */
-    void _processSystemReboot(sdeventplus::source::EventBase& source);
-
-    /*keeps track how many times setEventReceiver is sent */
-    void countSetEventReceiver()
-    {
-        setEventReceiverCnt++;
-    }
-
-    /* disables watchdog if running and Host is up */
-    void checkAndDisableWatchDog();
-
-    /** @brief To check if the watchdog app is running
-     *
-     *  @return the running status of watchdog app
-     */
-    bool watchDogRunning();
-
-    /** @brief Method to reset the Watchdog timer on receiving platform Event
-     *  Message for heartbeat elapsed time from Hostboot
-     */
-    void resetWatchDogTimer();
-
-    /** @brief To disable to the watchdog timer on host poweron completion*/
-    void disableWatchDogTimer();
-
-    /** @brief to check the BMC state*/
-    int checkBMCState();
-
-    /** @brief update the dbus object paths */
-    void updateOemDbusPaths(std::string& dbusPath);
-
-    /** @brief Method to fetch the last BMC record from the PDR repo
-     *
-     * @param[in] repo - pointer to BMC's primary PDR repo
-     *
-     * @return the last BMC record from the repo
-     */
-    const pldm_pdr_record* fetchLastBMCRecord(const pldm_pdr* repo);
-
-    /** @brief Method to check if the record handle passed is in remote PDR
-     *         record handle range
-     *
-     *  @param[in] record_handle - record handle of the PDR
-     *
-     *  @return true if record handle passed is in host PDR record handle range
-     */
-    bool checkRecordHandleInRange(const uint32_t& record_handle);
-
-    /** *brief Method to call the setEventReceiver command*/
-    void processSetEventReceiver();
-
-    /** @brief Method to call the setEventReceiver through the platform
-     *   handler
-     */
-    virtual void setEventReceiver()
-    {
-        platformHandler->setEventReceiver();
-    }
-
-    /** @brief To process the graceful shutdown, cycle chassis power, and boot
-     *  the host back up*/
-    void processPowerCycleOffSoftGraceful();
-
-    /** @brief To process powering down the host*/
-    void processPowerOffSoftGraceful();
-
-    /** @brief To process auto power restore policy*/
-    void processPowerOffHardGraceful();
-
-    /** @brief Method to Enable/Disable timer to see if remote terminus sends
-     *  the surveillance ping and logs informational error if remote terminus
-     *  fails to send the surveillance pings
-     *
-     * @param[in] tid - TID of the remote terminus
-     * @param[in] value - true or false, to indicate if the timer is
-     *                    running or not
-     */
-    void setSurvTimer(uint8_t tid, bool value);
-
-    /** @brief To turn off Real SAI effecter*/
-    void turnOffRealSAIEffecter();
-
-    /** @brief Fetch Real SAI status based on the partition SAI and platform SAI
-     *  sensor states. Real SAI is turned on if any of the partition or platform
-     *  SAI turned on else Real SAI is turned off
-     *  @return Real SAI sensor state PLDM_SENSOR_WARNING/PLDM_SENSOR_NORMAL
-     */
-    uint8_t fetchRealSAIStatus();
-
-    /** @brief Method to process virtual platform/partition SAI update*/
-    void processSAIUpdate();
-
-    /** @brief Method to perform actions when PLDM_RECORDS_MODIFIED event
-     *  is received from host
-     *  @param[in] entityType - entity type
-     *  @param[in] stateSetId - state set id
-     */
-    void modifyPDROemActions(uint16_t entityType, uint16_t stateSetId);
-
-    /** @brief D-Bus Method call to call the Panel D-Bus API
-     *
-     * @param[in] objPath - The D-Bus object path
-     * @param[in] dbusMethod - The Method name to be invoked
-     * @param[in] dbusInterface - The D-Bus interface
-     * @param[in] value - The value to be passed as argument
-     *            to D-Bus method
-     */
-    void setBitmapMethodCall(const std::string& objPath,
-                             const std::string& dbusMethod,
-                             const std::string& dbusInterface,
-                             const pldm::utils::PropertyValue& value);
-
-    /** @brief To handle the boot types bios attributes at power on*/
-    void handleBootTypesAtPowerOn();
-
-    /** @brief To set the boot types bios attributes based on the RestartCause
-     *  of host
-     *
-     *  @param[in] RestartCause - Host restart cause
-     */
-    void setBootTypesBiosAttr(const std::string& restartCause);
-
-    /** @brief To handle the boot types bios attributes at shutdown*/
-    void handleBootTypesAtChassisOff();
-
-    ~Handler() = default;
-
-    pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object
-
-    pldm::responder::SlotHandler*
-        slotHandler; //!< pointer to SlotHandler object
-
-    pldm::responder::platform::Handler*
-        platformHandler; //!< pointer to PLDM platform handler
-
-    /** @brief fd of MCTP communications socket */
-    int mctp_fd;
-
-    /** @brief MCTP EID of host firmware */
-    uint8_t mctp_eid;
-
-    /** @brief reference to an InstanceIdDb object, used to obtain a PLDM
-     * instance id. */
-    pldm::InstanceIdDb& instanceIdDb;
-    /** @brief sdeventplus event source */
-    std::unique_ptr<sdeventplus::source::Defer> assembleImageEvent;
-    std::unique_ptr<sdeventplus::source::Defer> startUpdateEvent;
-    std::unique_ptr<sdeventplus::source::Defer> systemRebootEvent;
-
-    /** @brief Effecterid to dbus object path map
-     */
-    std::unordered_map<uint16_t, std::string> effecterIdToDbusMap;
-
-    /** @brief reference of main event loop of pldmd, primarily used to schedule
-     *  work
-     */
-    sdeventplus::Event& event;
-
-  private:
-    /** @brief Method to reset or stop the surveillance timer
-     *
-     * @param[in] value - true or false, to indicate if the timer
-     *                    should be reset or turned off
-     */
-    void startStopTimer(bool value);
-
-    /*@brief Host restart cause*/
-    std::string restartCause;
-
-    /** @brief D-Bus property changed signal match for CurrentPowerState*/
-    std::unique_ptr<sdbusplus::bus::match_t> chassisOffMatch;
-
-    const pldm_pdr* pdrRepo;
-
-    /** @brief PLDM request handler */
-    pldm::requester::Handler<pldm::requester::Request>* handler;
-
-    /** @brief Pointer to BMC's entity association tree */
-    pldm_entity_association_tree* bmcEntityTree;
-    /** @brief D-Bus property changed signal match */
-    std::unique_ptr<sdbusplus::bus::match::match> hostOffMatch;
-    std::unique_ptr<sdbusplus::bus::match::match> updateBIOSMatch;
-
-    /** @brief D-Bus property changed signal match */
-    std::unique_ptr<sdbusplus::bus::match_t> hostOffMatch;
-
-    /** @brief D-Bus property changed signal match */
-    std::unique_ptr<sdbusplus::bus::match_t> powerStateOffMatch;
-
-    /** @brief D-Bus Interface added signal match for virtual platform SAI */
-    std::unique_ptr<sdbusplus::bus::match_t> platformSAIMatch;
-
-    /** @brief D-Bus Interface added signal match for virtual partition SAI */
-    std::unique_ptr<sdbusplus::bus::match_t> partitionSAIMatch;
-
-    /** @brief Timer used for monitoring surveillance pings from host */
-    sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
-    /** @brief D-Bus Interfaced added signal match for Entity Manager */
-    std::unique_ptr<sdbusplus::bus::match::match> ibmCompatibleMatch;
-    /** @brief D-Bus Interfaced added signal match for State Manager */
-    std::unique_ptr<sdbusplus::bus::match::match> stateManagerMatch;
-    /** @brief D-Bus property Changed Signal match for bootProgress*/
-    std::unique_ptr<sdbusplus::bus::match::match> bootProgressMatch;
-
-    bool hostOff = true;
-
-    bool hostTransitioningToOff;
-
-    int setEventReceiverCnt = 0;
-
-    /** @brief Real SAI sensor id*/
-    uint16_t realSAISensorId;
-
-    std::unique_ptr<pldm::responder::oem_fileio::Handler> dbusToFileioIntf;
+        }
+    });
+    ibmCompatibleMatch = std::make_unique<sdbusplus::bus::match::match>(
+        pldm::utils::DBusHandler::getBus(),
+        sdbusplus::bus::match::rules::interfacesAdded() +
+            sdbusplus::bus::match::rules::sender(
+                "xyz.openbmc_project.EntityManager"),
+        std::bind(&Handler::ibmCompatibleAddedCallback, this,
+                  std::placeholders::_1));
+
+    stateManagerMatch = std::make_unique<sdbusplus::bus::match::match>(
+        pldm::utils::DBusHandler::getBus(),
+        sdbusplus::bus::match::rules::interfacesAdded() +
+            sdbusplus::bus::match::rules::argNpath(
+                0, "/xyz/openbmc_project/state/host0"),
+        [this](sdbusplus::message::message& msg) {
+        sdbusplus::message::object_path path;
+        std::map<std::string, std::map<std::string, dbus::Value>> interfaces;
+        msg.read(path, interfaces);
+
+        for (auto interface : interfaces)
+        {
+            std::cout << interface.first;
+        }
+        if (!interfaces.contains("xyz.openbmc_project.State.Host"))
+        {
+            return;
+        }
+
+        const auto& properties =
+            interfaces.at("xyz.openbmc_project.State.Host");
+
+        if (!properties.contains("RestartCause"))
+        {
+            return;
+        }
+
+        restartCause = std::get<std::string>(properties.at("RestartCause"));
+        setBootTypesBiosAttr(restartCause);
+    });
+}
+
+int getOemStateSensorReadingsHandler(
+    pldm::pdr::EntityType entityType, pldm::pdr::EntityInstance entityInstance,
+    pldm::pdr::ContainerID containerId, pldm::pdr::StateSetId stateSetId,
+    pldm::pdr::CompositeCount compSensorCnt, uint16_t sensorId,
+    std::vector<get_sensor_state_field>& stateField);
+
+int oemSetStateEffecterStatesHandler(
+    uint16_t entityType, uint16_t entityInstance, uint16_t stateSetId,
+    uint8_t compEffecterCnt, std::vector<set_effecter_state_field>& stateField,
+    uint16_t effecterId);
+
+/** @brief Method to set the platform handler in the
+ *         oem_ibm_handler class
+ *  @param[in] handler - pointer to PLDM platform handler
+ */
+void setPlatformHandler(pldm::responder::platform::Handler* handler);
+
+/** @brief Method to fetch the effecter ID of the code update PDRs
+ *
+ * @return platformHandler->getNextEffecterId() - returns the
+ *             effecter ID from the platform handler
+ */
+virtual uint16_t getNextEffecterId()
+{
+    return platformHandler->getNextEffecterId();
+}
+
+/** @brief Method to fetch the sensor ID of the code update PDRs
+ *
+ * @return platformHandler->getNextSensorId() - returns the
+ *             Sensor ID from the platform handler
+ */
+virtual uint16_t getNextSensorId()
+{
+    return platformHandler->getNextSensorId();
+}
+
+/** @brief Get std::map associated with the entity
+ *         key: object path
+ *         value: pldm_entity
+ *
+ *  @return std::map<ObjectPath, pldm_entity>
+ */
+virtual const AssociatedEntityMap& getAssociateEntityMap()
+{
+    return platformHandler->getAssociateEntityMap();
+}
+
+/** @brief Method to Generate the OEM PDRs
+ *
+ * @param[in] repo - instance of concrete implementation of Repo
+ */
+void buildOEMPDR(pdr_utils::Repo& repo);
+
+/** @brief Method to send code update event to host
+ * @param[in] sensorId - sendor ID
+ * @param[in] sensorEventClass - event class of sensor
+ * @param[in] sensorOffset - sensor offset
+ * @param[in] eventState - new code update event state
+ * @param[in] prevEventState - previous code update event state
+ * @return none
+ */
+void sendStateSensorEvent(uint16_t sensorId,
+                          enum sensor_event_class_states sensorEventClass,
+                          uint8_t sensorOffset, uint8_t eventState,
+                          uint8_t prevEventState);
+
+/** @brief Method to send encoded request msg of code update event to host
+ *  @param[in] requestMsg - encoded request msg
+ *  @param[in] instanceId - instance id of the message
+ *  @return PLDM status code
+ */
+int sendEventToHost(std::vector<uint8_t>& requestMsg, uint8_t instanceId);
+
+/** @brief _processEndUpdate processes the actual work that needs
+ *  to be carried out after EndUpdate effecter is set. This is done async
+ *  after sending response for EndUpdate set effecter
+ *  @param[in] source - sdeventplus event source
+ */
+void _processEndUpdate(sdeventplus::source::EventBase& source);
+
+/** @brief _processStartUpdate processes the actual work that needs
+ *  to be carried out after StartUpdate effecter is set. This is done async
+ *  after sending response for StartUpdate set effecter
+ *  @param[in] source - sdeventplus event source
+ */
+void _processStartUpdate(sdeventplus::source::EventBase& source);
+
+/** @brief _processSystemReboot processes the actual work that needs to be
+ *  carried out after the System Power State effecter is set to reboot
+ *  the system
+ *  @param[in] source - sdeventplus event source
+ */
+void _processSystemReboot(sdeventplus::source::EventBase& source);
+
+/*keeps track how many times setEventReceiver is sent */
+void countSetEventReceiver()
+{
+    setEventReceiverCnt++;
+}
+
+/* disables watchdog if running and Host is up */
+void checkAndDisableWatchDog();
+
+/** @brief To check if the watchdog app is running
+ *
+ *  @return the running status of watchdog app
+ */
+bool watchDogRunning();
+
+/** @brief Method to reset the Watchdog timer on receiving platform Event
+ *  Message for heartbeat elapsed time from Hostboot
+ */
+void resetWatchDogTimer();
+
+/** @brief To disable to the watchdog timer on host poweron completion*/
+void disableWatchDogTimer();
+
+/** @brief to check the BMC state*/
+int checkBMCState();
+
+/** @brief update the dbus object paths */
+void updateOemDbusPaths(std::string& dbusPath);
+
+/** @brief Method to fetch the last BMC record from the PDR repo
+ *
+ * @param[in] repo - pointer to BMC's primary PDR repo
+ *
+ * @return the last BMC record from the repo
+ */
+const pldm_pdr_record* fetchLastBMCRecord(const pldm_pdr* repo);
+
+/** @brief Method to check if the record handle passed is in remote PDR
+ *         record handle range
+ *
+ *  @param[in] record_handle - record handle of the PDR
+ *
+ *  @return true if record handle passed is in host PDR record handle range
+ */
+bool checkRecordHandleInRange(const uint32_t& record_handle);
+
+/** *brief Method to call the setEventReceiver command*/
+void processSetEventReceiver();
+
+/** @brief Method to call the setEventReceiver through the platform
+ *   handler
+ */
+virtual void setEventReceiver()
+{
+    platformHandler->setEventReceiver();
+}
+
+/** @brief To process the graceful shutdown, cycle chassis power, and boot
+ *  the host back up*/
+void processPowerCycleOffSoftGraceful();
+
+/** @brief To process powering down the host*/
+void processPowerOffSoftGraceful();
+
+/** @brief To process auto power restore policy*/
+void processPowerOffHardGraceful();
+
+/** @brief Method to Enable/Disable timer to see if remote terminus sends
+ *  the surveillance ping and logs informational error if remote terminus
+ *  fails to send the surveillance pings
+ *
+ * @param[in] tid - TID of the remote terminus
+ * @param[in] value - true or false, to indicate if the timer is
+ *                    running or not
+ */
+void setSurvTimer(uint8_t tid, bool value);
+
+/** @brief To turn off Real SAI effecter*/
+void turnOffRealSAIEffecter();
+
+/** @brief Fetch Real SAI status based on the partition SAI and platform SAI
+ *  sensor states. Real SAI is turned on if any of the partition or platform
+ *  SAI turned on else Real SAI is turned off
+ *  @return Real SAI sensor state PLDM_SENSOR_WARNING/PLDM_SENSOR_NORMAL
+ */
+uint8_t fetchRealSAIStatus();
+
+/** @brief Method to process virtual platform/partition SAI update*/
+void processSAIUpdate();
+
+/** @brief Method to perform actions when PLDM_RECORDS_MODIFIED event
+ *  is received from host
+ *  @param[in] entityType - entity type
+ *  @param[in] stateSetId - state set id
+ */
+void modifyPDROemActions(uint16_t entityType, uint16_t stateSetId);
+
+/** @brief D-Bus Method call to call the Panel D-Bus API
+ *
+ * @param[in] objPath - The D-Bus object path
+ * @param[in] dbusMethod - The Method name to be invoked
+ * @param[in] dbusInterface - The D-Bus interface
+ * @param[in] value - The value to be passed as argument
+ *            to D-Bus method
+ */
+void setBitmapMethodCall(const std::string& objPath,
+                         const std::string& dbusMethod,
+                         const std::string& dbusInterface,
+                         const pldm::utils::PropertyValue& value);
+
+/** @brief To handle the boot types bios attributes at power on*/
+void handleBootTypesAtPowerOn();
+
+/** @brief To set the boot types bios attributes based on the RestartCause
+ *  of host
+ *
+ *  @param[in] RestartCause - Host restart cause
+ */
+void setBootTypesBiosAttr(const std::string& restartCause);
+
+/** @brief To handle the boot types bios attributes at shutdown*/
+void handleBootTypesAtChassisOff();
+
+~Handler() = default;
+
+pldm::responder::CodeUpdate* codeUpdate;   //!< pointer to CodeUpdate object
+
+pldm::responder::SlotHandler* slotHandler; //!< pointer to SlotHandler object
+
+pldm::responder::platform::Handler*
+    platformHandler; //!< pointer to PLDM platform handler
+
+/** @brief fd of MCTP communications socket */
+int mctp_fd;
+
+/** @brief MCTP EID of host firmware */
+uint8_t mctp_eid;
+
+/** @brief reference to an InstanceIdDb object, used to obtain a PLDM
+ * instance id. */
+pldm::InstanceIdDb& instanceIdDb;
+/** @brief sdeventplus event source */
+std::unique_ptr<sdeventplus::source::Defer> assembleImageEvent;
+std::unique_ptr<sdeventplus::source::Defer> startUpdateEvent;
+std::unique_ptr<sdeventplus::source::Defer> systemRebootEvent;
+
+/** @brief Effecterid to dbus object path map
+ */
+std::unordered_map<uint16_t, std::string> effecterIdToDbusMap;
+
+/** @brief reference of main event loop of pldmd, primarily used to schedule
+ *  work
+ */
+sdeventplus::Event& event;
+
+private:
+/** @brief Method to reset or stop the surveillance timer
+ *
+ * @param[in] value - true or false, to indicate if the timer
+ *                    should be reset or turned off
+ */
+void startStopTimer(bool value);
+
+/*@brief Host restart cause*/
+std::string restartCause;
+
+/** @brief D-Bus property changed signal match for CurrentPowerState*/
+std::unique_ptr<sdbusplus::bus::match_t> chassisOffMatch;
+
+const pldm_pdr* pdrRepo;
+
+/** @brief PLDM request handler */
+pldm::requester::Handler<pldm::requester::Request>* handler;
+
+/** @brief Pointer to BMC's entity association tree */
+pldm_entity_association_tree* bmcEntityTree;
+/** @brief D-Bus property changed signal match */
+std::unique_ptr<sdbusplus::bus::match_t> updateBIOSMatch;
+
+/** @brief D-Bus property changed signal match */
+std::unique_ptr<sdbusplus::bus::match_t> hostOffMatch;
+
+/** @brief D-Bus property changed signal match */
+std::unique_ptr<sdbusplus::bus::match_t> powerStateOffMatch;
+
+/** @brief D-Bus Interface added signal match for virtual platform SAI */
+std::unique_ptr<sdbusplus::bus::match_t> platformSAIMatch;
+
+/** @brief D-Bus Interface added signal match for virtual partition SAI */
+std::unique_ptr<sdbusplus::bus::match_t> partitionSAIMatch;
+
+/** @brief Timer used for monitoring surveillance pings from host */
+sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
+/** @brief D-Bus Interfaced added signal match for Entity Manager */
+std::unique_ptr<sdbusplus::bus::match_t> ibmCompatibleMatch;
+/** @brief D-Bus Interfaced added signal match for State Manager */
+std::unique_ptr<sdbusplus::bus::match_t> stateManagerMatch;
+/** @brief D-Bus property Changed Signal match for bootProgress*/
+std::unique_ptr<sdbusplus::bus::match_t> bootProgressMatch;
+
+bool hostOff = true;
+
+bool hostTransitioningToOff;
+
+int setEventReceiverCnt = 0;
+
+/** @brief Real SAI sensor id*/
+uint16_t realSAISensorId;
+
+std::unique_ptr<pldm::responder::oem_fileio::Handler> dbusToFileioIntf;
 };
 
 /** @brief Method to encode code update event msg

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -81,7 +81,6 @@ using BaseBIOSTable = std::map<AttributeName, BIOSTableObj>;
 
 using PendingObj = std::tuple<AttributeType, CurrentValue>;
 using PendingAttributes = std::map<AttributeName, PendingObj>;
-static constexpr auto PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577;
 static constexpr auto PLDM_OEM_IBM_FRONT_PANEL_TRIGGER = 32837;
 constexpr uint16_t ENTITY_INSTANCE_0 = 0;
 constexpr uint16_t ENTITY_INSTANCE_1 = 1;
@@ -165,451 +164,455 @@ class Handler : public oem_platform::Handler
             }
         });
 
-    powerStateOffMatch = std::make_unique<sdbusplus::bus::match::match>(
-        pldm::utils::DBusHandler::getBus(),
-        propertiesChanged("/xyz/openbmc_project/state/chassis0",
-                          "xyz.openbmc_project.State.Chassis"),
-        [this](sdbusplus::message_t& msg) {
-        pldm::utils::DbusChangedProps props{};
-        std::string intf;
-        msg.read(intf, props);
-        const auto itr = props.find("CurrentPowerState");
-        if (itr != props.end())
-        {
-            pldm::utils::PropertyValue value = itr->second;
-            auto propVal = std::get<std::string>(value);
-            if (propVal == "xyz.openbmc_project.State.Chassis.PowerState.Off")
+        powerStateOffMatch = std::make_unique<sdbusplus::bus::match::match>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged("/xyz/openbmc_project/state/chassis0",
+                              "xyz.openbmc_project.State.Chassis"),
+            [this](sdbusplus::message_t& msg) {
+            pldm::utils::DbusChangedProps props{};
+            std::string intf;
+            msg.read(intf, props);
+            const auto itr = props.find("CurrentPowerState");
+            if (itr != props.end())
             {
-                static constexpr auto searchpath =
-                    "/xyz/openbmc_project/inventory/system/chassis/motherboard";
-                int depth = 0;
-                std::vector<std::string> powerInterface = {
-                    "xyz.openbmc_project.State.Decorator.PowerState"};
-                pldm::utils::GetSubTreeResponse response =
-                    pldm::utils::DBusHandler().getSubtree(searchpath, depth,
-                                                          powerInterface);
-                for (const auto& [objPath, serviceMap] : response)
+                pldm::utils::PropertyValue value = itr->second;
+                auto propVal = std::get<std::string>(value);
+                if (propVal ==
+                    "xyz.openbmc_project.State.Chassis.PowerState.Off")
                 {
-                    pldm::utils::DBusMapping dbusMapping{
-                        objPath,
-                        "xyz.openbmc_project.State.Decorator.PowerState",
-                        "PowerState", "string"};
-                    value =
-                        "xyz.openbmc_project.State.Decorator.PowerState.State.Off";
-                    try
+                    static constexpr auto searchpath =
+                        "/xyz/openbmc_project/inventory/system/chassis/motherboard";
+                    int depth = 0;
+                    std::vector<std::string> powerInterface = {
+                        "xyz.openbmc_project.State.Decorator.PowerState"};
+                    pldm::utils::GetSubTreeResponse response =
+                        pldm::utils::DBusHandler().getSubtree(searchpath, depth,
+                                                              powerInterface);
+                    for (const auto& [objPath, serviceMap] : response)
                     {
-                        pldm::utils::DBusHandler().setDbusProperty(dbusMapping,
-                                                                   value);
-                    }
-                    catch (const std::exception& e)
-                    {
-                        error(
-                            "Unable to set the slot power state to Off error - {ERROR}",
-                            "ERROR", e);
+                        pldm::utils::DBusMapping dbusMapping{
+                            objPath,
+                            "xyz.openbmc_project.State.Decorator.PowerState",
+                            "PowerState", "string"};
+                        value =
+                            "xyz.openbmc_project.State.Decorator.PowerState.State.Off";
+                        try
+                        {
+                            pldm::utils::DBusHandler().setDbusProperty(
+                                dbusMapping, value);
+                        }
+                        catch (const std::exception& e)
+                        {
+                            error(
+                                "Unable to set the slot power state to Off error - {ERROR}",
+                                "ERROR", e);
+                        }
                     }
                 }
             }
-        }
-    });
+        });
 
-    platformSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
-        pldm::utils::DBusHandler::getBus(),
-        propertiesChanged(
-            "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
-            "xyz.openbmc_project.Led.Group"),
-        [this](sdbusplus::message_t& msg) {
-        pldm::utils::DbusChangedProps props{};
-        std::string intf;
-        msg.read(intf, props);
-        const auto itr = props.find("Asserted");
-        if (itr != props.end())
-        {
-            processSAIUpdate();
-        }
-    });
-
-    partitionSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
-        pldm::utils::DBusHandler::getBus(),
-        propertiesChanged(
-            "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
-            "xyz.openbmc_project.Led.Group"),
-        [this](sdbusplus::message_t& msg) {
-        pldm::utils::DbusChangedProps props{};
-        std::string intf;
-        msg.read(intf, props);
-        const auto itr = props.find("Asserted");
-        if (itr != props.end())
-        {
-            processSAIUpdate();
-        }
-    });
-    updateBIOSMatch = std::make_unique<sdbusplus::bus::match::match>(
-        pldm::utils::DBusHandler::getBus(),
-        propertiesChanged("/xyz/openbmc_project/bios_config/manager",
-                          "xyz.openbmc_project.BIOSConfig.Manager"),
-        [this, codeUpdate](sdbusplus::message::message& msg) {
-        constexpr auto propertyName = "PendingAttributes";
-        using Value =
-            std::variant<std::string, PendingAttributes, BaseBIOSTable>;
-        using Properties = std::map<pldm::utils::DbusProp, Value>;
-        Properties props{};
-        std::string intf;
-        msg.read(intf, props);
-
-        auto valPropMap = props.find(propertyName);
-        if (valPropMap == props.end())
-        {
-            return;
-        }
-
-        PendingAttributes pendingAttributes =
-            std::get<PendingAttributes>(valPropMap->second);
-        for (auto it : pendingAttributes)
-        {
-            if (it.first == "fw_boot_side")
+        platformSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged(
+                "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
+                "xyz.openbmc_project.Led.Group"),
+            [this](sdbusplus::message_t& msg) {
+            pldm::utils::DbusChangedProps props{};
+            std::string intf;
+            msg.read(intf, props);
+            const auto itr = props.find("Asserted");
+            if (itr != props.end())
             {
-                auto& [attributeType, attributevalue] = it.second;
-                std::string nextBootSide =
-                    std::get<std::string>(attributevalue);
-                codeUpdate->setNextBootSide(nextBootSide);
+                processSAIUpdate();
             }
-        }
-    });
-
-    stateManagerMatch = std::make_unique<sdbusplus::bus::match::match>(
-        pldm::utils::DBusHandler::getBus(),
-        sdbusplus::bus::match::rules::interfacesAdded() +
-            sdbusplus::bus::match::rules::argNpath(
-                0, "/xyz/openbmc_project/state/host0"),
-        [this](sdbusplus::message::message& msg) {
-        sdbusplus::message::object_path path;
-        std::map<std::string, std::map<std::string, dbus::Value>> interfaces;
-        msg.read(path, interfaces);
-
-        for (auto interface : interfaces)
-        {
-            std::cout << interface.first;
-        }
-        if (!interfaces.contains("xyz.openbmc_project.State.Host"))
-        {
-            return;
-        }
-
-        const auto& properties =
-            interfaces.at("xyz.openbmc_project.State.Host");
-
-        if (!properties.contains("RestartCause"))
-        {
-            return;
-        }
-
-        restartCause = std::get<std::string>(properties.at("RestartCause"));
-        setBootTypesBiosAttr(restartCause);
-    });
-}
-
-int getOemStateSensorReadingsHandler(
-    pldm::pdr::EntityType entityType, pldm::pdr::EntityInstance entityInstance,
-    pldm::pdr::ContainerID containerId, pldm::pdr::StateSetId stateSetId,
-    pldm::pdr::CompositeCount compSensorCnt, uint16_t sensorId,
-    std::vector<get_sensor_state_field>& stateField);
-
-int oemSetStateEffecterStatesHandler(
-    uint16_t entityType, uint16_t entityInstance, uint16_t stateSetId,
-    uint8_t compEffecterCnt, std::vector<set_effecter_state_field>& stateField,
-    uint16_t effecterId);
-
-/** @brief Method to set the platform handler in the
- *         oem_ibm_handler class
- *  @param[in] handler - pointer to PLDM platform handler
- */
-void setPlatformHandler(pldm::responder::platform::Handler* handler);
-
-/** @brief Method to fetch the effecter ID of the code update PDRs
- *
- * @return platformHandler->getNextEffecterId() - returns the
- *             effecter ID from the platform handler
- */
-virtual uint16_t getNextEffecterId()
-{
-    return platformHandler->getNextEffecterId();
-}
-
-/** @brief Method to fetch the sensor ID of the code update PDRs
- *
- * @return platformHandler->getNextSensorId() - returns the
- *             Sensor ID from the platform handler
- */
-virtual uint16_t getNextSensorId()
-{
-    return platformHandler->getNextSensorId();
-}
-
-/** @brief Get std::map associated with the entity
- *         key: object path
- *         value: pldm_entity
- *
- *  @return std::map<ObjectPath, pldm_entity>
- */
-virtual const AssociatedEntityMap& getAssociateEntityMap()
-{
-    return platformHandler->getAssociateEntityMap();
-}
-
-/** @brief Method to Generate the OEM PDRs
- *
- * @param[in] repo - instance of concrete implementation of Repo
- */
-void buildOEMPDR(pdr_utils::Repo& repo);
-
-/** @brief Method to send code update event to host
- * @param[in] sensorId - sendor ID
- * @param[in] sensorEventClass - event class of sensor
- * @param[in] sensorOffset - sensor offset
- * @param[in] eventState - new code update event state
- * @param[in] prevEventState - previous code update event state
- * @return none
- */
-void sendStateSensorEvent(uint16_t sensorId,
-                          enum sensor_event_class_states sensorEventClass,
-                          uint8_t sensorOffset, uint8_t eventState,
-                          uint8_t prevEventState);
-
-/** @brief Method to send encoded request msg of code update event to host
- *  @param[in] requestMsg - encoded request msg
- *  @param[in] instanceId - instance id of the message
- *  @return PLDM status code
- */
-int sendEventToHost(std::vector<uint8_t>& requestMsg, uint8_t instanceId);
-
-/** @brief _processEndUpdate processes the actual work that needs
- *  to be carried out after EndUpdate effecter is set. This is done async
- *  after sending response for EndUpdate set effecter
- *  @param[in] source - sdeventplus event source
- */
-void _processEndUpdate(sdeventplus::source::EventBase& source);
-
-/** @brief _processStartUpdate processes the actual work that needs
- *  to be carried out after StartUpdate effecter is set. This is done async
- *  after sending response for StartUpdate set effecter
- *  @param[in] source - sdeventplus event source
- */
-void _processStartUpdate(sdeventplus::source::EventBase& source);
-
-/** @brief _processSystemReboot processes the actual work that needs to be
- *  carried out after the System Power State effecter is set to reboot
- *  the system
- *  @param[in] source - sdeventplus event source
- */
-void _processSystemReboot(sdeventplus::source::EventBase& source);
-
-/*keeps track how many times setEventReceiver is sent */
-void countSetEventReceiver()
-{
-    setEventReceiverCnt++;
-}
-
-/* disables watchdog if running and Host is up */
-void checkAndDisableWatchDog();
-
-/** @brief To check if the watchdog app is running
- *
- *  @return the running status of watchdog app
- */
-bool watchDogRunning();
-
-/** @brief Method to reset the Watchdog timer on receiving platform Event
- *  Message for heartbeat elapsed time from Hostboot
- */
-void resetWatchDogTimer();
-
-/** @brief To disable to the watchdog timer on host poweron completion*/
-void disableWatchDogTimer();
-
-/** @brief to check the BMC state*/
-int checkBMCState();
-
-/** @brief update the dbus object paths */
-void updateOemDbusPaths(std::string& dbusPath);
-
-/** @brief Method to fetch the last BMC record from the PDR repo
- *
- * @param[in] repo - pointer to BMC's primary PDR repo
- *
- * @return the last BMC record from the repo
- */
-const pldm_pdr_record* fetchLastBMCRecord(const pldm_pdr* repo);
-
-/** @brief Method to check if the record handle passed is in remote PDR
- *         record handle range
- *
- *  @param[in] record_handle - record handle of the PDR
- *
- *  @return true if record handle passed is in host PDR record handle range
- */
-bool checkRecordHandleInRange(const uint32_t& record_handle);
-
-/** *brief Method to call the setEventReceiver command*/
-void processSetEventReceiver();
-
-/** @brief Method to call the setEventReceiver through the platform
- *   handler
- */
-virtual void setEventReceiver()
-{
-    platformHandler->setEventReceiver();
-}
-
-/** @brief To process the graceful shutdown, cycle chassis power, and boot
- *  the host back up*/
-void processPowerCycleOffSoftGraceful();
-
-/** @brief To process powering down the host*/
-void processPowerOffSoftGraceful();
-
-/** @brief To process auto power restore policy*/
-void processPowerOffHardGraceful();
-
-/** @brief Method to Enable/Disable timer to see if host sends the
- *  surveillance ping and logs informational error if host fails to send the
- *  surveillance pings
- *
- *  @param[in] tid - TID of the host
- *  @param[in] value - true or false, to indicate if the timer is
- *                     running or not*/
-void setSurvTimer(uint8_t tid, bool value);
-
-/** @brief Method to reset or stop the surveillance timer
-*
-*   @param[in] value - true or false, to indicate if the timer
-*                     should be reset or turned off*/
-void startStopTimer(bool value);
-
-/** @brief To turn off Real SAI effecter*/
-void turnOffRealSAIEffecter();
-
-/** @brief Fetch Real SAI status based on the partition SAI and platform SAI
- *  sensor states. Real SAI is turned on if any of the partition or platform
- *  SAI turned on else Real SAI is turned off
- *  @return Real SAI sensor state PLDM_SENSOR_WARNING/PLDM_SENSOR_NORMAL
- */
-uint8_t fetchRealSAIStatus();
-
-/** @brief Method to process virtual platform/partition SAI update*/
-void processSAIUpdate();
-
-/** @brief Method to perform actions when PLDM_RECORDS_MODIFIED event
- *  is received from host
- *  @param[in] entityType - entity type
- *  @param[in] stateSetId - state set id
- */
-void modifyPDROemActions(uint16_t entityType, uint16_t stateSetId);
-
-/** @brief D-Bus Method call to call the Panel D-Bus API
- *
- * @param[in] objPath - The D-Bus object path
- * @param[in] dbusMethod - The Method name to be invoked
- * @param[in] dbusInterface - The D-Bus interface
- * @param[in] value - The value to be passed as argument
- *            to D-Bus method
- */
-void setBitmapMethodCall(const std::string& objPath,
-                         const std::string& dbusMethod,
-                         const std::string& dbusInterface,
-                         const pldm::utils::PropertyValue& value);
-
-/** @brief To handle the boot types bios attributes at power on*/
-void handleBootTypesAtPowerOn();
-
-/** @brief To set the boot types bios attributes based on the RestartCause
- *  of host
- *
- *  @param[in] RestartCause - Host restart cause
- */
-void setBootTypesBiosAttr(const std::string& restartCause);
-
-/** @brief To handle the boot types bios attributes at shutdown*/
-void handleBootTypesAtChassisOff();
-
-~Handler() = default;
-
-pldm::responder::CodeUpdate* codeUpdate;   //!< pointer to CodeUpdate object
-
-pldm::responder::SlotHandler* slotHandler; //!< pointer to SlotHandler object
-
-pldm::responder::platform::Handler*
-    platformHandler; //!< pointer to PLDM platform handler
-
-/** @brief fd of MCTP communications socket */
-int mctp_fd;
-
-/** @brief MCTP EID of host firmware */
-uint8_t mctp_eid;
-
-/** @brief reference to an InstanceIdDb object, used to obtain a PLDM
- * instance id. */
-pldm::InstanceIdDb& instanceIdDb;
-/** @brief sdeventplus event source */
-std::unique_ptr<sdeventplus::source::Defer> assembleImageEvent;
-std::unique_ptr<sdeventplus::source::Defer> startUpdateEvent;
-std::unique_ptr<sdeventplus::source::Defer> systemRebootEvent;
-
-/** @brief Effecterid to dbus object path map
- */
-std::unordered_map<uint16_t, std::string> effecterIdToDbusMap;
-
-/** @brief reference of main event loop of pldmd, primarily used to schedule
- *  work
- */
-sdeventplus::Event& event;
-
-private:
-/*@brief Host restart cause*/
-std::string restartCause;
-
-/** @brief D-Bus property changed signal match for CurrentPowerState*/
-std::unique_ptr<sdbusplus::bus::match_t> chassisOffMatch;
-
-const pldm_pdr* pdrRepo;
-
-/** @brief PLDM request handler */
-pldm::requester::Handler<pldm::requester::Request>* handler;
-
-/** @brief Pointer to BMC's entity association tree */
-pldm_entity_association_tree* bmcEntityTree;
-/** @brief D-Bus property changed signal match */
-std::unique_ptr<sdbusplus::bus::match_t> updateBIOSMatch;
-
-/** @brief D-Bus property changed signal match */
-std::unique_ptr<sdbusplus::bus::match_t> hostOffMatch;
-
-/** @brief D-Bus property changed signal match */
-std::unique_ptr<sdbusplus::bus::match_t> powerStateOffMatch;
-
-/** @brief D-Bus Interface added signal match for virtual platform SAI */
-std::unique_ptr<sdbusplus::bus::match_t> platformSAIMatch;
-/** @brief D-Bus Interfaced added signal match for Entity Manager */
-std::unique_ptr<sdbusplus::bus::match_t> ibmCompatibleMatch;
-/** @brief D-Bus Interfaced added signal match for State Manager */
-std::unique_ptr<sdbusplus::bus::match_t> stateManagerMatch;
-/** @brief D-Bus property Changed Signal match for bootProgress*/
-std::unique_ptr<sdbusplus::bus::match_t> bootProgressMatch;
-/** @brief Timer used for monitoring surveillance pings from host */
-sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
-
-/** @brief D-Bus Interface added signal match for virtual partition SAI */
-std::unique_ptr<sdbusplus::bus::match_t> partitionSAIMatch;
-
-bool hostOff = true;
-
-bool hostTransitioningToOff;
-
-int setEventReceiverCnt = 0;
-
-/** @brief Real SAI sensor id*/
-uint16_t realSAISensorId;
-
-std::unique_ptr<pldm::responder::oem_fileio::Handler> dbusToFileioIntf;
+        });
+
+        partitionSAIMatch = std::make_unique<sdbusplus::bus::match_t>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged(
+                "/xyz/openbmc_project/led/groups/platform_system_attention_indicator",
+                "xyz.openbmc_project.Led.Group"),
+            [this](sdbusplus::message_t& msg) {
+            pldm::utils::DbusChangedProps props{};
+            std::string intf;
+            msg.read(intf, props);
+            const auto itr = props.find("Asserted");
+            if (itr != props.end())
+            {
+                processSAIUpdate();
+            }
+        });
+        updateBIOSMatch = std::make_unique<sdbusplus::bus::match::match>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged("/xyz/openbmc_project/bios_config/manager",
+                              "xyz.openbmc_project.BIOSConfig.Manager"),
+            [this, codeUpdate](sdbusplus::message::message& msg) {
+            constexpr auto propertyName = "PendingAttributes";
+            using Value =
+                std::variant<std::string, PendingAttributes, BaseBIOSTable>;
+            using Properties = std::map<pldm::utils::DbusProp, Value>;
+            Properties props{};
+            std::string intf;
+            msg.read(intf, props);
+
+            auto valPropMap = props.find(propertyName);
+            if (valPropMap == props.end())
+            {
+                return;
+            }
+
+            PendingAttributes pendingAttributes =
+                std::get<PendingAttributes>(valPropMap->second);
+            for (auto it : pendingAttributes)
+            {
+                if (it.first == "fw_boot_side")
+                {
+                    auto& [attributeType, attributevalue] = it.second;
+                    std::string nextBootSide =
+                        std::get<std::string>(attributevalue);
+                    codeUpdate->setNextBootSide(nextBootSide);
+                }
+            }
+        });
+
+        stateManagerMatch = std::make_unique<sdbusplus::bus::match::match>(
+            pldm::utils::DBusHandler::getBus(),
+            sdbusplus::bus::match::rules::interfacesAdded() +
+                sdbusplus::bus::match::rules::argNpath(
+                    0, "/xyz/openbmc_project/state/host0"),
+            [this](sdbusplus::message::message& msg) {
+            sdbusplus::message::object_path path;
+            std::map<std::string, std::map<std::string, dbus::Value>>
+                interfaces;
+            msg.read(path, interfaces);
+
+            for (auto interface : interfaces)
+            {
+                std::cout << interface.first;
+            }
+            if (!interfaces.contains("xyz.openbmc_project.State.Host"))
+            {
+                return;
+            }
+
+            const auto& properties =
+                interfaces.at("xyz.openbmc_project.State.Host");
+
+            if (!properties.contains("RestartCause"))
+            {
+                return;
+            }
+
+            restartCause = std::get<std::string>(properties.at("RestartCause"));
+            setBootTypesBiosAttr(restartCause);
+        });
+    }
+
+    int getOemStateSensorReadingsHandler(
+        pldm::pdr::EntityType entityType,
+        pldm::pdr::EntityInstance entityInstance,
+        pldm::pdr::ContainerID containerId, pldm::pdr::StateSetId stateSetId,
+        pldm::pdr::CompositeCount compSensorCnt, uint16_t sensorId,
+        std::vector<get_sensor_state_field>& stateField);
+
+    int oemSetStateEffecterStatesHandler(
+        uint16_t entityType, uint16_t entityInstance, uint16_t stateSetId,
+        uint8_t compEffecterCnt,
+        std::vector<set_effecter_state_field>& stateField, uint16_t effecterId);
+
+    /** @brief Method to set the platform handler in the
+     *         oem_ibm_handler class
+     *  @param[in] handler - pointer to PLDM platform handler
+     */
+    void setPlatformHandler(pldm::responder::platform::Handler* handler);
+
+    /** @brief Method to fetch the effecter ID of the code update PDRs
+     *
+     * @return platformHandler->getNextEffecterId() - returns the
+     *             effecter ID from the platform handler
+     */
+    virtual uint16_t getNextEffecterId()
+    {
+        return platformHandler->getNextEffecterId();
+    }
+
+    /** @brief Method to fetch the sensor ID of the code update PDRs
+     *
+     * @return platformHandler->getNextSensorId() - returns the
+     *             Sensor ID from the platform handler
+     */
+    virtual uint16_t getNextSensorId()
+    {
+        return platformHandler->getNextSensorId();
+    }
+
+    /** @brief Get std::map associated with the entity
+     *         key: object path
+     *         value: pldm_entity
+     *
+     *  @return std::map<ObjectPath, pldm_entity>
+     */
+    virtual const AssociatedEntityMap& getAssociateEntityMap()
+    {
+        return platformHandler->getAssociateEntityMap();
+    }
+
+    /** @brief Method to Generate the OEM PDRs
+     *
+     * @param[in] repo - instance of concrete implementation of Repo
+     */
+    void buildOEMPDR(pdr_utils::Repo& repo);
+
+    /** @brief Method to send code update event to host
+     * @param[in] sensorId - sendor ID
+     * @param[in] sensorEventClass - event class of sensor
+     * @param[in] sensorOffset - sensor offset
+     * @param[in] eventState - new code update event state
+     * @param[in] prevEventState - previous code update event state
+     * @return none
+     */
+    void sendStateSensorEvent(uint16_t sensorId,
+                              enum sensor_event_class_states sensorEventClass,
+                              uint8_t sensorOffset, uint8_t eventState,
+                              uint8_t prevEventState);
+
+    /** @brief Method to send encoded request msg of code update event to host
+     *  @param[in] requestMsg - encoded request msg
+     *  @param[in] instanceId - instance id of the message
+     *  @return PLDM status code
+     */
+    int sendEventToHost(std::vector<uint8_t>& requestMsg, uint8_t instanceId);
+
+    /** @brief _processEndUpdate processes the actual work that needs
+     *  to be carried out after EndUpdate effecter is set. This is done async
+     *  after sending response for EndUpdate set effecter
+     *  @param[in] source - sdeventplus event source
+     */
+    void _processEndUpdate(sdeventplus::source::EventBase& source);
+
+    /** @brief _processStartUpdate processes the actual work that needs
+     *  to be carried out after StartUpdate effecter is set. This is done async
+     *  after sending response for StartUpdate set effecter
+     *  @param[in] source - sdeventplus event source
+     */
+    void _processStartUpdate(sdeventplus::source::EventBase& source);
+
+    /** @brief _processSystemReboot processes the actual work that needs to be
+     *  carried out after the System Power State effecter is set to reboot
+     *  the system
+     *  @param[in] source - sdeventplus event source
+     */
+    void _processSystemReboot(sdeventplus::source::EventBase& source);
+
+    /*keeps track how many times setEventReceiver is sent */
+    void countSetEventReceiver()
+    {
+        setEventReceiverCnt++;
+    }
+
+    /* disables watchdog if running and Host is up */
+    void checkAndDisableWatchDog();
+
+    /** @brief To check if the watchdog app is running
+     *
+     *  @return the running status of watchdog app
+     */
+    bool watchDogRunning();
+
+    /** @brief Method to reset the Watchdog timer on receiving platform Event
+     *  Message for heartbeat elapsed time from Hostboot
+     */
+    void resetWatchDogTimer();
+
+    /** @brief To disable to the watchdog timer on host poweron completion*/
+    void disableWatchDogTimer();
+
+    /** @brief to check the BMC state*/
+    int checkBMCState();
+
+    /** @brief update the dbus object paths */
+    void updateOemDbusPaths(std::string& dbusPath);
+
+    /** @brief Method to fetch the last BMC record from the PDR repo
+     *
+     * @param[in] repo - pointer to BMC's primary PDR repo
+     *
+     * @return the last BMC record from the repo
+     */
+    const pldm_pdr_record* fetchLastBMCRecord(const pldm_pdr* repo);
+
+    /** @brief Method to check if the record handle passed is in remote PDR
+     *         record handle range
+     *
+     *  @param[in] record_handle - record handle of the PDR
+     *
+     *  @return true if record handle passed is in host PDR record handle range
+     */
+    bool checkRecordHandleInRange(const uint32_t& record_handle);
+
+    /** *brief Method to call the setEventReceiver command*/
+    void processSetEventReceiver();
+
+    /** @brief Method to call the setEventReceiver through the platform
+     *   handler
+     */
+    virtual void setEventReceiver()
+    {
+        platformHandler->setEventReceiver();
+    }
+
+    /** @brief To process the graceful shutdown, cycle chassis power, and boot
+     *  the host back up*/
+    void processPowerCycleOffSoftGraceful();
+
+    /** @brief To process powering down the host*/
+    void processPowerOffSoftGraceful();
+
+    /** @brief To process auto power restore policy*/
+    void processPowerOffHardGraceful();
+
+    /** @brief Method to Enable/Disable timer to see if host sends the
+     *  surveillance ping and logs informational error if host fails to send the
+     *  surveillance pings
+     *
+     *  @param[in] tid - TID of the host
+     *  @param[in] value - true or false, to indicate if the timer is
+     *                     running or not*/
+    void setSurvTimer(uint8_t tid, bool value);
+
+    /** @brief Method to reset or stop the surveillance timer
+     *
+     *   @param[in] value - true or false, to indicate if the timer
+     *                     should be reset or turned off*/
+    void startStopTimer(bool value);
+
+    /** @brief To turn off Real SAI effecter*/
+    void turnOffRealSAIEffecter();
+
+    /** @brief Fetch Real SAI status based on the partition SAI and platform SAI
+     *  sensor states. Real SAI is turned on if any of the partition or platform
+     *  SAI turned on else Real SAI is turned off
+     *  @return Real SAI sensor state PLDM_SENSOR_WARNING/PLDM_SENSOR_NORMAL
+     */
+    uint8_t fetchRealSAIStatus();
+
+    /** @brief Method to process virtual platform/partition SAI update*/
+    void processSAIUpdate();
+
+    /** @brief Method to perform actions when PLDM_RECORDS_MODIFIED event
+     *  is received from host
+     *  @param[in] entityType - entity type
+     *  @param[in] stateSetId - state set id
+     */
+    void modifyPDROemActions(uint16_t entityType, uint16_t stateSetId);
+
+    /** @brief D-Bus Method call to call the Panel D-Bus API
+     *
+     * @param[in] objPath - The D-Bus object path
+     * @param[in] dbusMethod - The Method name to be invoked
+     * @param[in] dbusInterface - The D-Bus interface
+     * @param[in] value - The value to be passed as argument
+     *            to D-Bus method
+     */
+    void setBitmapMethodCall(const std::string& objPath,
+                             const std::string& dbusMethod,
+                             const std::string& dbusInterface,
+                             const pldm::utils::PropertyValue& value);
+
+    /** @brief To handle the boot types bios attributes at power on*/
+    void handleBootTypesAtPowerOn();
+
+    /** @brief To set the boot types bios attributes based on the RestartCause
+     *  of host
+     *
+     *  @param[in] RestartCause - Host restart cause
+     */
+    void setBootTypesBiosAttr(const std::string& restartCause);
+
+    /** @brief To handle the boot types bios attributes at shutdown*/
+    void handleBootTypesAtChassisOff();
+
+    ~Handler() = default;
+
+    pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object
+
+    pldm::responder::SlotHandler*
+        slotHandler; //!< pointer to SlotHandler object
+
+    pldm::responder::platform::Handler*
+        platformHandler; //!< pointer to PLDM platform handler
+
+    /** @brief fd of MCTP communications socket */
+    int mctp_fd;
+
+    /** @brief MCTP EID of host firmware */
+    uint8_t mctp_eid;
+
+    /** @brief reference to an InstanceIdDb object, used to obtain a PLDM
+     * instance id. */
+    pldm::InstanceIdDb& instanceIdDb;
+    /** @brief sdeventplus event source */
+    std::unique_ptr<sdeventplus::source::Defer> assembleImageEvent;
+    std::unique_ptr<sdeventplus::source::Defer> startUpdateEvent;
+    std::unique_ptr<sdeventplus::source::Defer> systemRebootEvent;
+
+    /** @brief Effecterid to dbus object path map
+     */
+    std::unordered_map<uint16_t, std::string> effecterIdToDbusMap;
+
+    /** @brief reference of main event loop of pldmd, primarily used to schedule
+     *  work
+     */
+    sdeventplus::Event& event;
+
+  private:
+    /*@brief Host restart cause*/
+    std::string restartCause;
+
+    /** @brief D-Bus property changed signal match for CurrentPowerState*/
+    std::unique_ptr<sdbusplus::bus::match_t> chassisOffMatch;
+
+    const pldm_pdr* pdrRepo;
+
+    /** @brief PLDM request handler */
+    pldm::requester::Handler<pldm::requester::Request>* handler;
+
+    /** @brief Pointer to BMC's entity association tree */
+    pldm_entity_association_tree* bmcEntityTree;
+    /** @brief D-Bus property changed signal match */
+    std::unique_ptr<sdbusplus::bus::match_t> updateBIOSMatch;
+
+    /** @brief D-Bus property changed signal match */
+    std::unique_ptr<sdbusplus::bus::match_t> hostOffMatch;
+
+    /** @brief D-Bus property changed signal match */
+    std::unique_ptr<sdbusplus::bus::match_t> powerStateOffMatch;
+
+    /** @brief D-Bus Interface added signal match for virtual platform SAI */
+    std::unique_ptr<sdbusplus::bus::match_t> platformSAIMatch;
+    /** @brief D-Bus Interfaced added signal match for Entity Manager */
+    std::unique_ptr<sdbusplus::bus::match_t> ibmCompatibleMatch;
+    /** @brief D-Bus Interfaced added signal match for State Manager */
+    std::unique_ptr<sdbusplus::bus::match_t> stateManagerMatch;
+    /** @brief D-Bus property Changed Signal match for bootProgress*/
+    std::unique_ptr<sdbusplus::bus::match_t> bootProgressMatch;
+    /** @brief Timer used for monitoring surveillance pings from host */
+    sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
+
+    /** @brief D-Bus Interface added signal match for virtual partition SAI */
+    std::unique_ptr<sdbusplus::bus::match_t> partitionSAIMatch;
+
+    bool hostOff = true;
+
+    bool hostTransitioningToOff;
+
+    int setEventReceiverCnt = 0;
+
+    /** @brief Real SAI sensor id*/
+    uint16_t realSAISensorId;
+
+    std::unique_ptr<pldm::responder::oem_fileio::Handler> dbusToFileioIntf;
 };
 
 /** @brief Method to encode code update event msg

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -87,10 +87,15 @@ constexpr uint16_t ENTITY_INSTANCE_0 = 0;
 constexpr uint16_t ENTITY_INSTANCE_1 = 1;
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 const pldm::pdr::TerminusID HYPERVISOR_TID = 208;
 
 static constexpr uint8_t HEARTBEAT_TIMEOUT_DELTA = 10;
 =======
+=======
+const pldm::pdr::TerminusID HYPERVISOR_TID = 208;
+
+>>>>>>> 4dc9723a (PLDM: Log RecvSurveillancePingFail only if PHYP fails to send surveillance pings (#236))
 static constexpr uint8_t HEARTBEAT_TIMEOUT_DELTA = 10;
 struct InstanceInfo
 {
@@ -127,8 +132,8 @@ class Handler : public oem_platform::Handler
 =======
         requester(requester), event(event), pdrRepo(repo), handler(handler),
         bmcEntityTree(bmcEntityTree), hostEffecterParser(hostEffecterParser),
-        timer(event,
-              std::bind(std::mem_fn(&Handler::setSurvTimer), this, false))
+        timer(event, std::bind(std::mem_fn(&Handler::setSurvTimer), this,
+                               HYPERVISOR_TID, false))
 
 >>>>>>> af349d9f (PLDM: Implement timer for Surveillance Pings (#227))
     {
@@ -488,14 +493,14 @@ void processPowerOffSoftGraceful();
 /** @brief To process auto power restore policy*/
 void processPowerOffHardGraceful();
 
-/** @brief Method to Enable/Disable timer to see if remote terminus sends
- *  the surveillance ping and logs informational error if remote terminus
- *  fails to send the surveillance pings
+/** @brief Method to Enable/Disable timer to see if host sends the
+ *  surveillance ping and logs informational error if host fails to send the
+ *  surveillance pings
  *
- * @param[in] value - true or false, to indicate if the timer is
- *                    running or not
- */
-void setSurvTimer(bool value);
+ *  @param[in] tid - TID of the host
+ *  @param[in] value - true or false, to indicate if the timer is
+ *                     running or not*/
+void setSurvTimer(uint8_t tid, bool value);
 
 /** @brief To turn off Real SAI effecter*/
 void turnOffRealSAIEffecter();

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -480,6 +480,12 @@ class Handler : public oem_platform::Handler
                              const std::string& dbusInterface,
                              const pldm::utils::PropertyValue& value);
 
+    /** @brief To handle the boot types bios attributes at power on*/
+    void handleBootTypesAtPowerOn();
+
+    /** @brief To handle the boot types bios attributes at shutdown*/
+    void handleBootTypesAtChassisOff();
+
     ~Handler() = default;
 
     pldm::responder::CodeUpdate* codeUpdate; //!< pointer to CodeUpdate object

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -262,7 +262,7 @@ class Handler : public oem_platform::Handler
                     std::get<PendingAttributes>(valPropMap->second);
                 for (auto it : pendingAttributes)
                 {
-                    if (it.first == "hb_fw_boot_side")
+                    if (it.first == "fw_boot_side")
                     {
                         auto& [attributeType, attributevalue] = it.second;
                         std::string nextBootSide =

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -86,9 +86,19 @@ static constexpr auto PLDM_OEM_IBM_FRONT_PANEL_TRIGGER = 32837;
 constexpr uint16_t ENTITY_INSTANCE_0 = 0;
 constexpr uint16_t ENTITY_INSTANCE_1 = 1;
 
+<<<<<<< HEAD
 const pldm::pdr::TerminusID HYPERVISOR_TID = 208;
 
 static constexpr uint8_t HEARTBEAT_TIMEOUT_DELTA = 10;
+=======
+static constexpr uint8_t HEARTBEAT_TIMEOUT_DELTA = 10;
+struct InstanceInfo
+{
+    uint8_t procId;
+    uint8_t dcmId;
+};
+using HostEffecterInstanceMap = std::map<pldm::pdr::EffecterID, InstanceInfo>;
+>>>>>>> af349d9f (PLDM: Implement timer for Surveillance Pings (#227))
 
 enum SetEventReceiverCount
 {
@@ -108,11 +118,19 @@ class Handler : public oem_platform::Handler
         oem_platform::Handler(dBusIntf),
         codeUpdate(codeUpdate), slotHandler(slotHandler),
         platformHandler(nullptr), mctp_fd(mctp_fd), mctp_eid(mctp_eid),
+<<<<<<< HEAD
         instanceIdDb(instanceIdDb), event(event), pdrRepo(repo),
         handler(handler), bmcEntityTree(bmcEntityTree),
         timer(event, std::bind(std::mem_fn(&Handler::setSurvTimer), this,
                                HYPERVISOR_TID, false)),
         hostTransitioningToOff(true)
+=======
+        requester(requester), event(event), pdrRepo(repo), handler(handler),
+        bmcEntityTree(bmcEntityTree), hostEffecterParser(hostEffecterParser),
+        timer(event,
+              std::bind(std::mem_fn(&Handler::setSurvTimer), this, false))
+
+>>>>>>> af349d9f (PLDM: Implement timer for Surveillance Pings (#227))
     {
         codeUpdate->setVersions();
         pldm::responder::utils::clearLicenseStatus();
@@ -474,11 +492,10 @@ void processPowerOffHardGraceful();
  *  the surveillance ping and logs informational error if remote terminus
  *  fails to send the surveillance pings
  *
- * @param[in] tid - TID of the remote terminus
  * @param[in] value - true or false, to indicate if the timer is
  *                    running or not
  */
-void setSurvTimer(uint8_t tid, bool value);
+void setSurvTimer(bool value);
 
 /** @brief To turn off Real SAI effecter*/
 void turnOffRealSAIEffecter();
@@ -529,6 +546,8 @@ void handleBootTypesAtChassisOff();
 ~Handler() = default;
 
 pldm::responder::CodeUpdate* codeUpdate;   //!< pointer to CodeUpdate object
+
+    ~Handler() = default;
 
 pldm::responder::SlotHandler* slotHandler; //!< pointer to SlotHandler object
 
@@ -588,8 +607,22 @@ std::unique_ptr<sdbusplus::bus::match_t> hostOffMatch;
 /** @brief D-Bus property changed signal match */
 std::unique_ptr<sdbusplus::bus::match_t> powerStateOffMatch;
 
+<<<<<<< HEAD
 /** @brief D-Bus Interface added signal match for virtual platform SAI */
 std::unique_ptr<sdbusplus::bus::match_t> platformSAIMatch;
+=======
+    /** @brief D-Bus property changed signal match */
+    std::unique_ptr<sdbusplus::bus::match::match> hostOffMatch;
+    std::unique_ptr<sdbusplus::bus::match::match> updateBIOSMatch;
+    /** @brief D-Bus Interfaced added signal match for Entity Manager */
+    std::unique_ptr<sdbusplus::bus::match::match> ibmCompatibleMatch;
+    /** @brief D-Bus Interfaced added signal match for State Manager */
+    std::unique_ptr<sdbusplus::bus::match::match> stateManagerMatch;
+    /** @brief D-Bus property Changed Signal match for bootProgress*/
+    std::unique_ptr<sdbusplus::bus::match::match> bootProgressMatch;
+    /** @brief Timer used for monitoring surveillance pings from host */
+    sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
+>>>>>>> af349d9f (PLDM: Implement timer for Surveillance Pings (#227))
 
 /** @brief D-Bus Interface added signal match for virtual partition SAI */
 std::unique_ptr<sdbusplus::bus::match_t> partitionSAIMatch;

--- a/softoff/softoff.cpp
+++ b/softoff/softoff.cpp
@@ -285,13 +285,27 @@ int SoftPowerOff::hostSoftOff(sdeventplus::Event& event)
     // TODO: fix mapping to work around OpenBMC ecosystem deficiencies
     pldm_tid_t pldmTID = static_cast<pldm_tid_t>(mctpEID);
 
+    uint8_t effecterState;
+    auto requestHostTransition =
+        pldm::utils::DBusHandler().getDbusProperty<std::string>(
+            "/xyz/openbmc_project/state/host0", "RequestedHostTransition",
+            "xyz.openbmc_project.State.Host");
+    if (requestHostTransition !=
+        "xyz.openbmc_project.State.Host.Transition.Off")
+    {
+        effecterState = PLDM_SW_TERM_GRACEFUL_RESTART_REQUESTED;
+    }
+    else
+    {
+        effecterState = PLDM_SW_TERM_GRACEFUL_SHUTDOWN_REQUESTED;
+    }
+
     std::array<uint8_t, sizeof(pldm_msg_hdr) + sizeof(effecterID) +
                             sizeof(effecterCount) +
                             sizeof(set_effecter_state_field)>
         requestMsg{};
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
-    set_effecter_state_field stateField{
-        PLDM_REQUEST_SET, PLDM_SW_TERM_GRACEFUL_SHUTDOWN_REQUESTED};
+    set_effecter_state_field stateField{PLDM_REQUEST_SET, effecterState};
     instanceID = instanceIdDb.next(pldmTID);
     auto rc = encode_set_state_effecter_states_req(
         instanceID, effecterID, effecterCount, &stateField, request);


### PR DESCRIPTION
This PR contains the following commits:
1. Concurrent code update support.
2. Bootside mapping
3. Support for boot types attributes
4. All the defect fixes for inband and out of band updates in pldm. 

commit list:
66f7ac79 (HEAD -> 1110) Trigger Assemblelids method and handle response (#402)
d0397ba6 PLDM:Wait on the Software Updater (#296)
a5ee378a PLDM: Make boot type as Reipl during MPIPL (#270)
fa3d99a7 PLDM: Reset image activation after sending end update event (#259)
795b9cfe PLDM: Reset image activation match (#241)
9622648c PLDM: Minimise sending BIOS attr change event (#193)
66f7ac79 (HEAD -> 1110) Trigger Assemblelids method and handle response (#402)
d0397ba6 PLDM:Wait on the Software Updater (#296)
a5ee378a PLDM: Make boot type as Reipl during MPIPL (#270)
fa3d99a7 PLDM: Reset image activation after sending end update event (#259)
795b9cfe PLDM: Reset image activation match (#241)
9622648c PLDM: Minimise sending BIOS attr change event (#193)
56cd8dd1 oem: ibm: Set next boot side attribute During a rename, set the next boot side to Perm (same as current) so that in case of a failed update, PHYP knows to boot from the Perm side. The next boot side would be set to Temp on a successful update (via the Priority callback function).
b6fae78a oem: ibm: Side information enhancements (#132)
aea0bc0a PLDM: Remove old boot side setting (#190)
70c1d40b PLDM: Fix code update Rename
abfbe210 PLDM: APR changes in inband CU path (#178)
dca892f7 Pldm RR crash fix (#92)
cb246f9f pldm: Support bios attributes for boot types
3d8f9d9c PLDM: Setting the slot power state to Off (#62)
cd50161d PLDM: Support for LID type running in constructLidpath (#161)
c674f9ca PLDM: Add file type running (#156)
640271bc PLDM: Fix ContainerID for rename sensor (#130)
beec0379 PLDM: Next Boot Support (#123)
1e4220e4 PLDM: Include additional debug traces (#118)
04533600 PLDM bootside bump failure fix (#103)
bd85888e PLDM Fix for bootside attribute defect (#99)
44982b70 oem-ibm: Eliminate the Boot side Effecters and sensors
3e4c6d28 oem-ibm: State effecter for rename operation
bba274a4 oem-ibm: Maintain bootside Mapping and Set bios attribute
c1b78781 oem-ibm: support concurrent FW update