### PR TITLE
oem: ibm: PCIe Topology support

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -455,6 +455,19 @@ void CustomDBus::implementGlobalInterface(const std::string& path)
     }
 }
 
+void CustomDBus::implementPcieTopologyInterface(
+    const std::string& path, uint8_t mctpEid,
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser)
+{
+    if (pcietopology.find(path) == pcietopology.end())
+    {
+        pcietopology.emplace(path,
+                             std::make_unique<PCIETopology>(
+                                 pldm::utils::DBusHandler::getBus(),
+                                 path.c_str(), hostEffecterParser, mctpEid));
+    }
+}
+
 void CustomDBus::deleteObject(const std::string& path)
 {
     if (location.contains(path))
@@ -599,6 +612,15 @@ void CustomDBus::removeDBus(const std::vector<uint16_t> types)
         {
             deleteObject(path);
         }
+    }
+}
+
+void CustomDBus::updateTopologyProperty(bool value)
+{
+    if (pcietopology.contains("/xyz/openbmc_project/pldm"))
+    {
+        pcietopology.at("/xyz/openbmc_project/pldm")
+            ->pcIeTopologyRefresh(value);
     }
 }
 

--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -137,15 +137,14 @@ void CustomDBus::implementPCIeSlotInterface(const std::string& path)
 }
 
 void CustomDBus::setSlotProperties(const std::string& path,
-                                   const uint32_t& /*value*/,
-                                   const std::string& /*linkState*/)
+                                   const uint32_t& value,
+                                   const std::string& linkState)
 {
-    // auto linkStatus =
-    // pldm::dbus::PCIeSlot::convertStatusFromString(linkState);
+    auto linkStatus = pldm::dbus::PCIeSlot::convertStatusFromString(linkState);
     if (pcieSlot.contains(path))
     {
-        // pcieSlot.at(path)->busId(value);
-        //  pcieSlot.at(path)->linkStatus(linkStatus);
+        pcieSlot.at(path)->busId(value);
+        pcieSlot.at(path)->linkStatus(linkStatus);
     }
 }
 
@@ -184,15 +183,15 @@ void CustomDBus::setPCIeDeviceProps(const std::string& path, int64_t lanesInuse,
 
 void CustomDBus::setCableAttributes(const std::string& path, double length,
                                     const std::string& cableDescription,
-                                    const std::string& /*status*/)
+                                    const std::string& status)
 {
-    // pldm::dbus::ItemCable::Status cableStatus =
-    //   pldm::dbus::Cable::convertStatusFromString(status);
+    pldm::dbus::ItemCable::Status cableStatus =
+        pldm::dbus::Cable::convertStatusFromString(status);
     if (cable.contains(path))
     {
         cable.at(path)->length(length);
         cable.at(path)->cableTypeDescription(cableDescription);
-        // cable.at(path)->cableStatus(cableStatus);
+        cable.at(path)->cableStatus(cableStatus);
     }
 }
 

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -25,6 +25,7 @@
 #include "operational_status.hpp"
 #include "pcie_device.hpp"
 #include "pcie_slot.hpp"
+#include "pcie_topology.hpp"
 #include "port.hpp"
 #include "power_supply.hpp"
 #include "vrm.hpp"
@@ -346,6 +347,17 @@ class CustomDBus
      */
     void implementObjectEnableIface(const std::string& path, bool value);
 
+    /** @brief Implement PCIE Topology interface
+     *
+     *  @param[in] path - The object path
+     *  @param[in] mctpEid - mctp endpoint
+     *  @param[in] hostEffecterParser - Pointer to host effecter parser
+     *
+     */
+    void implementPcieTopologyInterface(
+        const std::string& path, uint8_t mctpEid,
+        pldm::host_effecters::HostEffecterParser* hostEffecterParser);
+
     /** @brief Remove DBus objects from cache
      *
      *  @param[in] types  - entity type
@@ -376,6 +388,12 @@ class CustomDBus
 
     /* @brief set slot type */
     void setSlotType(const std::string& path, const std::string& slotType);
+
+    /** @brief update topology property
+     *
+     *  @param[in] value - topology value
+     */
+    void updateTopologyProperty(bool value);
 
   private:
     std::unordered_map<ObjectPath, std::unique_ptr<LocationCode>> location;
@@ -408,6 +426,7 @@ class CustomDBus
     std::unordered_map<ObjectPath, std::unique_ptr<Port>> port;
     std::unordered_map<ObjectPath, std::unique_ptr<Cable>> cable;
     std::unordered_map<ObjectPath, std::unique_ptr<Asset>> asset;
+    std::unordered_map<ObjectPath, std::unique_ptr<PCIETopology>> pcietopology;
 };
 
 } // namespace dbus

