### PR TITLE
oem-ibm: Error log name correction

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -423,7 +423,7 @@ int DumpHandler::fileAck(uint8_t fileStatus)
                         "Failed to make a D-bus call to DUMP manager for reseting source dump file '{PATH}' on interface '{INTERFACE}', error - {ERROR}",
                         "PATH", path, "INTERFACE", dumpIntf, "ERROR", e);
                     pldm::utils::reportError(
-                        "xyz.openbmc_project.bmc.PLDM.fileAck.SourceDumpIdResetFail");
+                        "xyz.openbmc_project.PLDM.Error.fileAck.SourceDumpIdResetFail");
                     return PLDM_ERROR;
                 }
             }
@@ -441,7 +441,7 @@ int DumpHandler::fileAck(uint8_t fileStatus)
                     "Failed to make a D-bus call to DUMP manager for delete dump file '{PATH}', error - {ERROR}",
                     "PATH", path, "ERROR", e);
                 pldm::utils::reportError(
-                    "xyz.openbmc_project.bmc.PLDM.fileAck.DumpEntryDeleteFail");
+                    "xyz.openbmc_project.PLDM.Error.fileAck.DumpEntryDeleteFail");
                 return PLDM_ERROR;
             }
             return PLDM_SUCCESS;

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -2006,7 +2006,7 @@ void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
             (bool)hostTransitioningToOff, "TID", (uint16_t)tid);
         startStopTimer(false);
         pldm::utils::reportError(
-            "xyz.openbmc_project.bmc.PLDM.setSurvTimer.RecvSurveillancePingFail");
+            "xyz.openbmc_project.PLDM.Error.setSurvTimer.RecvSurveillancePingFail");
     }
 }
 


### PR DESCRIPTION
This commit corrects the error log name according to the latest PEL message registry values.

Tested:
Restart of the pldm daemon does not cause any new error logs.