### PR TITLE
CI: Adding format change

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-04-26T19:13:37Z",
+  "generated_at": "2024-09-06T12:22:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -84,24 +84,6 @@
         "is_verified": false,
         "line_number": 7,
         "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp": [
-      {
-        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 71,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "76115425ed87da96eced3ae323aab27391989146",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 97,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],

--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -575,8 +575,8 @@ std::string toString(const struct variable_field& var)
     }
 
     std::string str(reinterpret_cast<const char*>(var.ptr), var.length);
-    std::replace_if(
-        str.begin(), str.end(), [](const char& c) { return !isprint(c); }, ' ');
+    std::replace_if(str.begin(), str.end(),
+                    [](const char& c) { return !isprint(c); }, ' ');
     return str;
 }
 

--- a/fw-update/device_updater.hpp
+++ b/fw-update/device_updater.hpp
@@ -53,8 +53,7 @@ class DeviceUpdater
                            const ComponentInfo& compInfo,
                            uint32_t maxTransferSize,
                            UpdateManager* updateManager) :
-        eid(eid),
-        package(package), fwDeviceIDRecord(fwDeviceIDRecord),
+        eid(eid), package(package), fwDeviceIDRecord(fwDeviceIDRecord),
         compImageInfos(compImageInfos), compInfo(compInfo),
         maxTransferSize(maxTransferSize), updateManager(updateManager)
     {}

--- a/fw-update/inventory_manager.hpp
+++ b/fw-update/inventory_manager.hpp
@@ -41,9 +41,8 @@ class InventoryManager
         pldm::requester::Handler<pldm::requester::Request>& handler,
         InstanceIdDb& instanceIdDb, DescriptorMap& descriptorMap,
         ComponentInfoMap& componentInfoMap) :
-        handler(handler),
-        instanceIdDb(instanceIdDb), descriptorMap(descriptorMap),
-        componentInfoMap(componentInfoMap)
+        handler(handler), instanceIdDb(instanceIdDb),
+        descriptorMap(descriptorMap), componentInfoMap(componentInfoMap)
     {}
 
     /** @brief Discover the firmware identifiers and component details of FDs

--- a/fw-update/package_parser.hpp
+++ b/fw-update/package_parser.hpp
@@ -47,8 +47,7 @@ class PackageParser
     explicit PackageParser(PackageHeaderSize pkgHeaderSize,
                            const PackageVersion& pkgVersion,
                            ComponentBitmapBitLength componentBitmapBitLength) :
-        pkgHeaderSize(pkgHeaderSize),
-        pkgVersion(pkgVersion),
+        pkgHeaderSize(pkgHeaderSize), pkgVersion(pkgVersion),
         componentBitmapBitLength(componentBitmapBitLength)
     {}
 

--- a/fw-update/update_manager.hpp
+++ b/fw-update/update_manager.hpp
@@ -48,8 +48,7 @@ class UpdateManager
         pldm::requester::Handler<pldm::requester::Request>& handler,
         InstanceIdDb& instanceIdDb, const DescriptorMap& descriptorMap,
         const ComponentInfoMap& componentInfoMap) :
-        event(event),
-        handler(handler), instanceIdDb(instanceIdDb),
+        event(event), handler(handler), instanceIdDb(instanceIdDb),
         descriptorMap(descriptorMap), componentInfoMap(componentInfoMap),
         watch(event.get(),
               std::bind_front(&UpdateManager::processPackage, this)),

--- a/host-bmc/dbus/associations.hpp
+++ b/host-bmc/dbus/associations.hpp
@@ -30,8 +30,7 @@ class Associations : public AssociationsIntf
 
     Associations(sdbusplus::bus_t& bus, const std::string& objPath,
                  const std::map<std::string, PropertiesVariant>& vals) :
-        AssociationsIntf(bus, objPath.c_str(), vals),
-        path(objPath)
+        AssociationsIntf(bus, objPath.c_str(), vals), path(objPath)
     {}
 
     /** Get value of Associations */

--- a/host-bmc/dbus_to_event_handler.cpp
+++ b/host-bmc/dbus_to_event_handler.cpp
@@ -21,8 +21,8 @@ const std::vector<uint8_t> pdrTypes{PLDM_STATE_SENSOR_PDR};
 DbusToPLDMEvent::DbusToPLDMEvent(
     int mctp_fd, uint8_t mctp_eid, pldm::InstanceIdDb& instanceIdDb,
     pldm::requester::Handler<pldm::requester::Request>* handler) :
