### PR TITLE
Change LanesInUse type to size_t

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -169,7 +169,7 @@ void CustomDBus::implementPCIeDeviceInterface(const std::string& path)
     }
 }
 
-void CustomDBus::setPCIeDeviceProps(const std::string& path, int64_t lanesInuse,
+void CustomDBus::setPCIeDeviceProps(const std::string& path, size_t lanesInuse,
                                     const std::string& value)
 {
     Generations generationsInuse =

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -363,7 +363,7 @@ class CustomDBus
                            const std::string& linkState);
 
     /** @brief set pcie device properties */
-    void setPCIeDeviceProps(const std::string& path, int64_t lanesInuse,
+    void setPCIeDeviceProps(const std::string& path, size_t lanesInuse,
                             const std::string& value);
 
     /** @brief set cable attributes */


### PR DESCRIPTION
Change LanesInUse to type size_t from int64_t. This change is made as per upstream changes at [1]
[1]: https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/53650



Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>