### PR TITLE
oem-ibm: Handle the json parse exception correctly

### DIFF
--- a/libpldmresponder/bios_config.cpp
+++ b/libpldmresponder/bios_config.cpp
@@ -128,11 +128,20 @@ void BIOSConfig::initBIOSAttributes(const std::string& systemType,
 
     buildTables();
 
+    info("Register listenPendingAttributes");
+    listenPendingAttributes();
+
     if (pendingAttributes.size())
     {
         try
         {
-            info("Setting Pending Attributes");
+            for (const auto& pair : pendingAttributes)
+            {
+                info("Pending Attribute is {A}", "A", pair.first);
+            }
+
+            info("Setting Pending Attributes {NUMBER}", "NUMBER",
+                 (int)pendingAttributes.size());
             auto method = bus.new_method_call(service.c_str(), biosObjPath,
                                               dbusProperties, "Set");
             method.append(biosInterface, "PendingAttributes",
@@ -145,8 +154,6 @@ void BIOSConfig::initBIOSAttributes(const std::string& systemType,
                   "ERROR", e);
         }
     }
-    info("Register listenPendingAttributes");
-    listenPendingAttributes();
     if (registerService)
     {
         requestPLDMServiceName();

--- a/oem/ibm/libpldmresponder/file_io_type_lic.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_lic.cpp
@@ -33,13 +33,17 @@ int LicenseHandler::updateBinFileAndLicObjs(const fs::path& newLicJsonFilePath)
     int rc = PLDM_SUCCESS;
     fs::path newLicFilePath(fs::path(licFilePath) / newLicenseFile);
     std::ifstream jsonFileNew(newLicJsonFilePath);
+    Json dataNew;
 
-    auto dataNew = Json::parse(jsonFileNew, nullptr, false);
-    if (dataNew.is_discarded())
+    try
+    {
+        dataNew = Json::parse(jsonFileNew);
+    }
+    catch (const Json::parse_error& e)
     {
         error("Failed to parse the new license json file '{NEW_LIC_JSON}'",
               "NEW_LIC_JSON", newLicJsonFilePath);
-        throw InternalFailure();
+        return PLDM_ERROR_INVALID_DATA;
     }
 
     // Store the json data in a file with binary format

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1367,7 +1367,10 @@ void pldm::responder::oem_ibm_platform::Handler::_processSystemReboot(
                                          "RequestedPowerTransition", "string"};
     try
     {
-        info("InbandCodeUpdate: ChassifOff the host");
+        info(
+            "InbandCodeUpdate: ChassisOff the host. Current Boot Side {C}, Next boot Side {N}",
+            "C", getBiosAttrValue("fw_boot_side_current"), "N",
+            getBiosAttrValue("fw_boot_side"));
         dBusIntf->setDbusProperty(dbusMapping, value);
     }
     catch (const std::exception& e)

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -407,12 +407,12 @@ int createOrUpdateLicenseObjs()
 
         if (fs::exists(newLicFilePath))
         {
-            fs::remove_all(newLicFilePath);
+            // fs::remove_all(newLicFilePath);
         }
 
         if (fs::exists(newLicJsonFilePath))
         {
-            fs::remove_all(newLicJsonFilePath);
+            // fs::remove_all(newLicJsonFilePath);
         }
     }
 


### PR DESCRIPTION
This commit handles the CoD license json parsing exception by correctly catching it and returs the error to the caller. Also made the change to avoid the removal of license json file whenever shared by the host.

Tested:
Done the sanity testing to verify that json file was kept without removal.