### PR TITLE
libpldmresponder: Minor fix in isOemStateEffecter

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -963,6 +963,10 @@ bool isOemNumericEffecter(Handler& handler, uint16_t effecterId,
             effecterResolution = tmpEffecterResolution;
             return true;
         }
+        else
+        {
+            return false;
+        }
     }
     return false;
 }


### PR DESCRIPTION
This commit adds a minor fix to isOemStateEffecter missed out in SBE Dump implement rebase due to which pldm was getting hung as code control was getting stuck in the while loop of pdrRecord check due to the missing else condition in the loop.

Tested: Did persistent patch testing with setNumericEffecter cmd, did poweron of the persistent patch, flashed a complete openbmc image and did poweron till PHYP runtime. Also did boot side switch and poweron the driver to boot till PHYP runtime.