### PR TITLE
oem-ibm: Change in hb_predictive_mem_guard bios attribute

### DIFF
--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/enum_attrs.json
@@ -64,15 +64,15 @@
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard"
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation"
         },
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard",
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation",
             "readOnly": true
         },
         {

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/enum_attrs.json
@@ -78,15 +78,15 @@
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard"
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation"
         },
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard",
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation",
             "readOnly": true
         },
         {

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/enum_attrs.json
@@ -78,15 +78,15 @@
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard"
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation"
         },
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard",
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation",
             "readOnly": true
         },
         {

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/enum_attrs.json
@@ -78,15 +78,15 @@
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard"
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation"
         },
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard",
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation",
             "readOnly": true
         },
         {

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/enum_attrs.json
@@ -78,15 +78,15 @@
             "attribute_name": "hb_predictive_mem_guard",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard"
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation"
         },
         {
             "attribute_name": "hb_predictive_mem_guard_current",
             "possible_values": ["Enabled", "Disabled"],
             "default_values": ["Enabled"],
-            "helpText": "Enable or Disable Predictive Guard for Memory Errors.",
-            "displayName": "Predictive Memory Guard",
+            "helpText": "The Hypervisor dynamically removes memory pages from memory that detected predictive failures. If this option is disabled, dynamic memory deallocation will not occur for the predictive memory failures.",
+            "displayName": "Predictive Dynamic Memory Deallocation",
             "readOnly": true
         },
         {


### PR DESCRIPTION
This commit enhances the displayName and helpText of hb_predictive_mem_guard and hb_predictive_mem_guard_current bios enum attribute.