### PR TITLE
oem-ibm: Fix a minor bug in dump offload path

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -520,11 +520,11 @@ std::shared_ptr<FileHandler> getSharedHandlerByType(uint16_t fileType,
         case PLDM_FILE_TYPE_RESOURCE_DUMP:
         case PLDM_FILE_TYPE_BMC_DUMP:
         case PLDM_FILE_TYPE_SBE_DUMP:
-            // case PLDM_FILE_TYPE_HOSTBOOT_DUMP:
-            // case PLDM_FILE_TYPE_HARDWARE_DUMP:
-            {
-                return std::make_shared<DumpHandler>(fileHandle, fileType);
-            }
+        case PLDM_FILE_TYPE_HOSTBOOT_DUMP:
+        case PLDM_FILE_TYPE_HARDWARE_DUMP:
+        {
+            return std::make_shared<DumpHandler>(fileHandle, fileType);
+        }
         case PLDM_FILE_TYPE_CERT_SIGNING_REQUEST:
         case PLDM_FILE_TYPE_SIGNED_CERT:
         case PLDM_FILE_TYPE_ROOT_CERT:


### PR DESCRIPTION
The code lines for hardware and hostboot dumps which gets the handler for the dumps was commented which caused an error when we try to offload the HB and HW dumps to PHYP in a non-HMC managed systems.

Tested: Succesfully offloaded the hardware and hostboot dump to PHYP

Change-Id: I9d89b01c1a36af0a1487d814fd0564b61af5ab02
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>