### PR TITLE
oem-ibm: Improving SBE Dump

### DIFF
--- a/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
+++ b/oem/ibm/test/libpldmresponder_oem_platform_test.cpp
@@ -206,34 +206,6 @@ TEST(generateStateEffecterOEMPDR, testGoodRequest)
     auto event = sdeventplus::Event::get_default();
     std::unique_ptr<CodeUpdate> mockCodeUpdate =
         std::make_unique<MockCodeUpdate>(mockDbusHandler.get());
-    GetSubTreeResponse mockResponse1 = {
-        {"/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0",
-         {{"xyz.openbmc_project.Inventory.Manager",
-           {"xyz.openbmc_project.Inventory.Item.Cpu"}}}}};
-
-    EXPECT_CALL(*mockDbusHandler,
-                getSubtree("/xyz/openbmc_project/inventory/system", 0,
-                           std::vector<std::string>{
-                               "xyz.openbmc_project.Inventory.Item.Cpu"}))
-        .WillRepeatedly(Return(mockResponse1));
-
-    pldm::utils::GetSubTreeResponse mockDimmResponse = {
-        {"/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
-         {{"xyz.openbmc_project.Inventory.Manager",
-           {"com.ibm.ipzvpd.Location", "org.freedesktop.DBus.Introspectable",
-            "org.freedesktop.DBus.Peer", "org.freedesktop.DBus.Properties",
-            "xyz.openbmc_project.Association.Definitions",
-            "xyz.openbmc_project.Inventory.Decorator.LocationCode",
-            "xyz.openbmc_project.Inventory.Item",
-            "xyz.openbmc_project.Inventory.Item.Dimm",
-            "xyz.openbmc_project.Object.Enable",
-            "xyz.openbmc_project.State.Decorator.Availability",
-            "xyz.openbmc_project.State.Decorator.OperationalStatus"}}}}};
-    EXPECT_CALL(*mockDbusHandler,
-                getSubtree("/xyz/openbmc_project/inventory/system", 0,
-                           std::vector<std::string>{
-                               "xyz.openbmc_project.Inventory.Item.Dimm"}))
-        .WillRepeatedly(Return(mockDimmResponse));
 
     std::unique_ptr<MockOemPlatformHandler> mockoemPlatformHandler =
         std::make_unique<MockOemPlatformHandler>(mockDbusHandler.get(),
@@ -368,34 +340,6 @@ TEST(generateStateSensorOEMPDR, testGoodRequest)
     auto event = sdeventplus::Event::get_default();
     std::unique_ptr<CodeUpdate> mockCodeUpdate =
         std::make_unique<MockCodeUpdate>(mockDbusHandler.get());
-    GetSubTreeResponse mockResponse1 = {
-        {"/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0",
-         {{"xyz.openbmc_project.Inventory.Manager",
-           {"xyz.openbmc_project.Inventory.Item.Cpu"}}}}};
-
-    EXPECT_CALL(*mockDbusHandler,
-                getSubtree("/xyz/openbmc_project/inventory/system", 0,
-                           std::vector<std::string>{
-                               "xyz.openbmc_project.Inventory.Item.Cpu"}))
-        .WillRepeatedly(Return(mockResponse1));
-
-    pldm::utils::GetSubTreeResponse mockDimmResponse = {
-        {"/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0",
-         {{"xyz.openbmc_project.Inventory.Manager",
-           {"com.ibm.ipzvpd.Location", "org.freedesktop.DBus.Introspectable",
-            "org.freedesktop.DBus.Peer", "org.freedesktop.DBus.Properties",
-            "xyz.openbmc_project.Association.Definitions",
-            "xyz.openbmc_project.Inventory.Decorator.LocationCode",
-            "xyz.openbmc_project.Inventory.Item",
-            "xyz.openbmc_project.Inventory.Item.Dimm",
-            "xyz.openbmc_project.Object.Enable",
-            "xyz.openbmc_project.State.Decorator.Availability",
-            "xyz.openbmc_project.State.Decorator.OperationalStatus"}}}}};
-    EXPECT_CALL(*mockDbusHandler,
-                getSubtree("/xyz/openbmc_project/inventory/system", 0,
-                           std::vector<std::string>{
-                               "xyz.openbmc_project.Inventory.Item.Dimm"}))
-        .WillRepeatedly(Return(mockDimmResponse));
 
     std::unique_ptr<MockOemPlatformHandler> mockoemPlatformHandler =
         std::make_unique<MockOemPlatformHandler>(mockDbusHandler.get(),


### PR DESCRIPTION
Earlier, we were using the getSubTree API, which returns a pair of object paths and a mapper service map. From this, we extracted the object path and stored it for future retrieval of the entity ID from that path. We are now replacing this API with the existing getSubTreePaths API, as it returns only the object paths, which we use to extract entity IDs. Additionally, the function to extract the entity IDs now utilizes regex for a more dynamic approach instead of using hardcoded character position indices to extract the entity ID.

Tested: Verified the PDRs for populating correct entity instance IDs.