--- a/host-bmc/dbus/pcie_topology.cpp
+++ b/host-bmc/dbus/pcie_topology.cpp
@@ -1,0 +1,179 @@
+#include "pcie_topology.hpp"
+
+#include "libpldm/entity.h"
+#include "libpldm/oem/ibm/state_set.h"
+
+#include "host-bmc/dbus/custom_dbus.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm
+{
+namespace dbus
+{
+
+bool PCIETopology::pcIeTopologyRefresh() const
+{
+    return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+        pcIeTopologyRefresh();
+}
+
+bool PCIETopology::updateTopologyRefresh()
+{
+    stateOfCallback.first = false;
+    stateOfCallback.second = false;
+    return sdbusplus::com::ibm::PLDM::server::PCIeTopology::pcIeTopologyRefresh(
+        true);
+}
+
+bool PCIETopology::callbackGetPCIeTopology(bool value)
+{
+    stateOfCallback.first = value;
+
+    if (stateOfCallback.first && stateOfCallback.second)
+    {
+        // if both the states of the effecter are set only then update the
+        // property
+        return updateTopologyRefresh();
+    }
+    return false;
+}
+
+bool PCIETopology::callbackGetCableInfo(bool value)
+{
+    stateOfCallback.second = value;
+
+    if (stateOfCallback.first && stateOfCallback.second)
+    {
+        // if both the states of the effecter are set only then update the
+        // property
+        return updateTopologyRefresh();
+    }
+    return false;
+}
+
+bool PCIETopology::pcIeTopologyRefresh(bool value)
+{
+    std::vector<set_effecter_state_field> stateField;
+    std::vector<set_effecter_state_field> stateField1;
+
+    if (value ==
+        sdbusplus::com::ibm::PLDM::server::PCIeTopology::pcIeTopologyRefresh())
+    {
+        stateField.push_back({PLDM_NO_CHANGE, 0});
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            pcIeTopologyRefresh(value);
+    }
+    else
+    {
+        stateField.push_back({PLDM_REQUEST_SET, GET_PCIE_TOPOLOGY});
+        stateField1.push_back({PLDM_REQUEST_SET, GET_CABLE_INFO});
+    }
+
+    if (value && hostEffecterParser)
+    {
+        uint16_t effecterID = getEffecterID();
+
+        if (effecterID == 0)
+        {
+            return false;
+        }
+        // callback is done only when setting the effecter is successful
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctpEid, effecterID, 1, stateField,
+            std::bind(
+                std::mem_fn(&pldm::dbus::PCIETopology::callbackGetPCIeTopology),
+                this, std::placeholders::_1),
+            value);
+
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctpEid, effecterID, 1, stateField1,
+            std::bind(
+                std::mem_fn(&pldm::dbus::PCIETopology::callbackGetCableInfo),
+                this, std::placeholders::_1),
+            value);
+    }
+
+    // Set the property to true only when the two set state effecter calls are
+    // successful
+    if (stateOfCallback.first && stateOfCallback.second)
+    {
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            pcIeTopologyRefresh(true);
+    }
+    else
+    {
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            pcIeTopologyRefresh(false);
+    }
+}
+
+bool PCIETopology::savePCIeTopologyInfo() const
+{
+    return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+        savePCIeTopologyInfo();
+}
+
+bool PCIETopology::savePCIeTopologyInfo(bool value)
+{
+    std::vector<set_effecter_state_field> stateField;
+
+    if (value ==
+        sdbusplus::com::ibm::PLDM::server::PCIeTopology::savePCIeTopologyInfo())
+    {
+        stateField.push_back({PLDM_NO_CHANGE, 0});
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            savePCIeTopologyInfo(value);
+    }
+    else
+    {
+        stateField.push_back({PLDM_REQUEST_SET, SAVE_PCIE_TOPLOGY});
+    }
+
+    if (value && hostEffecterParser)
+    {
+        uint16_t effecterID = getEffecterID();
+
+        if (effecterID == 0)
+        {
+            return false;
+        }
+
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctpEid, effecterID, 1, stateField, nullptr, value);
+        return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+            savePCIeTopologyInfo(false);
+    }
+    return sdbusplus::com::ibm::PLDM::server::PCIeTopology::
+        savePCIeTopologyInfo(value);
+}
+
+uint16_t PCIETopology::getEffecterID()
+{
+    uint16_t effecterID = 0;
+
+    pldm::pdr::EntityType entityType = PLDM_ENTITY_GROUP | 0x8000;
+    auto stateEffecterPDRs = pldm::utils::findStateEffecterPDR(
+        mctpEid, entityType,
+        static_cast<uint16_t>(PLDM_OEM_IBM_PCIE_TOPOLOGY_ACTIONS),
+        hostEffecterParser->getPldmPDR());
+    if (stateEffecterPDRs.empty())
+    {
+        error(
+            "PCIe Topology: The state set PDR can not be found, entityType = {ENTITY_TYPE}",
+            "ENTITY_TYPE", entityType);
+        return effecterID;
+    }
+    for (auto& rep : stateEffecterPDRs)
+    {
+        auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(rep.data());
+        effecterID = pdr->effecter_id;
+        break;
+    }
+    return effecterID;
+}
+
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/dbus/pcie_topology.hpp
+++ b/host-bmc/dbus/pcie_topology.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "libpldm/pdr.h"
+
+#include "../dbus_to_host_effecters.hpp"
+#include "common/utils.hpp"
+
+#include <com/ibm/PLDM/PCIeTopology/server.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdbusplus/server/object.hpp>
+
+#include <string>
+#include <utility>
+
+namespace pldm
+{
+namespace dbus
+{
+using TopologyObj = sdbusplus::server::object_t<
+    sdbusplus::com::ibm::PLDM::server::PCIeTopology>;
+
+class PCIETopology : public TopologyObj
+{
+  public:
+    PCIETopology() = delete;
+    ~PCIETopology() = default;
+    PCIETopology(const PCIETopology&) = delete;
+    PCIETopology& operator=(const PCIETopology&) = delete;
+    PCIETopology(PCIETopology&&) = delete;
+    PCIETopology& operator=(PCIETopology&&) = delete;
+
+    PCIETopology(sdbusplus::bus_t& bus, const std::string& objPath,
+                 pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+                 uint8_t mctpEid) :
+        TopologyObj(bus, objPath.c_str()),
+        hostEffecterParser(hostEffecterParser), mctpEid(mctpEid)
+
+    {}
+
+    bool pcIeTopologyRefresh(bool value) override;
+
+    bool pcIeTopologyRefresh() const override;
+
+    bool savePCIeTopologyInfo(bool value) override;
+
+    bool savePCIeTopologyInfo() const override;
+
+    uint16_t getEffecterID();
+
+    bool updateTopologyRefresh();
+
+    /** @brief callback to getPCIeTopology **/
+    bool callbackGetPCIeTopology(bool value);
+
+    /** @brief callback to getCableInfo **/
+    bool callbackGetCableInfo(bool value);
+
+  private:
+    /** @brief Pointer to host effecter parser */
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser;
+
+    /** mctp endpoint id */
+    uint8_t mctpEid;
+
+    /** Pair to indicate the state of callbacks */
+    std::pair<bool, bool> stateOfCallback = std::make_pair(false, false);
+};
+
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/test/meson.build
+++ b/host-bmc/test/meson.build
@@ -23,6 +23,7 @@ test_sources = [
   '../dbus/cable.cpp',
   '../dbus/asset.cpp',
   '../dbus/pcie_device.cpp',
+  '../dbus/pcie_topology.cpp',
 ]
 
 tests = [

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -52,6 +52,7 @@ sources = [
   '../host-bmc/dbus/serialize.cpp',
   '../host-bmc/dbus/location_code.cpp',
   '../host-bmc/dbus/deserialize.cpp',
+  '../host-bmc/dbus/pcie_topology.cpp',
   'event_parser.cpp'
 ]
 

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -14,12 +14,74 @@ namespace pldm
 namespace responder
 {
 
+std::unordered_map<uint8_t, std::string> linkStateMap{
+    {0x00, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Operational"},
+    {0x01, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Degraded"},
+    {0x02, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Unused"},
+    {0x03, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Unused"},
+    {0x04, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Failed"},
+    {0x05, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Open"},
+    {0x06, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Inactive"},
+    {0x07, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Unused"},
+    {0xFF, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Status.Unknown"}};
+
+std::unordered_map<uint8_t, std::string> linkSpeed{
+    {0x00, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Gen1"},
+    {0x01, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Gen2"},
+    {0x02, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Gen3"},
+    {0x03, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Gen4"},
+    {0x04, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Gen5"},
+    {0x10, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Unknown"},
+    {0xFF, "xyz.openbmc_project.Inventory.Item.PCIeSlot.Generations.Unknown"}};
+
+std::unordered_map<uint8_t, size_t> linkWidth{
+    {0x01, 1},  {0x02, 2},        {0x04, 4}, {0x08, 8},
+    {0x10, 16}, {0xFF, UINT_MAX}, {0x00, 0}};
+
+std::unordered_map<uint8_t, double> cableLengthMap{
+    {0x00, 0},  {0x01, 2},  {0x02, 3},
+    {0x03, 10}, {0x04, 20}, {0xFF, std::numeric_limits<double>::quiet_NaN()}};
+
+std::unordered_map<uint8_t, std::string> cableTypeMap{
+    {0x00, "optical"}, {0x01, "copper"}, {0xFF, "Unknown"}};
+
+std::unordered_map<uint8_t, std::string> cableStatusMap{
+    {0x00, "xyz.openbmc_project.Inventory.Item.Cable.Status.Inactive"},
+    {0x01, "xyz.openbmc_project.Inventory.Item.Cable.Status.Running"},
+    {0x02, "xyz.openbmc_project.Inventory.Item.Cable.Status.PoweredOff"},
+    {0xFF, "xyz.openbmc_project.Inventory.Item.Cable.Status.Unknown"}};
+
 static constexpr auto pciePath = "/var/lib/pldm/pcie-topology/";
 constexpr auto topologyFile = "topology";
 constexpr auto cableInfoFile = "cableinfo";
 
+// Slot location code structure contains multiple slot location code
+// suffix structures.
+// Each slot location code suffix structure is as follows
+// {Slot location code suffix size(uint8_t),
+//  Slot location code suffix(variable size)}
+constexpr auto sizeOfSuffixSizeDataMember = 1;
+
+// Each slot location structure contains
+// {
+//   Number of slot location codes (1byte),
+//   Slot location code Common part size (1byte)
+//   Slot location common part (Var)
+// }
+constexpr auto slotLocationDataMemberSize = 2;
+
 namespace fs = std::filesystem;
+
 std::unordered_map<uint16_t, bool> PCIeInfoHandler::receivedFiles;
+std::unordered_map<LinkId, std::tuple<LinkStatus, linkTypeData, LinkSpeed,
+                                      LinkWidth, PcieHostBridgeLoc, LocalPort,
+                                      RemotePort, IoSlotLocation, LinkId>>
+    PCIeInfoHandler::topologyInformation;
+std::unordered_map<
+    CableLinkNum, std::tuple<LinkId, LocalPortLocCode, IoSlotLocationCode,
+                             CablePartNum, CableLength, CableType, CableStatus>>
+    PCIeInfoHandler::cableInformation;
+std::unordered_map<LinkId, linkTypeData> PCIeInfoHandler::linkTypeInfo;
 
 PCIeInfoHandler::PCIeInfoHandler(uint32_t fileHandle, uint16_t fileType) :
     FileHandler(fileHandle), infoType(fileType)
@@ -110,6 +172,9 @@ int PCIeInfoHandler::fileAck(uint8_t /*fileStatus*/)
             receivedFiles.at(PLDM_FILE_TYPE_PCIE_TOPOLOGY))
         {
             receivedFiles.clear();
+            // parse the topology data and cache the information
+            // for further processing
+            parseTopologyData();
         }
     }
     catch (const std::out_of_range& e)
@@ -117,6 +182,342 @@ int PCIeInfoHandler::fileAck(uint8_t /*fileStatus*/)
         info("Received only one of the topology file");
     }
     return PLDM_SUCCESS;
+}
+
+void PCIeInfoHandler::parseTopologyData()
+{
+    int fd = open((fs::path(pciePath) / topologyFile).string().c_str(),
+                  O_RDONLY, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        perror("Topology file not present");
+        return;
+    }
+    pldm::utils::CustomFD topologyFd(fd);
+    // Reading the statistics of the topology file, to get the size.
+    // stat sb is the out parameter provided to fstat
+    struct stat sb;
+    if (fstat(fd, &sb) == -1)
+    {
+        perror("Could not get topology file size");
+        return;
+    }
+
+    if (sb.st_size == 0)
+    {
+        error("Topology file Size is 0");
+        return;
+    }
+
+    auto topologyCleanup = [sb](void* fileInMemory) {
+        munmap(fileInMemory, sb.st_size);
+    };
+
+    // memory map the topology file into pldm memory
+    void* fileInMemory = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE,
+                              topologyFd(), 0);
+    if (MAP_FAILED == fileInMemory)
+    {
+        error("mmap on topology file failed with error {RC}", "RC", -errno);
+        return;
+    }
+
+    std::unique_ptr<void, decltype(topologyCleanup)> topologyPtr(
+        fileInMemory, topologyCleanup);
+
+    auto pcieLinkList = reinterpret_cast<struct topologyBlob*>(fileInMemory);
+    uint16_t numOfLinks = 0;
+    if (!pcieLinkList)
+    {
+        error("Parsing of topology file failed : pcieLinkList is null");
+        return;
+    }
+
+    // The elements in the structure that were being parsed from the obtained
+    // files via write() and writeFromMemory() were written by IBM enterprise
+    // host firmware which runs on big-endian format. The DMA engine in BMC
+    // (aspeed-xdma device driver) which is responsible for exposing the data
+    // shared by the host in the shared VGA memory has no idea of the structure
+    // of the data it's copying from host. So it's up to the consumers of the
+    // data to deal with the endianness once it has been copied to user space &
+    // and as pldm is the first application layer that interprets the data
+    // provided by host reading from the sysfs interface of xdma-engine & also
+    // since pldm application runs on BMC which could be little/big endian, its
+    // essential to swap the endianness to agreed big-endian format (htobe)
+    // before using the data.
+
+    numOfLinks = htobe16(pcieLinkList->numPcieLinkEntries);
+
+    // To fetch the PCIe link from the topology data, moving the pointer
+    // by 8 bytes based on the size of other elements of the structure
+    struct pcieLinkEntry* singleEntryData =
+        reinterpret_cast<struct pcieLinkEntry*>(
+            reinterpret_cast<uint8_t*>(pcieLinkList) + 8);
+
+    if (!singleEntryData)
+    {
+        error("Parsing of topology file failed : single_link is null");
+        return;
+    }
+
+    auto singleEntryDataCharStream = reinterpret_cast<char*>(singleEntryData);
+
+    // iterate over every pcie link and get the link specific attributes
+    for ([[maybe_unused]] const auto& link :
+         std::views::iota(0) | std::views::take(numOfLinks))
+    {
+        // get the link id
+        auto linkId = htobe16(singleEntryData->linkId);
+
+        // get parent link id
+        auto parentLinkId = htobe16(singleEntryData->parentLinkId);
+
+        // get link status
+        auto linkStatus = singleEntryData->linkStatus;
+
+        // get link type
+        auto type = singleEntryData->linkType;
+        if (type != pldm::responder::linkTypeData::Unknown)
+        {
+            linkTypeInfo[linkId] = type;
+        }
+
+        // get link speed
+        auto linkSpeed = singleEntryData->linkSpeed;
+
+        // get link width
+        auto width = singleEntryData->linkWidth;
+
+        // get the PCIe Host Bridge Location
+        size_t pcieLocCodeSize = singleEntryData->pcieHostBridgeLocCodeSize;
+        std::vector<char> pcieHostBridgeLocation(
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->pcieHostBridgeLocCodeOff),
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->pcieHostBridgeLocCodeOff) +
+                static_cast<int>(pcieLocCodeSize));
+        std::string pcieHostBridgeLocationCode(pcieHostBridgeLocation.begin(),
+                                               pcieHostBridgeLocation.end());
+
+        // get the local port - top location
+        size_t localTopPortLocSize = singleEntryData->topLocalPortLocCodeSize;
+        std::vector<char> localTopPortLocation(
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->topLocalPortLocCodeOff),
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->topLocalPortLocCodeOff) +
+                static_cast<int>(localTopPortLocSize));
+        std::string localTopPortLocationCode(localTopPortLocation.begin(),
+                                             localTopPortLocation.end());
+
+        // get the local port - bottom location
+        size_t localBottomPortLocSize =
+            singleEntryData->bottomLocalPortLocCodeSize;
+        std::vector<char> localBottomPortLocation(
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->bottomLocalPortLocCodeOff),
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->bottomLocalPortLocCodeOff) +
+                static_cast<int>(localBottomPortLocSize));
+        std::string localBottomPortLocationCode(localBottomPortLocation.begin(),
+                                                localBottomPortLocation.end());
+
+        // get the remote port - top location
+        size_t remoteTopPortLocSize = singleEntryData->topRemotePortLocCodeSize;
+        std::vector<char> remoteTopPortLocation(
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->topRemotePortLocCodeOff),
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->topRemotePortLocCodeOff) +
+                static_cast<int>(remoteTopPortLocSize));
+        std::string remoteTopPortLocationCode(remoteTopPortLocation.begin(),
+                                              remoteTopPortLocation.end());
+
+        // get the remote port - bottom location
+        size_t remoteBottomLocSize =
+            singleEntryData->bottomRemotePortLocCodeSize;
+        std::vector<char> remoteBottomPortLocation(
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->bottomRemotePortLocCodeOff),
+            singleEntryDataCharStream +
+                htobe16(singleEntryData->bottomRemotePortLocCodeOff) +
+                static_cast<int>(remoteBottomLocSize));
+        std::string remoteBottomPortLocationCode(
+            remoteBottomPortLocation.begin(), remoteBottomPortLocation.end());
+
+        struct slotLocCode* slotData = reinterpret_cast<struct slotLocCode*>(
+            (reinterpret_cast<uint8_t*>(singleEntryData)) +
+            htobe16(singleEntryData->slotLocCodesOffset));
+        if (!slotData)
+        {
+            error("Parsing the topology file failed : slotData is null");
+            return;
+        }
+        // get the Slot location code common part
+        size_t numOfSlots = slotData->numSlotLocCodes;
+        size_t slotLocCodeCompartSize = slotData->slotLocCodesCmnPrtSize;
+        std::vector<char> slotLocation(
+            reinterpret_cast<char*>(slotData->slotLocCodesCmnPrt),
+            (reinterpret_cast<char*>(slotData->slotLocCodesCmnPrt) +
+             static_cast<int>(slotLocCodeCompartSize)));
+        std::string slotLocationCode(slotLocation.begin(), slotLocation.end());
+
+        uint8_t* suffixData = reinterpret_cast<uint8_t*>(slotData) +
+                              slotLocationDataMemberSize +
+                              slotData->slotLocCodesCmnPrtSize;
+        if (!suffixData)
+        {
+            error("slot location suffix data is nullptr");
+            return;
+        }
+
+        // create the full slot location code by combining common part and
+        // suffix part
+        std::string slotSuffixLocationCode;
+        std::vector<std::string> slotFinaLocationCode{};
+        for ([[maybe_unused]] const auto& slot :
+             std::views::iota(0) | std::views::take(numOfSlots))
+        {
+            struct slotLocCodeSuf* slotLocSufData =
+                reinterpret_cast<struct slotLocCodeSuf*>(suffixData);
+            if (!slotLocSufData)
+            {
+                error("slot location suffix data is nullptr");
+                break;
+            }
+
+            size_t slotLocCodeSuffixSize = slotLocSufData->slotLocCodeSz;
+            if (slotLocCodeSuffixSize > 0)
+            {
+                std::vector<char> slotSuffixLocation(
+                    reinterpret_cast<char*>(slotLocSufData) + 1,
+                    reinterpret_cast<char*>(slotLocSufData) + 1 +
+                        static_cast<int>(slotLocCodeSuffixSize));
+                std::string slotSuffLocationCode(slotSuffixLocation.begin(),
+                                                 slotSuffixLocation.end());
+
+                slotSuffixLocationCode = slotSuffLocationCode;
+            }
+            std::string slotFullLocationCode = slotLocationCode +
+                                               slotSuffixLocationCode;
+            slotFinaLocationCode.push_back(slotFullLocationCode);
+
+            // move the pointer to next slot
+            suffixData += sizeOfSuffixSizeDataMember + slotLocCodeSuffixSize;
+        }
+
+        // store the information into a map
+        topologyInformation[linkId] =
+            std::make_tuple(linkStateMap[linkStatus], type, linkSpeed,
+                            linkWidth[width], pcieHostBridgeLocationCode,
+                            std::make_pair(localTopPortLocationCode,
+                                           localBottomPortLocationCode),
+                            std::make_pair(remoteTopPortLocationCode,
+                                           remoteBottomPortLocationCode),
+                            slotFinaLocationCode, parentLinkId);
+
+        // move the pointer to next link
+        singleEntryData = reinterpret_cast<struct pcieLinkEntry*>(
+            reinterpret_cast<uint8_t*>(singleEntryData) +
+            htobe16(singleEntryData->entryLength));
+    }
+    // Need to call cable info at the end , because we dont want to parse
+    // cable info without parsing the successfull topology successfully
+    // Having partial information is of no use.
+    parseCableInfo();
+}
+
+void PCIeInfoHandler::parseCableInfo()
+{
+    int fd = open((fs::path(pciePath) / cableInfoFile).string().c_str(),
+                  O_RDONLY, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        perror("CableInfo file not present");
+        return;
+    }
+    pldm::utils::CustomFD cableInfoFd(fd);
+    struct stat sb;
+
+    if (fstat(fd, &sb) == -1)
+    {
+        perror("Could not get cableinfo file size");
+        return;
+    }
+
+    if (sb.st_size == 0)
+    {
+        error("Topology file Size is 0");
+        return;
+    }
+
+    auto cableInfoCleanup = [sb](void* fileInMemory) {
+        munmap(fileInMemory, sb.st_size);
+    };
+
+    void* fileInMemory = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE,
+                              cableInfoFd(), 0);
+
+    if (MAP_FAILED == fileInMemory)
+    {
+        int rc = -errno;
+        error("mmap on cable ifno file failed, RC={RC}", "RC", rc);
+        return;
+    }
+
+    std::unique_ptr<void, decltype(cableInfoCleanup)> cablePtr(
+        fileInMemory, cableInfoCleanup);
+
+    auto cableList =
+        reinterpret_cast<struct cableAttributesList*>(fileInMemory);
+
+    // get number of cable links
+    auto numOfCableLinks = htobe16(cableList->numOfCables);
+
+    struct pcieLinkCableAttr* cableData =
+        reinterpret_cast<struct pcieLinkCableAttr*>(
+            (reinterpret_cast<uint8_t*>(cableList)) +
+            (sizeof(struct cableAttributesList) - 1));
+
+    if (!cableData)
+    {
+        error("Cable info parsing failed , cableData = nullptr");
+        return;
+    }
+
+    // iterate over each pci cable link
+    for (const auto& cable :
+         std::views::iota(0) | std::views::take(numOfCableLinks))
+    {
+        // get the link id
+        auto linkId = htobe16(cableData->linkId);
+        char* cableDataPtr = reinterpret_cast<char*>(cableData);
+
+        std::string localPortLocCode(
+            cableDataPtr + htobe16(cableData->hostPortLocationCodeOffset),
+            cableData->hostPortLocationCodeSize);
+
+        std::string ioSlotLocationCode(
+            cableDataPtr +
+                htobe16(cableData->ioEnclosurePortLocationCodeOffset),
+            cableData->ioEnclosurePortLocationCodeSize);
+
+        std::string cablePartNum(cableDataPtr +
+                                     htobe16(cableData->cablePartNumberOffset),
+                                 cableData->cablePartNumberSize);
+
+        // cache the data into a map
+        cableInformation[cable] = std::make_tuple(
+            linkId, localPortLocCode, ioSlotLocationCode, cablePartNum,
+            cableLengthMap[cableData->cableLength],
+            cableTypeMap[cableData->cableType],
+            cableStatusMap[cableData->cableStatus]);
+        // move the cable data pointer
+
+        cableData = reinterpret_cast<struct pcieLinkCableAttr*>(
+            (reinterpret_cast<uint8_t*>(cableData)) +
+            htobe16(cableData->entryLength));
+    }
 }
 
 } // namespace responder

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -2,12 +2,131 @@
 
 #include "file_io_by_type.hpp"
 
+#include <sys/mman.h>
+
 #include <unordered_map>
 
 namespace pldm
 {
 namespace responder
 {
+/* Topology enum definitions*/
+
+extern std::unordered_map<uint8_t, std::string> linkStateMap;
+extern std::unordered_map<uint8_t, std::string> linkSpeed;
+extern std::unordered_map<uint8_t, size_t> linkWidth;
+
+enum class linkTypeData : uint8_t
+{
+    Primary = 0x0,
+    Secondary = 0x1,
+    OpenCAPI = 0x2,
+    Unknown = 0xFF
+};
+
+struct slotLocCode
+{
+    uint8_t numSlotLocCodes;
+    uint8_t slotLocCodesCmnPrtSize;
+    uint8_t slotLocCodesCmnPrt[1];
+} __attribute__((packed));
+
+struct slotLocCodeSuf
+{
+    uint8_t slotLocCodeSz;
+    uint8_t slotLocCodeSuf[1];
+} __attribute__((packed));
+
+struct pcieLinkEntry
+{
+    uint16_t entryLength;
+    uint8_t version;
+    uint8_t reserved1;
+    uint16_t linkId;
+    uint16_t parentLinkId;
+    uint32_t linkDrcIndex;
+    uint32_t hubDrcIndex;
+    uint8_t linkStatus;
+    pldm::responder::linkTypeData linkType;
+    uint16_t reserved2;
+    uint8_t linkSpeed;
+    uint8_t linkWidth;
+    uint8_t pcieHostBridgeLocCodeSize;
+    uint16_t pcieHostBridgeLocCodeOff;
+    uint8_t topLocalPortLocCodeSize;
+    uint16_t topLocalPortLocCodeOff;
+    uint8_t bottomLocalPortLocCodeSize;
+    uint16_t bottomLocalPortLocCodeOff;
+    uint8_t topRemotePortLocCodeSize;
+    uint16_t topRemotePortLocCodeOff;
+    uint8_t bottomRemotePortLocCodeSize;
+    uint16_t bottomRemotePortLocCodeOff;
+    uint16_t slotLocCodesOffset;
+    uint8_t pciLinkEntryLocCode[1];
+} __attribute__((packed));
+
+struct topologyBlob
+{
+    uint32_t totalDataSize;
+    int16_t numPcieLinkEntries;
+    uint16_t reserved;
+    pcieLinkEntry pciLinkEntry[1];
+} __attribute__((packed));
+
+using LinkId = uint16_t;
+using LinkStatus = std::string;
+using LinkType = uint8_t;
+using LinkSpeed = uint8_t;
+using LinkWidth = int64_t;
+using PcieHostBridgeLoc = std::string;
+using LocalPortTop = std::string;
+using LocalPortBot = std::string;
+using LocalPort = std::pair<LocalPortTop, LocalPortBot>;
+using RemotePortTop = std::string;
+using RemotePortBot = std::string;
+using RemotePort = std::pair<RemotePortTop, RemotePortBot>;
+using IoSlotLocation = std::vector<std::string>;
+using CableLinkNum = unsigned short int;
+using LocalPortLocCode = std::string;
+using IoSlotLocationCode = std::string;
+using CablePartNum = std::string;
+using CableLength = double;
+using CableType = std::string;
+using CableStatus = std::string;
+
+/* Cable Attributes Info */
+
+extern std::unordered_map<uint8_t, double> cableLengthMap;
+extern std::unordered_map<uint8_t, std::string> cableTypeMap;
+extern std::unordered_map<uint8_t, std::string> cableStatusMap;
+
+struct pcieLinkCableAttr
+{
+    uint16_t entryLength;
+    uint8_t version;
+    uint8_t reserved1;
+    uint16_t linkId;
+    uint16_t reserved2;
+    uint32_t linkDrcIndex;
+    uint8_t cableLength;
+    uint8_t cableType;
+    uint8_t cableStatus;
+    uint8_t hostPortLocationCodeSize;
+    uint8_t ioEnclosurePortLocationCodeSize;
+    uint8_t cablePartNumberSize;
+    uint16_t hostPortLocationCodeOffset;
+    uint16_t ioEnclosurePortLocationCodeOffset;
+    uint16_t cablePartNumberOffset;
+    uint8_t cableAttrLocCode[1];
+};
+
+struct cableAttributesList
+{
+    uint32_t lengthOfResponse;
+    uint16_t numOfCables;
+    uint16_t reserved;
+    pcieLinkCableAttr pciLinkCableAttr[1];
+};
 
 /** @class PCIeInfoHandler
  *
@@ -80,6 +199,11 @@ class PCIeInfoHandler : public FileHandler
     {
         return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
     }
+    /** @brief method to parse the pcie topology information */
+    virtual void parseTopologyData();
+
+    /** @brief method to parse the cable information */
+    virtual void parseCableInfo();
 
     virtual void postWriteAction(
         const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
@@ -91,6 +215,58 @@ class PCIeInfoHandler : public FileHandler
 
   private:
     uint16_t infoType; //!< type of the information
+
+    /**
+     * @brief Map contains Topology data
+     *
+     * This static unordered map associates link IDs with link attributes.
+     * Key - LinkID (LinkId)
+     * Value - Tuple
+     *         link status (LinkStatus)
+     *         link type (LinkType)
+     *         link speed (LinkSpeed)
+     *         link width (LinkWidth)
+     *         PCIe host bridge location (PcieHostBridgeLoc)
+     *         Local port (LocalPort - Pair of local port top and bottom)
+     *         Remote port (RemotePort - Pair of remote port top and bottom)
+     *         I/O slot location (IoSlotLocation - Vector of strings)
+     */
+    static std::unordered_map<
+        LinkId, std::tuple<LinkStatus, linkTypeData, LinkSpeed, LinkWidth,
+                           PcieHostBridgeLoc, LocalPort, RemotePort,
+                           IoSlotLocation, LinkId>>
+        topologyInformation;
+    /**
+     * @brief Static unordered map containing cable information.
+     *
+     * This map associates cable link numbers with a tuple containing various
+     * cable attributes.
+     *
+     * Key - CableLinkID (CableLinkNum)
+     * Value - Tuple
+     *         Link ID (LinkId)
+     *         Local port location code (LocalPortLocCode)
+     *         I/O slot location code (IoSlotLocationCode)
+     *         Cable part number (CablePartNum)
+     *         Cable length (CableLength)
+     *         Cable type (CableType)
+     *         Cable status (CableStatus)
+     */
+
+    static std::unordered_map<
+        CableLinkNum,
+        std::tuple<LinkId, LocalPortLocCode, IoSlotLocationCode, CablePartNum,
+                   CableLength, CableType, CableStatus>>
+        cableInformation;
+    /**
+     * @brief Static unordered map containing linkId to link type information.
+     *
+     * This map associates link numbers to the link type
+     *
+     * Key - LinkID (LinkId)
+     * Value - linkTypeData (linkTypeData)
+     */
+    static std::unordered_map<LinkId, linkTypeData> linkTypeInfo;
 
     /** @brief A static unordered map storing information about received files.
      *

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -122,11 +122,13 @@ class Handler : public oem_platform::Handler
             uint8_t mctp_eid, pldm::InstanceIdDb& instanceIdDb,
             sdeventplus::Event& event, pldm_pdr* repo,
             pldm::requester::Handler<pldm::requester::Request>* handler,
-            pldm_entity_association_tree* bmcEntityTree) :
+            pldm_entity_association_tree* bmcEntityTree,
+            pldm::host_effecters::HostEffecterParser* hostEffecterParser) :
         oem_platform::Handler(dBusIntf), codeUpdate(codeUpdate),
         slotHandler(slotHandler), platformHandler(nullptr), mctp_fd(mctp_fd),
         mctp_eid(mctp_eid), instanceIdDb(instanceIdDb), event(event),
         pdrRepo(repo), handler(handler), bmcEntityTree(bmcEntityTree),
+        hostEffecterParser(hostEffecterParser),
         timer(event, std::bind(std::mem_fn(&Handler::setSurvTimer), this,
                                HYPERVISOR_TID, false)),
         hostTransitioningToOff(true)
@@ -134,6 +136,8 @@ class Handler : public oem_platform::Handler
         codeUpdate->setVersions();
         pldm::responder::utils::clearLicenseStatus();
         setEventReceiverCnt = 0;
+        pldm::responder::utils::hostPCIETopologyIntf(mctp_eid,
+                                                     hostEffecterParser);
 
         sdbusplus::message::object_path path;
         dbusToFileioIntf =
@@ -668,6 +672,10 @@ class Handler : public oem_platform::Handler
 
     /** @brief Pointer to BMC's entity association tree */
     pldm_entity_association_tree* bmcEntityTree;
+
+    /** @brief Pointer to host effecter parser */
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser;
+
     /** @brief D-Bus property changed signal match */
     std::unique_ptr<sdbusplus::bus::match_t> updateBIOSMatch;
 

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -440,6 +440,14 @@ std::vector<char> vecSplit(const std::vector<char>& inputVec,
     return resultVec;
 }
 
+void hostPCIETopologyIntf(
+    uint8_t mctp_eid,
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser)
+{
+    CustomDBus::getCustomDBus().implementPcieTopologyInterface(
+        "/xyz/openbmc_project/pldm", mctp_eid, hostEffecterParser);
+}
+
 } // namespace utils
 
 namespace oem_ibm_utils

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -174,6 +174,20 @@ void hostPCIETopologyIntf(
     uint8_t mctp_eid,
     pldm::host_effecters::HostEffecterParser* hostEffecterParser);
 
+std::pair<std::string, std::string>
+    getSlotAndAdapter(const std::string& portLocationCode);
+
+/** @brief Fetch D-Bus object path based on location details and the type of
+ * Inventory Item
+ *
+ *  @param[in] locationCode - property value of LocationCode
+ *  @param[in] inventoryItemType - inventory item type
+ *
+ *  @return std::string - the D-Bus object path
+ */
+std::string getObjectPathByLocationCode(const std::string& locationCode,
+                                        const std::string& inventoryItemType);
+
 } // namespace utils
 
 namespace oem_ibm_utils

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -165,6 +165,15 @@ void hostChapDataIntf(
  */
 std::vector<char> vecSplit(const std::vector<char>& inputVec,
                            const uint32_t startIdx, const uint32_t endIdx);
+/** @brief host PCIE Topology Interface
+ *  @param[in] mctp_eid - MCTP Endpoint ID
+ *  @param[in] hostEffecterParser - Pointer to host effecter parser
+ */
+
+void hostPCIETopologyIntf(
+    uint8_t mctp_eid,
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser);
+
 } // namespace utils
 
 namespace oem_ibm_utils

--- a/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
+++ b/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
@@ -67,7 +67,7 @@ class MockOemPlatformHandler : public oem_ibm_platform::Handler
                            sdeventplus::Event& event) :
         oem_ibm_platform::Handler(dBusIntf, codeUpdate, slotHandler, mctp_fd,
                                   mctp_eid, instanceIdDb, event, nullptr,
-                                  nullptr, nullptr) {};
+                                  nullptr, nullptr, nullptr) {};
     MOCK_METHOD(uint16_t, getNextEffecterId, ());
     MOCK_METHOD(uint16_t, getNextSensorId, ());
     MOCK_METHOD((const AssociatedEntityMap&), getAssociateEntityMap, (),

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -256,6 +256,14 @@ int main(int argc, char** argv)
     std::unique_ptr<oem_fru::Handler> oemFruHandler{};
     std::unique_ptr<oem_utils::Handler> oemUtilsHandler{};
 
+    if (hostEID)
+    {
+        hostEffecterParser =
+            std::make_unique<pldm::host_effecters::HostEffecterParser>(
+                &dbusImplReq, pldmTransport.getEventSource(), pdrRepo.get(),
+                &dbusHandler, HOST_JSONS_DIR, &reqHandler);
+    }
+
 #ifdef OEM_IBM
     respInterface.responseObj =
         std::make_unique<pldm::response_api::AltResponse>(&pldmTransport, TID,
@@ -269,7 +277,8 @@ int main(int argc, char** argv)
     oemPlatformHandler = std::make_unique<oem_ibm_platform::Handler>(
         &dbusHandler, codeUpdate.get(), slotHandler.get(),
         pldmTransport.getEventSource(), hostEID, instanceIdDb, event,
-        pdrRepo.get(), &reqHandler, bmcEntityTree.get());
+        pdrRepo.get(), &reqHandler, bmcEntityTree.get(),
+        hostEffecterParser.get());
     codeUpdate->setOemPlatformHandler(oemPlatformHandler.get());
     slotHandler->setOemPlatformHandler(oemPlatformHandler.get());
     oemFruHandler = std::make_unique<oem_ibm_fru::Handler>(pdrRepo.get());
@@ -285,10 +294,6 @@ int main(int argc, char** argv)
         associationsParser =
             std::make_unique<pldm::host_associations::HostAssociationsParser>(
                 HOST_JSONS_DIR);
-        hostEffecterParser =
-            std::make_unique<pldm::host_effecters::HostEffecterParser>(
-                &dbusImplReq, pldmTransport.getEventSource(), pdrRepo.get(),
-                &dbusHandler, HOST_JSONS_DIR, &reqHandler);
         hostPDRHandler = std::make_shared<HostPDRHandler>(
             pldmTransport.getEventSource(), hostEID, event, pdrRepo.get(),
             EVENTS_JSONS_DIR, entityTree.get(), bmcEntityTree.get(),


### PR DESCRIPTION
This commit adds support to implement the topology interface and also host it under PLDM and also supports the set and get property under the topology interface.

When PCIeTopologyRefresh property is set to true, we send the setEffecterCall to host to set the effecter state 1 and 2. When SaveTopologyRefresh property is set to true we send the setEffecterCall to host to set the effecter state to 3 and then sets it back to false.

Tested the 2 properties and worked fine

Change-Id: Ic53f6fd33bbc4a84136b3f70517ee5cb4d8488a3
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>