### PR TITLE
oem-ibm: Adding BIOS attribute for IPL version

### DIFF
--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/string_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Bonnell/string_attrs.json
@@ -162,6 +162,28 @@
             }
         },
         {
+            "attribute_name": "hb_full_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last full CEC IPL was performed",
+            "displayName": "Complete IPL System FW Level",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last CEC IPL was performed (mpipl)",
+            "displayName": "System FW Level",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_ibmi_load_source",
             "string_type": "ASCII",
             "minimum_string_length": 0,

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/string_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/string_attrs.json
@@ -202,6 +202,28 @@
             }
         },
         {
+            "attribute_name": "hb_full_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last full CEC IPL was performed",
+            "displayName": "Complete IPL System FW Level",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last CEC IPL was performed (mpipl)",
+            "displayName": "System FW Level",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_ibmi_load_source",
             "string_type": "ASCII",
             "minimum_string_length": 0,

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/string_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/string_attrs.json
@@ -202,6 +202,28 @@
             }
         },
         {
+            "attribute_name": "hb_full_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last full CEC IPL was performed",
+            "displayName": "Complete IPL System FW Level",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last CEC IPL was performed (mpipl)",
+            "displayName": "System FW Level",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_ibmi_load_source",
             "string_type": "ASCII",
             "minimum_string_length": 0,

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/string_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/string_attrs.json
@@ -202,6 +202,28 @@
             }
         },
         {
+            "attribute_name": "hb_full_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last full CEC IPL was performed",
+            "displayName": "Complete IPL System FW Level",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last CEC IPL was performed (mpipl)",
+            "displayName": "System FW Level",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_ibmi_load_source",
             "string_type": "ASCII",
             "minimum_string_length": 0,

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/string_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/string_attrs.json
@@ -202,6 +202,28 @@
             }
         },
         {
+            "attribute_name": "hb_full_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last full CEC IPL was performed",
+            "displayName": "Complete IPL System FW Level",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last CEC IPL was performed (mpipl)",
+            "displayName": "System FW Level",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_ibmi_load_source",
             "string_type": "ASCII",
             "minimum_string_length": 0,

--- a/oem/ibm/configurations/bios/string_attrs.json
+++ b/oem/ibm/configurations/bios/string_attrs.json
@@ -202,6 +202,28 @@
             }
         },
         {
+            "attribute_name": "hb_full_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last full CEC IPL was performed",
+            "displayName": "Complete IPL System FW Level",
+            "readOnly": true
+        },
+        {
+            "attribute_name": "hb_ipl_fw_version",
+            "string_type": "ASCII",
+            "minimum_string_length": 0,
+            "maximum_string_length": 64,
+            "default_string_length": 0,
+            "default_string": "",
+            "helpText": "Provides the full system firmware version level with which last CEC IPL was performed (mpipl)",
+            "displayName": "System FW Level",
+            "readOnly": true
+        },
+        {
             "attribute_name": "pvm_ibmi_load_source",
             "string_type": "ASCII",
             "minimum_string_length": 0,


### PR DESCRIPTION
This commit introduces two new string bios attributes to capture system code level version with which last CEC full IPL was performed and another attribute to capture version level in case of MPIPL (after concurrent code update) scenario. Both the attributes will be updated by remote terminus during every IPL.

Tested: Verified with a BMC poweron