### PR TITLE
1030: oem: ibm: fileTable: Add lid files for P10

### DIFF
--- a/oem/ibm/configurations/fileTable.json
+++ b/oem/ibm/configurations/fileTable.json
@@ -8,6 +8,26 @@
       "file_traits":4
    },
    {
+      "path": "/usr/local/share/hostfw/running/81e00300.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00300.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00430.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00430.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00440.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00440.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00602.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00602.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00630.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00630.lid",
+      "file_traits": 1
+   },
+   {
       "path":"/usr/local/share/hostfw/running/81e0065d.lid,/var/lib/phosphor-software-manager/hostfw/running/81e0065d.lid",
       "file_traits":1
    },
@@ -17,6 +37,50 @@
    },
    {
       "path":"/usr/local/share/hostfw/running/81e00661.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00661.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00671.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00671.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00674.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00674.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00677.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00677.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e0067c.lid,/var/lib/phosphor-software-manager/hostfw/running/81e0067c.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e0067d.lid,/var/lib/phosphor-software-manager/hostfw/running/81e0067d.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00685.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00685.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00686.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00686.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00687.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00687.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e00689.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00689.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e0068a.lid,/var/lib/phosphor-software-manager/hostfw/running/81e0068a.lid",
+      "file_traits":1
+   },
+   {
+      "path": "/usr/local/share/hostfw/running/81e0068b.lid,/var/lib/phosphor-software-manager/hostfw/running/81e0068b.lid",
       "file_traits":1
    },
    {

--- a/oem/ibm/configurations/fileTable.json
+++ b/oem/ibm/configurations/fileTable.json
@@ -152,6 +152,10 @@
       "file_traits":1
    },
    {
+      "path": "/usr/local/share/hostfw/running/81e00670.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00670.lid",
+      "file_traits":1
+   },
+   {
       "path":"/usr/local/share/hostfw/running/81e00679.lid,/var/lib/phosphor-software-manager/hostfw/running/81e00679.lid",
       "file_traits":6
    },


### PR DESCRIPTION
Add the following 1060 commits to 1030, except the lids for Bonnell:

- https://github.com/ibm-openbmc/pldm/commit/939400b2f91a036582e052bb00fd9557d3f1c1f6

- https://github.com/ibm-openbmc/pldm/commit/4971dcff3b810e1048a97d7bca016112f9b6d805

Verified that all the lids in the hostfw json file for 1030 are now listed in the pldm table.