### PR TITLE
Remove check for IBM cable card

### DIFF
--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -929,7 +929,7 @@ void FruImpl::processFruPresenceChange(const DbusChangedProps& chProperties,
     {
         if (fruInterface == "xyz.openbmc_project.Inventory.Item.PCIeDevice")
         {
-            if (!(oemUtilsHandler->checkModelPresence(fruObjPath)))
+            if (!oemUtilsHandler->checkFruPresence(fruObjPath.c_str()))
             {
                 return;
             }

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -550,14 +550,16 @@ bool pldm::responder::oem_ibm_utils::Handler::checkFruPresence(
     std::string newObjPath = objPath;
     bool isPresent = true;
 
-    if ((newObjPath.find(pcieAdapter) != std::string::npos) &&
-        !checkModelPresence(newObjPath))
+    if (newObjPath.find(pcieAdapter) != std::string::npos)
     {
-        return true; // industry std cards
-    }
-    else if (newObjPath.find(portStr) != std::string::npos)
-    {
-        newObjPath = pldm::utils::findParent(objPath);
+        if (newObjPath.find(portStr) != std::string::npos)
+        {
+            newObjPath = pldm::utils::findParent(objPath);
+        }
+        else
+        {
+            return true; // industry std cards
+        }
     }
 
     // Phyp expects the FRU records for industry std cards to be always


### PR DESCRIPTION
Removing the check for IBM cable card because this will be verified in VPD and there is no need to have an additional check inside PLDM.
This commit also includes the check for presence property before PDRs are added for adpaters and ports. PDRs should not be added for empty slots.

Tested by : performing CM on IBM cable cards and industry standard adapters