### PR TITLE
bios: Updated Power supply bios attribute name

### DIFF
--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/enum_attrs.json
@@ -578,7 +578,7 @@
             "readOnly": true
         },
         {
-            "attribute_name": "hb_power_PS0_functional",
+            "attribute_name": "hb_power_PS0_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -593,7 +593,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS1_functional",
+            "attribute_name": "hb_power_PS1_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -608,7 +608,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS2_functional",
+            "attribute_name": "hb_power_PS2_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -623,7 +623,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS3_functional",
+            "attribute_name": "hb_power_PS3_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/enum_attrs.json
@@ -611,7 +611,7 @@
             "readOnly": true
         },
         {
-            "attribute_name": "hb_power_PS0_functional",
+            "attribute_name": "hb_power_PS0_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -626,7 +626,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS1_functional",
+            "attribute_name": "hb_power_PS1_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -641,7 +641,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS2_functional",
+            "attribute_name": "hb_power_PS2_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -656,7 +656,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS3_functional",
+            "attribute_name": "hb_power_PS3_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/enum_attrs.json
@@ -611,7 +611,7 @@
             "readOnly": true
         },
         {
-            "attribute_name": "hb_power_PS0_functional",
+            "attribute_name": "hb_power_PS0_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -626,7 +626,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS1_functional",
+            "attribute_name": "hb_power_PS1_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -641,7 +641,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS2_functional",
+            "attribute_name": "hb_power_PS2_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -656,7 +656,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS3_functional",
+            "attribute_name": "hb_power_PS3_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/enum_attrs.json
@@ -611,7 +611,7 @@
             "readOnly": true
         },
         {
-            "attribute_name": "hb_power_PS0_functional",
+            "attribute_name": "hb_power_PS0_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -626,7 +626,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS1_functional",
+            "attribute_name": "hb_power_PS1_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -641,7 +641,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS2_functional",
+            "attribute_name": "hb_power_PS2_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -656,7 +656,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS3_functional",
+            "attribute_name": "hb_power_PS3_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/enum_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/enum_attrs.json
@@ -611,7 +611,7 @@
             "readOnly": true
         },
         {
-            "attribute_name": "hb_power_PS0_functional",
+            "attribute_name": "hb_power_PS0_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -626,7 +626,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS1_functional",
+            "attribute_name": "hb_power_PS1_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -641,7 +641,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS2_functional",
+            "attribute_name": "hb_power_PS2_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],
@@ -656,7 +656,7 @@
             }
         },
         {
-            "attribute_name": "hb_power_PS3_functional",
+            "attribute_name": "hb_power_PS3_present",
             "possible_values": ["Enabled", "Disabled"],
             "value_names": ["Enabled", "Disabled"],
             "default_values": ["Disabled"],


### PR DESCRIPTION
Updated the Power supply attribute name from hb_power_PS*_functional to hb_power_PS*_present to match the upstream.
The upstream for this change is
https://gerrit.openbmc.org/c/openbmc/pldm/+/61015