### PR TITLE
pldm: Fix the incorrect processor core count

### DIFF
--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -216,6 +216,7 @@ class Handler : public CmdHandler
      *  @param[in] associations - the data of entity association
      *  @param[in] entityMaps - the mapping of entity to DBus string
      *
+     *  @return int - the processor core count
      */
     virtual int setCoreCount(const EntityAssociations& associations,
                              const EntityMaps entityMaps) = 0;

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -449,7 +449,7 @@ using namespace pldm::utils;
 int pldm::responder::oem_ibm_utils::Handler::setCoreCount(
     const EntityAssociations& Associations, const EntityMaps entityMaps)
 {
-    int coreCountRef = 0;
+    int coreCount = 0;
     // get the CPU pldm entities
     for (const auto& entries : Associations)
     {
@@ -457,7 +457,8 @@ int pldm::responder::oem_ibm_utils::Handler::setCoreCount(
         // entries[0] would be the parent in the entity association map
         if (parent.entity_type == PLDM_ENTITY_PROC)
         {
-            int& coreCount = coreCountRef;
+            // Need to reset the count for each of the processors
+            coreCount = 0;
             for (const auto& entry : entries)
             {
                 auto child = pldm_entity_extract(entry);
@@ -510,7 +511,7 @@ int pldm::responder::oem_ibm_utils::Handler::setCoreCount(
             }
         }
     }
-    return coreCountRef;
+    return coreCount;
 }
 
 bool pldm::responder::oem_ibm_utils::Handler::checkModelPresence(

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -182,6 +182,7 @@ class Handler : public oem_utils::Handler
      *  @param[in] associations - the data of entity association
      *  @param[in] entityMaps - the mapping of entity to DBus string
      *
+     *  @return int - the processor core count
      */
     virtual int
         setCoreCount(const pldm::utils::EntityAssociations& associations,

--- a/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
+++ b/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
@@ -617,6 +617,6 @@ TEST(SetCoreCount, testgoodpath)
         std::make_unique<MockOemUtilsHandler>(&mockedDbusUtils);
     int coreCount = oemMockedUtils->setCoreCount(entityAssociations,
                                                  entityMaps);
-    EXPECT_EQ(coreCount, 2);
+    EXPECT_EQ(coreCount, 1);
     pldm_entity_association_tree_destroy(tree);
 }


### PR DESCRIPTION
This commit fixes the issue of calculating the processor core count incorrectly.

Fixes: STG Defect 658536

Tested By:
Tested the changes in a Blue ridge system and verified that, the processor core count is coming up correctly under each of the processors.