### PR TITLE
Remove check for IBM cable card

### DIFF
--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -921,7 +921,7 @@ void FruImpl::processFruPresenceChange(const DbusChangedProps& chProperties,
 #ifdef OEM_IBM
     if (fruInterface == "xyz.openbmc_project.Inventory.Item.PCIeDevice")
     {
-        if (!pldm::responder::utils::checkIfIBMCableCard(fruObjPath))
+        if (!pldm::responder::utils::checkFruPresence(fruObjPath.c_str()))
         {
             return;
         }

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -472,14 +472,16 @@ bool checkFruPresence(const char* objPath)
     std::string newObjPath = objPath;
     bool isPresent = true;
 
-    if ((newObjPath.find(pcieAdapter) != std::string::npos) &&
-        !checkIfIBMCableCard(newObjPath))
+    if (newObjPath.find(pcieAdapter) != std::string::npos)
     {
-        return true; // industry std cards
-    }
-    else if (newObjPath.find(portStr) != std::string::npos)
-    {
-        newObjPath = pldm::utils::findParent(objPath);
+        if (newObjPath.find(portStr) != std::string::npos)
+        {
+            newObjPath = pldm::utils::findParent(objPath);
+        }
+        else
+        {
+            return true; // industry std cards
+        }
     }
 
     // Phyp expects the FRU records for industry std cards to be always


### PR DESCRIPTION
Removing the check for IBM cable card because this will be verified in VPD and there is no need to have an additional check inside PLDM

Tested by : performing CM on IBM cable cards and industry standard adapters