### PR TITLE
oem-ibm: Introducing sensor design for SBE ocmb dump

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -772,6 +772,11 @@ Response Handler::setNumericEffecterValue(const pldm_msg* request,
 
     int rc = decode_set_numeric_effecter_value_req(
         request, payloadLength, &effecterId, &effecterDataSize, effecterValue);
+    if (rc)
+    {
+        error("Failed to decode set numeric effecter value request, RC = {RC}",
+              "RC", rc);
+    }
 
     const pldm::utils::DBusHandler dBusIntf;
     uint16_t entityType{};

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -21,7 +21,18 @@
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/utility/timer.hpp>
 
+enum ibm_oem_pldm_state_set_dimm_dump_state_values
+{
+    UNAVAILABLE = 0,
+    SUCCESS = 0x1,
+    RETRY = 0x2,
+};
+
 typedef ibm_oem_pldm_state_set_firmware_update_state_values CodeUpdateState;
+
+typedef ibm_oem_pldm_state_set_dimm_dump_state_values DimmDumpState;
+
+static std::map<uint16_t, int> dumpStatusMap;
 
 namespace pldm
 {
@@ -469,6 +480,18 @@ class Handler : public oem_platform::Handler
 
     /** @brief update containerID in PDRs */
     void updateContainerID();
+
+    /** @brief read the state of a dimm sensor
+     *   @param entityInstance - the entity instance id of the dimm sensor
+     *   @return the state of the sensor
+     */
+    int fetchDimmStateSensor(uint16_t entityInstance);
+
+    /** @brief Methode to set the dimm sensor state
+     *   @param status - the status of dump creation
+     *   @param entityInstance - the entity instance id of the sensor
+     */
+    void setDimmStateSensor(bool status, uint16_t entityInstance);
 
     /** @brief setNumericEffecter
      *

--- a/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
+++ b/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
@@ -233,7 +233,7 @@ TEST(generateStateEffecterOEMPDR, testGoodRequest)
                 getSubtree("/xyz/openbmc_project/inventory/system", 0,
                            std::vector<std::string>{
                                "xyz.openbmc_project.Inventory.Item.Dimm"}))
-        .WillOnce(Return(mockDimmResponse));
+        .WillRepeatedly(Return(mockDimmResponse));
 
     std::unique_ptr<MockOemPlatformHandler> mockoemPlatformHandler =
         std::make_unique<MockOemPlatformHandler>(mockDbusHandler.get(),
@@ -395,7 +395,7 @@ TEST(generateStateSensorOEMPDR, testGoodRequest)
                 getSubtree("/xyz/openbmc_project/inventory/system", 0,
                            std::vector<std::string>{
                                "xyz.openbmc_project.Inventory.Item.Dimm"}))
-        .WillOnce(Return(mockDimmResponse));
+        .WillRepeatedly(Return(mockDimmResponse));
 
     std::unique_ptr<MockOemPlatformHandler> mockoemPlatformHandler =
         std::make_unique<MockOemPlatformHandler>(mockDbusHandler.get(),

--- a/pldmtool/oem/ibm/oem_ibm_state_set.hpp
+++ b/pldmtool/oem/ibm/oem_ibm_state_set.hpp
@@ -54,6 +54,7 @@ extern const std::map<uint16_t, std::string> OemIBMstateSet{
     {PLDM_OEM_IBM_FIRMWARE_UPDATE_STATE, "OEM IBM Firmware Update State"},
     {PLDM_OEM_IBM_BOOT_STATE, "OEM IBM Boot State"},
     {PLDM_OEM_IBM_VERIFICATION_STATE, "OEM IBM Verification State"},
+    {PLDM_OEM_IBM_SBE_DUMP_UPDATE_STATE, "OEM IBM SBE Dump Update State"},
     {PLDM_OEM_IBM_SYSTEM_POWER_STATE, "OEM IBM System Power State"}};
 
 /** @brief Map for PLDM OEM IBM firmware update possible state values


### PR DESCRIPTION
This commit introduces new oem sensor PDRs of state set id - PLDM_OEM_IBM_SBE_DUMP_UPDATE_STATE(32777) whose state will be set for ocmb dump progress status. This change implements the new sensor based dump design only for ocmb sbe dumps whereas the sbe PROC dump design remains unchanged. As part of this change PLDM will be updating the sensor state with dump progress state. The remote terminus will be using polling mechanism on getStateSensorReadings command for dump status update.

Tested:
1. Used pldmtool to set numeric effecter for triggering dump.
2. Tested using sbe error injection( unrecoverable by HRESET ) during IPL [1] and during runtime[1]. Also verified the sensor readings post dump completion. Additionally verified SBE PROC dump [2].

[1]: https://gist.github.com/riyadixitagra/1b02a56477d98bfda158e2112aba0476
[2]: https://gist.github.com/riyadixitagra/3f61ec85722acf2f1983a9f2d8f5e4f0