### PR TITLE
codeupdate: Fix to boot always from temp side

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -895,7 +895,7 @@ void setBiosAttr(const BiosAttributeList& biosAttrList)
             method.append(
                 biosConfigIntf, "PendingAttributes",
                 std::variant<PendingAttributesType>(pendingAttributes));
-            bus.call_noreply(method);
+            bus.call_noreply(method, dbusTimeout);
         }
         catch (const sdbusplus::exception::SdBusError& e)
         {

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -130,6 +130,10 @@ HostPDRHandler::HostPDRHandler(
             auto propVal = std::get<std::string>(value);
             if (propVal == "xyz.openbmc_project.State.Host.HostState.Off")
             {
+                if (oemPlatformHandler)
+                {
+                    oemPlatformHandler->startStopTimer(false);
+                }
                 // Delete all the remote terminus information
                 std::erase_if(tlPDRInfo, [](const auto& item) {
                     const auto& [key, value] = item;
@@ -1239,7 +1243,6 @@ void HostPDRHandler::getFRURecordTableMetadataByRemote()
                 "RC", lg2::hex, rc, "CC", cc);
             return;
         }
-        info("Fru RecordTable length {LEN}", "LEN", total);
         // pass total to getFRURecordTableByRemote
         this->getFRURecordTableByRemote(total);
     };
@@ -1264,7 +1267,6 @@ void HostPDRHandler::getFRURecordTableByRemote(uint16_t& totalTableRecords)
 
     if (!totalTableRecords)
     {
-        error("Failed to get fru record table");
         return;
     }
 

--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -66,17 +66,23 @@ int CodeUpdate::setCurrentBootSide(const std::string& currSide)
 
 int CodeUpdate::setNextBootSide(const std::string& nextSide)
 {
+    info("setNextBootSide, nextSide={NXT_SIDE}", "NXT_SIDE", nextSide);
     pldm_boot_side_data pldmBootSideData = readBootSideFile();
-    currBootSide = pldmBootSideData.current_boot_side;
+    currBootSide = (pldmBootSideData.current_boot_side == "Perm" ? Pside
+                                                                 : Tside);
     nextBootSide = nextSide;
-    pldmBootSideData.next_boot_side = nextSide;
+    pldmBootSideData.next_boot_side = (nextSide == Pside ? "Perm" : "Temp");
     std::string objPath{};
     if (nextBootSide == currBootSide)
     {
+        info("Current bootside is same as next boot side");
+        info("setting priority of running version 0");
         objPath = runningVersion;
     }
     else
     {
+        info("Current bootside is not same as next boot side");
+        info("setting priority of non running version 0");
         objPath = nonRunningVersion;
     }
     if (objPath.empty())
@@ -99,7 +105,9 @@ int CodeUpdate::setNextBootSide(const std::string& nextSide)
     catch (const std::exception& e)
     {
         // Alternate side may not be present due to a failed code update
-        info("Alternate side not present due to failed code update");
+        error(
+            "Alternate side may not be present due to a failed code update. ERROR = {ERR}",
+            "ERR", e);
         return PLDM_PLATFORM_INVALID_STATE_VALUE;
     }
 
@@ -218,6 +226,19 @@ void CodeUpdate::setVersions()
             pldm_boot_side_data pldmBootSideData;
             std::string nextBootSideBiosValue =
                 getBiosAttrValue("fw_boot_side");
+
+            // We enter this path during Genesis boot/boot after Factory reset.
+            // PLDM waits for Entity manager to populate System Type. After
+            // receiving system Type from EM it populates the bios attributes
+            // specific to that system We do not have bios attributes populated
+            // when we reach here so setting it to default value of the
+            // attribute as mentioned in the json files.
+            if (nextBootSideBiosValue.empty())
+            {
+                info(
+                    "Boot side is not initialized yet, so setting default value");
+                nextBootSideBiosValue = "Temp";
+            }
             pldmBootSideData.current_boot_side = nextBootSideBiosValue;
             pldmBootSideData.next_boot_side = nextBootSideBiosValue;
             pldmBootSideData.running_version_object = runningPath;
@@ -304,15 +325,16 @@ void CodeUpdate::setVersions()
     }));
     fwUpdateMatcher.push_back(std::make_unique<sdbusplus::bus::match_t>(
         pldm::utils::DBusHandler::getBus(),
-        "interface='org.freedesktop.DBus.ObjectManager',type='signal',"
+        "sender='xyz.openbmc_project.Software.BMC.Updater',interface='org.freedesktop.DBus.ObjectManager',type='signal',"
         "member='InterfacesAdded',path='/xyz/openbmc_project/software'",
         [this](sdbusplus::message_t& msg) {
         DBusInterfaceAdded interfaces;
         sdbusplus::message::object_path path;
         msg.read(path, interfaces);
-
+        info("Software interface got added");
         for (auto& interface : interfaces)
         {
+            info("Interface is {I}", "I", interface.first);
             if (interface.first == "xyz.openbmc_project.Software.Activation")
             {
                 auto imageInterface = "xyz.openbmc_project.Software.Activation";
@@ -468,6 +490,7 @@ void CodeUpdate::processRenameEvent()
     nextBootSide = Pside;
 
     auto sensorId = getBootSideRenameStateSensor();
+    info("Received sendor id for rename {ID}", "ID", sensorId);
     sendStateSensorEvent(sensorId, PLDM_STATE_SENSOR_STATE, 0,
                          PLDM_BOOT_SIDE_HAS_BEEN_RENAMED,
                          PLDM_BOOT_SIDE_NOT_RENAMED);
@@ -481,6 +504,7 @@ void CodeUpdate::processRenameEvent()
 
 void CodeUpdate::writeBootSideFile(const pldm_boot_side_data& pldmBootSideData)
 {
+    fs::create_directories(bootSideDirPath.parent_path());
     std::ofstream writeFile(bootSideDirPath.string(),
                             std::ios::out | std::ios::binary);
     if (writeFile)
@@ -713,6 +737,16 @@ int processCodeUpdateLid(const std::string& filePath)
     fs::create_directories(imageDirPath);
     fs::create_directories(lidDirPath);
 
+    // Set the lid directory permissions to 777
+    std::error_code ec;
+    fs::permissions(lidDirPath, fs::perms::all, fs::perm_options::replace, ec);
+    if (ec)
+    {
+        error("Failed to set the lid directory permissions:{ERR}", "ERR",
+              ec.message());
+        return PLDM_ERROR;
+    }
+
     constexpr auto bmcClass = 0x2000;
     if (htons(header.lidClass) == bmcClass)
     {
@@ -735,6 +769,17 @@ int processCodeUpdateLid(const std::string& filePath)
         ofs << ifs.rdbuf();
         ofs.flush();
         ofs.close();
+        // Set the lid file permissions to 440
+        std::error_code ec;
+        fs::permissions(lidNoHeaderPath,
+                        fs::perms::owner_read | fs::perms::group_read,
+                        fs::perm_options::replace, ec);
+        if (ec)
+        {
+            error("Failed to set the lid file permissions: {ERR}", "ERR",
+                  ec.message());
+            return PLDM_ERROR;
+        }
     }
 
     ifs.close();
@@ -757,7 +802,7 @@ int CodeUpdate::assembleCodeUpdateImage()
         auto method = bus.new_method_call(UPDATER_SERVICE, SOFTWARE_PATH,
                                           LID_INTERFACE,
                                           "AssembleCodeUpdateImage");
-        bus.call_noreply(method);
+        bus.call_noreply(method, dbusTimeout);
     }
     catch (const std::exception& e)
     {

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -919,6 +919,10 @@ void pldm::responder::oem_ibm_platform::Handler::buildOEMPDR(
         this, PLDM_OEM_IBM_CHASSIS_POWER_CONTROLLER, ENTITY_INSTANCE_0,
         PLDM_STATE_SET_SYSTEM_POWER_STATE, repo);
 
+    pldm_entity fwUpEntity = {PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE, 0, 1};
+    attachOemEntityToEntityAssociationPDR(
+        this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,
+        fwUpEntity);
     pldm_entity saiEntity = {PLDM_OEM_IBM_ENTITY_REAL_SAI, 1, 1};
     attachOemEntityToEntityAssociationPDR(
         this, bmcEntityTree, "/xyz/openbmc_project/inventory/system", repo,

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -156,6 +156,7 @@ class Handler : public oem_platform::Handler
                 else if (propVal ==
                          "xyz.openbmc_project.State.Host.HostState.Running")
                 {
+                    hostOff = false;
                     hostTransitioningToOff = false;
                 }
                 else if (
@@ -183,6 +184,9 @@ class Handler : public oem_platform::Handler
                 if (propVal ==
                     "xyz.openbmc_project.State.Chassis.PowerState.Off")
                 {
+                    startStopTimer(false);
+                    handleBootTypesAtChassisOff();
+
                     static constexpr auto searchpath =
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard";
                     int depth = 0;
@@ -271,8 +275,10 @@ class Handler : public oem_platform::Handler
                 if (it.first == "fw_boot_side")
                 {
                     auto& [attributeType, attributevalue] = it.second;
-                    std::string nextBootSide =
+                    std::string nextBootSideAttr =
                         std::get<std::string>(attributevalue);
+                    std::string nextBootSide =
+                        (nextBootSideAttr == "Perm" ? Pside : Tside);
                     codeUpdate->setNextBootSide(nextBootSide);
                 }
             }

--- a/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/platform_oem_ibm.cpp
@@ -71,8 +71,9 @@ int sendBiosAttributeUpdateEvent(
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
 
     auto rc = encode_bios_attribute_update_event_req(
-        instanceId, PLDM_PLATFORM_EVENT_MESSAGE_FORMAT_VERSION, TERMINUS_ID,
-        handles.size(), reinterpret_cast<const uint8_t*>(handles.data()),
+        instanceId, PLDM_PLATFORM_EVENT_MESSAGE_FORMAT_VERSION,
+        pldm::responder::pdr::BmcMctpEid, handles.size(),
+        reinterpret_cast<const uint8_t*>(handles.data()),
         requestMsg.size() - sizeof(pldm_msg_hdr), request);
     if (rc != PLDM_SUCCESS)
     {
@@ -83,6 +84,17 @@ int sendBiosAttributeUpdateEvent(
         return rc;
     }
 
+    if (requestMsg.size())
+    {
+        std::ostringstream tempStream;
+        for (int byte : requestMsg)
+        {
+            tempStream << std::setfill('0') << std::setw(2) << std::hex << byte
+                       << " ";
+        }
+        std::cout << "platformEventMessage for BIOS Attribute  "
+                  << tempStream.str() << std::endl;
+    }
     auto platformEventMessageResponseHandler =
         [](mctp_eid_t /*eid*/, const pldm_msg* response, size_t respMsgLen) {
         if (response == nullptr || !respMsgLen)


### PR DESCRIPTION
Added missed code and traces from 1060 in code update path.

The problem faced during existing code update code is the delay in receiving the system type. PLDM was setting the fw_boot_side and fw_boot_side_current before building the bios table. So those values where not getting set.
To fix the issue saving the pending bios attributes before setting biostable and resetting it after biostable update.

With the Fix pldm is booting from Temp side after codeupdate.