-    mctp_fd(mctp_fd),
-    mctp_eid(mctp_eid), instanceIdDb(instanceIdDb), handler(handler)
+    mctp_fd(mctp_fd), mctp_eid(mctp_eid), instanceIdDb(instanceIdDb),
+    handler(handler)
 {}
 
 void DbusToPLDMEvent::sendEventMsg(uint8_t eventType,

--- a/host-bmc/dbus_to_host_effecters.hpp
+++ b/host-bmc/dbus_to_host_effecters.hpp
@@ -87,8 +87,8 @@ class HostEffecterParser
         pldm::utils::DBusHandler* const dbusHandler,
         const std::string& jsonPath,
         pldm::requester::Handler<pldm::requester::Request>* handler) :
-        requester(requester),
-        sockFd(fd), pdrRepo(repo), dbusHandler(dbusHandler), handler(handler)
+        requester(requester), sockFd(fd), pdrRepo(repo),
+        dbusHandler(dbusHandler), handler(handler)
     {
         try
         {

--- a/host-bmc/host_condition.hpp
+++ b/host-bmc/host_condition.hpp
@@ -25,7 +25,7 @@ class Host : public HostIntf
     virtual ~Host() = default;
 
     Host(sdbusplus::bus_t& bus, const std::string& path) :
-        HostIntf(bus, path.c_str()){};
+        HostIntf(bus, path.c_str()) {};
 
     /** @brief Override reads to CurrentFirmwareCondition */
     FirmwareCondition currentFirmwareCondition() const override;

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -102,8 +102,7 @@ HostPDRHandler::HostPDRHandler(
     pldm::responder::oem_platform::Handler* oemPlatformHandler,
     pldm::responder::oem_utils::Handler* oemUtilsHandler,
     pldm::host_associations::HostAssociationsParser* associationsParser) :
-    mctp_fd(mctp_fd),
-    mctp_eid(mctp_eid), event(event), repo(repo),
+    mctp_fd(mctp_fd), mctp_eid(mctp_eid), event(event), repo(repo),
     stateSensorHandler(eventsJsonsDir), entityTree(entityTree),
     bmcEntityTree(bmcEntityTree), hostEffecterParser(hostEffecterParser),
     instanceIdDb(instanceIdDb), handler(handler),
@@ -132,7 +131,7 @@ HostPDRHandler::HostPDRHandler(
             {
                 // Delete all the remote terminus information
                 std::erase_if(tlPDRInfo, [](const auto& item) {
-                    auto const& [key, value] = item;
+                    const auto& [key, value] = item;
                     return key != TERMINUS_HANDLE;
                 });
                 // when the host is powered off, set the availability

--- a/libpldmresponder/base.hpp
+++ b/libpldmresponder/base.hpp
@@ -22,8 +22,7 @@ class Handler : public CmdHandler
   public:
     Handler(sdeventplus::Event& event,
             pldm::responder::oem_platform::Handler* oemPlatformHandler) :
-        event(event),
-        oemPlatformHandler(oemPlatformHandler)
+        event(event), oemPlatformHandler(oemPlatformHandler)
     {
         handlers.emplace(
             PLDM_GET_PLDM_TYPES,

--- a/libpldmresponder/bios_attribute.cpp
+++ b/libpldmresponder/bios_attribute.cpp
@@ -16,9 +16,9 @@ namespace bios
 
 BIOSAttribute::BIOSAttribute(const Json& entry,
                              DBusHandler* const dbusHandler) :
-    name(entry.at("attribute_name")),
-    readOnly(false), displayName(entry.at("displayName")),
-    helpText(entry.at("helpText")), dbusHandler(dbusHandler)
+    name(entry.at("attribute_name")), readOnly(false),
+    displayName(entry.at("displayName")), helpText(entry.at("helpText")),
+    dbusHandler(dbusHandler)
 {
     try
     {

--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -47,9 +47,8 @@ BIOSConfig::BIOSConfig(
     pldm::requester::Handler<pldm::requester::Request>* handler,
     pldm::responder::platform_config::Handler* platformConfigHandler,
     pldm::responder::bios::Callback requestPLDMServiceName) :
-    jsonDir(jsonDir),
-    tableDir(tableDir), dbusHandler(dbusHandler), fd(fd), eid(eid),
-    instanceIdDb(instanceIdDb), handler(handler),
+    jsonDir(jsonDir), tableDir(tableDir), dbusHandler(dbusHandler), fd(fd),
+    eid(eid), instanceIdDb(instanceIdDb), handler(handler),
     platformConfigHandler(platformConfigHandler),
     requestPLDMServiceName(requestPLDMServiceName)
 {

--- a/libpldmresponder/fru.hpp
+++ b/libpldmresponder/fru.hpp
@@ -97,8 +97,8 @@ class FruImpl
             pldm::requester::Handler<pldm::requester::Request>* handler,
             uint8_t mctp_eid, sdeventplus::Event& event,
             pldm::state_sensor::DbusToPLDMEvent* dbusToPLDMEventHandler) :
-        parser(configPath, fruMasterJsonPath),
-        pdrRepo(pdrRepo), entityTree(entityTree), bmcEntityTree(bmcEntityTree),
+        parser(configPath, fruMasterJsonPath), pdrRepo(pdrRepo),
+        entityTree(entityTree), bmcEntityTree(bmcEntityTree),
         oemFruHandler(oemFruHandler), requester(requester), handler(handler),
         mctp_eid(mctp_eid), event(event),
         dbusToPLDMEventHandler(dbusToPLDMEventHandler), oemUtilsHandler(nullptr)

--- a/libpldmresponder/platform.hpp
+++ b/libpldmresponder/platform.hpp
@@ -62,8 +62,7 @@ class Handler : public CmdHandler
             pldm::requester::Handler<pldm::requester::Request>* handler,
             sdeventplus::Event& event, bool buildPDRLazily = false,
             const std::optional<EventMap>& addOnHandlersMap = std::nullopt) :
-        eid(eid),
-        instanceIdDb(instanceIdDb), pdrRepo(repo),
+        eid(eid), instanceIdDb(instanceIdDb), pdrRepo(repo),
         hostPDRHandler(hostPDRHandler),
         dbusToPLDMEventHandler(dbusToPLDMEventHandler), fruHandler(fruHandler),
         bmcEntityTree(bmcEntityTree), dBusIntf(dBusIntf),

--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -659,9 +659,8 @@ class Handler : public CmdHandler
             uint8_t hostEid, pldm::InstanceIdDb* instanceIdDb,
             pldm::requester::Handler<pldm::requester::Request>* handler,
             pldm::response_api::AltResponse* respInterface) :
-        oemPlatformHandler(oemPlatformHandler),
-        hostSockFd(hostSockFd), hostEid(hostEid), instanceIdDb(instanceIdDb),
-        handler(handler),
+        oemPlatformHandler(oemPlatformHandler), hostSockFd(hostSockFd),
+        hostEid(hostEid), instanceIdDb(instanceIdDb), handler(handler),
         sharedAIORespDataobj({0, 0, nullptr, 0, respInterface})
     {
         handlers.emplace(

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -85,11 +85,10 @@ class Handler : public oem_platform::Handler
             sdeventplus::Event& event, pldm_pdr* repo,
             pldm::requester::Handler<pldm::requester::Request>* handler,
             pldm_entity_association_tree* bmcEntityTree) :
-        oem_platform::Handler(dBusIntf),
-        codeUpdate(codeUpdate), slotHandler(slotHandler),
-        platformHandler(nullptr), mctp_fd(mctp_fd), mctp_eid(mctp_eid),
-        instanceIdDb(instanceIdDb), event(event), pdrRepo(repo),
-        handler(handler), bmcEntityTree(bmcEntityTree),
+        oem_platform::Handler(dBusIntf), codeUpdate(codeUpdate),
+        slotHandler(slotHandler), platformHandler(nullptr), mctp_fd(mctp_fd),
+        mctp_eid(mctp_eid), instanceIdDb(instanceIdDb), event(event),
+        pdrRepo(repo), handler(handler), bmcEntityTree(bmcEntityTree),
         timer(event, std::bind(std::mem_fn(&Handler::setSurvTimer), this,
                                HYPERVISOR_TID, false)),
         hostTransitioningToOff(true)

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -26,8 +26,7 @@ DbusToFileHandler::DbusToFileHandler(
     int mctp_fd, uint8_t mctp_eid, pldm::InstanceIdDb* instanceIdDb,
     sdbusplus::message::object_path resDumpCurrentObjPath,
     pldm::requester::Handler<pldm::requester::Request>* handler) :
-    mctp_fd(mctp_fd),
-    mctp_eid(mctp_eid), instanceIdDb(instanceIdDb),
+    mctp_fd(mctp_fd), mctp_eid(mctp_eid), instanceIdDb(instanceIdDb),
     resDumpCurrentObjPath(resDumpCurrentObjPath), handler(handler)
 {}
 

--- a/pldmd/dbus_impl_pdr.hpp
+++ b/pldmd/dbus_impl_pdr.hpp
@@ -39,7 +39,7 @@ class Pdr : public PdrIntf
      *  @param[in] repo - pointer to BMC's primary PDR repo
      */
     Pdr(sdbusplus::bus_t& bus, const std::string& path, const pldm_pdr* repo) :
-        PdrIntf(bus, path.c_str()), pdrRepo(repo){};
+        PdrIntf(bus, path.c_str()), pdrRepo(repo) {};
 
     /** @brief Implementation for PdrIntf.FindStateEffecterPDR
      *  @param[in] tid - PLDM terminus ID.

--- a/pldmd/dbus_impl_requester.hpp
+++ b/pldmd/dbus_impl_requester.hpp
@@ -42,8 +42,7 @@ class Requester : public RequesterIntf
      */
     Requester(sdbusplus::bus_t& bus, const std::string& path,
               InstanceIdDb& db) :
-        RequesterIntf(bus, path.c_str()),
-        pldmInstanceIdDb(db){};
+        RequesterIntf(bus, path.c_str()), pldmInstanceIdDb(db) {};
 
     /** @brief Implementation for RequesterIntf.GetInstanceId */
     uint8_t getInstanceId(uint8_t eid) override

--- a/pldmd/pldm_resp_interface.hpp
+++ b/pldmd/pldm_resp_interface.hpp
@@ -37,8 +37,7 @@ class AltResponse
     AltResponse(const AltResponse&) = delete;
     AltResponse(PldmTransport* pldmTransport, pldm_tid_t& TID,
                 bool verbose = false) :
-        pldmTransport(pldmTransport),
-        TID(TID), verbose(verbose)
+        pldmTransport(pldmTransport), TID(TID), verbose(verbose)
     {}
 
     /** @brief method to send response to remote pldm using Response interface

--- a/pldmtool/pldm_base_cmd.cpp
+++ b/pldmtool/pldm_base_cmd.cpp
@@ -251,8 +251,7 @@ class GetPLDMCommands : public CommandInterface
     GetPLDMCommands& operator=(GetPLDMCommands&&) = delete;
 
     explicit GetPLDMCommands(const char* type, const char* name,
-                             CLI::App* app) :
-        CommandInterface(type, name, app)
+                             CLI::App* app) : CommandInterface(type, name, app)
     {
         app->add_option("-t,--type", pldmType, "pldm supported type")
             ->required()

--- a/pldmtool/pldm_cmd_helper.hpp
+++ b/pldmtool/pldm_cmd_helper.hpp
@@ -78,9 +78,8 @@ class CommandInterface
   public:
     explicit CommandInterface(const char* type, const char* name,
                               CLI::App* app) :
-        pldmType(type),
-        commandName(name), mctp_eid(PLDM_ENTITY_ID), pldmVerbose(false),
-        instanceId(0)
+        pldmType(type), commandName(name), mctp_eid(PLDM_ENTITY_ID),
+        pldmVerbose(false), instanceId(0)
     {
         app->add_option("-m,--mctp_eid", mctp_eid, "MCTP endpoint ID");
         app->add_flag("-v, --verbose", pldmVerbose);

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -1565,8 +1565,7 @@ class SetStateEffecter : public CommandInterface
     static constexpr auto minEffecterCount = 1;
     static constexpr auto maxEffecterCount = 8;
     explicit SetStateEffecter(const char* type, const char* name,
-                              CLI::App* app) :
-        CommandInterface(type, name, app)
+                              CLI::App* app) : CommandInterface(type, name, app)
     {
         app->add_option(
                "-i, --id", effecterId,
@@ -1830,8 +1829,7 @@ class GetSensorReading : public CommandInterface
     GetSensorReading& operator=(GetSensorReading&&) = delete;
 
     explicit GetSensorReading(const char* type, const char* name,
-                              CLI::App* app) :
-        CommandInterface(type, name, app)
+                              CLI::App* app) : CommandInterface(type, name, app)
     {
         app->add_option(
                "-i, --sensor_id", sensorId,

--- a/requester/handler.hpp
+++ b/requester/handler.hpp
@@ -135,9 +135,8 @@ class Handler
         uint8_t numRetries = static_cast<uint8_t>(NUMBER_OF_REQUEST_RETRIES),
         std::chrono::milliseconds responseTimeOut =
             std::chrono::milliseconds(RESPONSE_TIME_OUT)) :
-        pldmTransport(pldmTransport),
-        event(event), instanceIdDb(instanceIdDb), verbose(verbose),
-        instanceIdExpiryInterval(instanceIdExpiryInterval),
+        pldmTransport(pldmTransport), event(event), instanceIdDb(instanceIdDb),
+        verbose(verbose), instanceIdExpiryInterval(instanceIdExpiryInterval),
         numRetries(numRetries), responseTimeOut(responseTimeOut)
     {}
 
@@ -464,8 +463,7 @@ struct SendRecvMsgOperation
     explicit SendRecvMsgOperation(Handler<RequestInterface>& handler,
                                   mctp_eid_t eid, pldm::Request&& request,
                                   R&& r) :
-        handler(handler),
-        request(std::move(request)), receiver(std::move(r))
+        handler(handler), request(std::move(request)), receiver(std::move(r))
     {
         auto requestMsg =
             reinterpret_cast<const pldm_msg*>(this->request.data());
@@ -601,8 +599,7 @@ struct SendRecvMsgSender
 
     explicit SendRecvMsgSender(requester::Handler<RequestInterface>& handler,
                                mctp_eid_t eid, pldm::Request&& request) :
-        handler(handler),
-        eid(eid), request(std::move(request))
+        handler(handler), eid(eid), request(std::move(request))
     {}
 
     friend auto tag_invoke(stdexec::get_completion_signatures_t,

--- a/requester/mctp_endpoint_discovery.cpp
+++ b/requester/mctp_endpoint_discovery.cpp
@@ -24,10 +24,9 @@ namespace pldm
 MctpDiscovery::MctpDiscovery(
     sdbusplus::bus_t& bus,
     std::initializer_list<MctpDiscoveryHandlerIntf*> list) :
-    bus(bus),
-    mctpEndpointAddedSignal(
-        bus, interfacesAdded(MCTPPath),
-        std::bind_front(&MctpDiscovery::discoverEndpoints, this)),
+    bus(bus), mctpEndpointAddedSignal(
+                  bus, interfacesAdded(MCTPPath),
+                  std::bind_front(&MctpDiscovery::discoverEndpoints, this)),
     mctpEndpointRemovedSignal(
         bus, interfacesRemoved(MCTPPath),
         std::bind_front(&MctpDiscovery::removeEndpoints, this)),

--- a/requester/request.hpp
+++ b/requester/request.hpp
@@ -48,8 +48,7 @@ class RequestRetryTimer
     explicit RequestRetryTimer(sdeventplus::Event& event, uint8_t numRetries,
                                std::chrono::milliseconds timeout) :
 
-        event(event),
-        numRetries(numRetries), timeout(timeout),
+        event(event), numRetries(numRetries), timeout(timeout),
         timer(event.get(), std::bind_front(&RequestRetryTimer::callback, this))
     {}
 

--- a/softoff/softoff.cpp
+++ b/softoff/softoff.cpp
@@ -39,8 +39,7 @@ namespace sdbusRule = sdbusplus::bus::match::rules;
 
 SoftPowerOff::SoftPowerOff(sdbusplus::bus_t& bus, sd_event* event,
                            pldm::InstanceIdDb& instanceIdDb, bool noTimeOut) :
-    bus(bus),
-    timer(event), instanceIdDb(instanceIdDb), noTimeOut(noTimeOut)
+    bus(bus), timer(event), instanceIdDb(instanceIdDb), noTimeOut(noTimeOut)
 {
     auto jsonData = parseConfig();
 


### PR DESCRIPTION
Due to new change in openbmc-build-scripts for the 1110 branch to clang-18, a lot of files were failing in CI format. Adding the changed format files in correspondance to CI update.