### PR TITLE
oem-ibm : PCIE linkreset support

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -70,6 +70,15 @@ bool CustomDBus::getOperationalStatus(const std::string& path) const
     return false;
 }
 
+size_t CustomDBus::getBusId(const std::string& path) const
+{
+    if (pcieSlot.find(path) != pcieSlot.end())
+    {
+        return pcieSlot.at(path)->busId();
+    }
+    return 0;
+}
+
 void CustomDBus::implementChapDataInterface(
     const std::string& path,
     pldm::responder::oem_fileio::Handler* dbusToFilehandlerObj)
@@ -90,6 +99,20 @@ void CustomDBus::implementCableInterface(const std::string& path)
             path, std::make_unique<Cable>(pldm::utils::DBusHandler::getBus(),
                                           path.c_str()));
     }
+}
+
+void CustomDBus::setLinkReset(
+    const std::string& path, bool value,
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+    uint8_t mctpEid)
+{
+    if (!link.contains(path))
+    {
+        link.emplace(path, std::make_unique<Link>(
+                               pldm::utils::DBusHandler::getBus(), path.c_str(),
+                               hostEffecterParser, mctpEid));
+    }
+    link.at(path)->linkReset(value);
 }
 
 void CustomDBus::updateItemPresentStatus(const std::string& path,

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -20,6 +20,7 @@
 #include "inventory_item.hpp"
 #include "led_group.hpp"
 #include "license_entry.hpp"
+#include "linkreset.hpp"
 #include "location_code.hpp"
 #include "motherboard.hpp"
 #include "operational_status.hpp"
@@ -394,6 +395,11 @@ class CustomDBus
      *  @param[in] value - topology value
      */
     void updateTopologyProperty(bool value);
+    /** set reset link value*/
+    void setLinkReset(
+        const std::string& path, bool value,
+        pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+        uint8_t instanceId);
 
   private:
     std::unordered_map<ObjectPath, std::unique_ptr<LocationCode>> location;
@@ -427,6 +433,7 @@ class CustomDBus
     std::unordered_map<ObjectPath, std::unique_ptr<Cable>> cable;
     std::unordered_map<ObjectPath, std::unique_ptr<Asset>> asset;
     std::unordered_map<ObjectPath, std::unique_ptr<PCIETopology>> pcietopology;
+    std::unordered_map<ObjectPath, std::unique_ptr<Link>> link;
 };
 
 } // namespace dbus

--- a/host-bmc/dbus/linkreset.cpp
+++ b/host-bmc/dbus/linkreset.cpp
@@ -1,0 +1,99 @@
+#include "linkreset.hpp"
+
+#include "libpldm/entity.h"
+#include "libpldm/state_set.h"
+
+#include <libpldm/states.h>
+
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm
+{
+namespace dbus
+{
+
+bool Link::linkReset(bool value)
+{
+    error("CustomDBus: Got a link reset on: {PATH}", "PATH", path);
+    std::vector<set_effecter_state_field> stateField;
+
+    if (value ==
+        sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset())
+    {
+        stateField.push_back({PLDM_NO_CHANGE, 0});
+        return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset(
+            value);
+    }
+    else
+    {
+        stateField.push_back({PLDM_REQUEST_SET, PLDM_RESETTING});
+    }
+
+    if (value && hostEffecterParser)
+    {
+        uint16_t effecterID = getEffecterID();
+
+        if (effecterID == 0)
+        {
+            return false;
+        }
+
+        error(
+            "CustomDBus: Sending a effecter call to host with effecter id: {EFF_ID}",
+            "EFF_ID", effecterID);
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctpEid, effecterID, 1, stateField, nullptr, value);
+        error(
+            "Link reset on path : {PATH}  is successful setting it back to false",
+            "PATH", path);
+        return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset(
+            false);
+    }
+    return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset(
+        value);
+}
+
+uint16_t Link::getEffecterID()
+{
+    uint16_t effecterID = 0;
+
+    pldm::pdr::EntityType entityType = PLDM_ENTITY_PCI_EXPRESS_BUS | 0x8000;
+    auto stateEffecterPDRs = pldm::utils::findStateEffecterPDR(
+        mctpEid, entityType, static_cast<uint16_t>(PLDM_STATE_SET_AVAILABILITY),
+        hostEffecterParser->getPldmPDR());
+
+    if (stateEffecterPDRs.empty())
+    {
+        error(
+            "PCIe LinkReset: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+            "ENTITY_TYP", entityType);
+        return effecterID;
+    }
+
+    uint32_t entityInstance = 0;
+#ifdef OEM_IBM
+    entityInstance = pldm::responder::utils::getLinkResetInstanceNumber(path);
+#endif
+
+    error("CustomDBus: BusID of the link is: {ENTITY_INST}", "ENTITY_INST",
+          entityInstance);
+    for (auto& rep : stateEffecterPDRs)
+    {
+        auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(rep.data());
+        if (entityInstance == (uint32_t)pdr->entity_instance)
+        {
+            effecterID = pdr->effecter_id;
+            break;
+        }
+    }
+    return effecterID;
+}
+
+bool Link::linkReset() const
+{
+    return sdbusplus::com::ibm::Control::Host::server::PCIeLink::linkReset();
+}
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/dbus/linkreset.hpp
+++ b/host-bmc/dbus/linkreset.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "../dbus_to_host_effecters.hpp"
+#include "serialize.hpp"
+
+#ifdef OEM_IBM
+#include "oem/ibm/libpldmresponder/utils.hpp"
+#endif
+
+#include <com/ibm/Control/Host/PCIeLink/server.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdbusplus/server/object.hpp>
+
+#include <string>
+namespace pldm
+{
+namespace dbus
+{
+using Itemlink = sdbusplus::server::object_t<
+    sdbusplus::com::ibm::Control::Host::server::PCIeLink>;
+
+class Link : public Itemlink
+{
+  public:
+    Link() = delete;
+    ~Link() = default;
+    Link(const Link&) = delete;
+    Link& operator=(const Link&) = delete;
+    Link(Link&&) = default;
+    Link& operator=(Link&&) = default;
+
+    Link(sdbusplus::bus_t& bus, const std::string& objPath,
+         pldm::host_effecters::HostEffecterParser* hostEffecterParser,
+         uint8_t mctpEid) :
+        Itemlink(bus, objPath.c_str()), path(objPath),
+        hostEffecterParser(hostEffecterParser), mctpEid(mctpEid)
+    {
+        // no need to save this in pldm memory
+    }
+    /** set link reset */
+    bool linkReset(bool value) override;
+    /** Get link reset state */
+    bool linkReset() const override;
+
+    uint16_t getEffecterID();
+
+  private:
+    std::string path;
+
+    /** @brief Pointer to host effecter parser */
+    pldm::host_effecters::HostEffecterParser* hostEffecterParser;
+
+    /** mctp endpoint id */
+    uint8_t mctpEid;
+};
+
+} // namespace dbus
+} // namespace pldm

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1633,8 +1633,8 @@ void HostPDRHandler::createDbusObjects()
             case PLDM_ENTITY_SLOT:
                 CustomDBus::getCustomDBus().implementPCIeSlotInterface(
                     entity.first);
-                // CustomDBus::getCustomDBus().setLinkReset(
-                //   entity.first, false, hostEffecterParser, mctp_eid);
+                CustomDBus::getCustomDBus().setLinkReset(
+                    entity.first, false, hostEffecterParser, mctp_eid);
                 break;
             case PLDM_ENTITY_CONNECTOR:
                 CustomDBus::getCustomDBus().implementConnecterInterface(
@@ -1664,6 +1664,8 @@ void HostPDRHandler::createDbusObjects()
                 CustomDBus::getCustomDBus().setSlotType(
                     entity.first,
                     "xyz.openbmc_project.Inventory.Item.PCIeSlot.SlotTypes.OEM");
+                CustomDBus::getCustomDBus().setLinkReset(
+                    entity.first, false, hostEffecterParser, mctp_eid);
                 break;
             default:
                 break;

--- a/host-bmc/test/meson.build
+++ b/host-bmc/test/meson.build
@@ -24,7 +24,12 @@ test_sources = [
   '../dbus/asset.cpp',
   '../dbus/pcie_device.cpp',
   '../dbus/pcie_topology.cpp',
+  '../dbus/linkreset.cpp'
 ]
+
+if get_option('oem-ibm').enabled()
+    test_sources += '../../oem/ibm/libpldmresponder/utils.cpp'
+    endif
 
 tests = [
   'dbus_to_host_effecter_test',

--- a/libpldmresponder/meson.build
+++ b/libpldmresponder/meson.build
@@ -53,6 +53,7 @@ sources = [
   '../host-bmc/dbus/location_code.cpp',
   '../host-bmc/dbus/deserialize.cpp',
   '../host-bmc/dbus/pcie_topology.cpp',
+  '../host-bmc/dbus/linkreset.cpp',
   'event_parser.cpp'
 ]
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -8,6 +8,7 @@
 #include <libpldm/entity.h>
 #include <libpldm/oem/ibm/entity.h>
 #include <libpldm/state_set.h>
+#include <libpldm/states.h>
 
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/State/BMC/client.hpp>
@@ -2007,6 +2008,128 @@ void pldm::responder::oem_ibm_platform::Handler::setSurvTimer(uint8_t tid,
         startStopTimer(false);
         pldm::utils::reportError(
             "xyz.openbmc_project.PLDM.Error.setSurvTimer.RecvSurveillancePingFail");
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::propertyChanged(
+    const DbusChangedProps& chProperties, std::string objPath)
+{
+    error("Got a link reset set for CEC path: {OBJ_PATH} ", "OBJ_PATH",
+          objPath);
+    static constexpr auto propName = "linkReset";
+    const auto it = chProperties.find(propName);
+    if (it == chProperties.end())
+    {
+        return;
+    }
+
+    bool Value = std::get<bool>(it->second);
+    triggerHostEffecter(Value, objPath);
+}
+
+void pldm::responder::oem_ibm_platform::Handler::createMatches()
+{
+    /* Already setup */
+    if (!this->matches.empty())
+    {
+        return;
+    }
+
+    /* Creating matches*/
+    using namespace sdbusplus::bus::match::rules;
+    std::vector<std::string> slotObjects;
+    static constexpr auto boardObjPath =
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard";
+
+    pldm::responder::utils::findSlotObjects(boardObjPath, slotObjects);
+
+    for (const std::string& slot : slotObjects)
+    {
+        matches.push_back(std::make_unique<sdbusplus::bus::match::match>(
+            pldm::utils::DBusHandler::getBus(),
+            propertiesChanged(slot, "com.ibm.Control.Host.PCIeLink"),
+            [this, slot](sdbusplus::message::message& msg) {
+            DbusChangedProps props;
+            std::string iface;
+            msg.read(iface, props);
+            propertyChanged(props, slot);
+        }));
+    }
+}
+
+void pldm::responder::oem_ibm_platform::Handler::triggerHostEffecter(
+    bool value, std::string path)
+{
+    std::vector<set_effecter_state_field> stateField;
+
+    stateField.push_back({PLDM_REQUEST_SET, PLDM_RESETTING});
+
+    uint16_t effecterID = 0;
+    if (value && hostEffecterParser)
+    {
+        pldm::pdr::EntityType entityType = PLDM_ENTITY_PCI_EXPRESS_BUS | 0x8000;
+        auto stateEffecterPDRs = pldm::utils::findStateEffecterPDR(
+            mctp_eid, entityType,
+            static_cast<uint16_t>(PLDM_STATE_SET_AVAILABILITY), pdrRepo);
+
+        if (stateEffecterPDRs.empty())
+        {
+            error(
+                "PCIe CEC LinkReset: The state set PDR can not be found, entityType = {ENTITY_TYP}",
+                "ENTITY_TYP", entityType);
+            return;
+        }
+        static constexpr auto propName = "BusId";
+        static constexpr auto interface =
+            "xyz.openbmc_project.Inventory.Item.PCIeSlot";
+        uint32_t instanceId = 0;
+
+        try
+        {
+            instanceId = pldm::utils::DBusHandler().getDbusProperty<uint32_t>(
+                path.c_str(), propName, interface);
+        }
+        catch (const std::exception& e)
+        {
+            error("Failed to fetch the BusID of the slot. ERROR= {ERR}", "ERR",
+                  e);
+            return;
+        }
+        for (auto& rep : stateEffecterPDRs)
+        {
+            auto pdr = reinterpret_cast<pldm_state_effecter_pdr*>(rep.data());
+            if (instanceId == (uint32_t)pdr->entity_instance)
+            {
+                effecterID = pdr->effecter_id;
+                break;
+            }
+        }
+
+        error(
+            "Sending effecter call to host with effecter ID : {EFF_ID} and BusID : {BUS_ID}",
+            "EFF_ID", effecterID, "BUS_ID", instanceId);
+        hostEffecterParser->sendSetStateEffecterStates(
+            mctp_eid, effecterID, 1, stateField, nullptr, value);
+
+        error(
+            "Setting link reset on link: {PATH} is successful setting it back to false",
+            "PATH", path);
+        pldm::utils::DBusMapping dbusMapping;
+        dbusMapping.objectPath = path;
+        dbusMapping.interface = "com.ibm.Control.Host.PCIeLink";
+        dbusMapping.propertyName = "linkReset";
+        dbusMapping.propertyType = "bool";
+
+        try
+        {
+            pldm::utils::DBusHandler().setDbusProperty(dbusMapping, false);
+        }
+        catch (const std::exception& e)
+        {
+            error("Failed to set the link reset property. ERROR = {ERR}", "ERR",
+                  e);
+            return;
+        }
     }
 }
 

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -145,6 +145,8 @@ class Handler : public oem_platform::Handler
                 mctp_fd, mctp_eid, &instanceIdDb, path, handler);
         pldm::responder::utils::hostChapDataIntf(dbusToFileioIntf.get());
 
+        createMatches();
+
         using namespace sdbusplus::bus::match::rules;
 
         hostOffMatch = std::make_unique<sdbusplus::bus::match_t>(
@@ -576,6 +578,21 @@ class Handler : public oem_platform::Handler
      */
     void setSurvTimer(uint8_t tid, bool value);
 
+    /** @brief method to fetch the properties changed
+     *
+     *  @param[in] chProperties - list of properties which have changed
+     *  @param[in] objPath - path on which property is changed
+     */
+    void propertyChanged(const DbusChangedProps& chProperties,
+                         std::string objPath);
+
+    /** @brief method to trigger host effecter
+     *
+     *  @param[in] value - value to set
+     *  @param[in] path - path for which the effecter is set
+     */
+    void triggerHostEffecter(bool value, std::string path);
+
     /** @brief To turn off Real SAI effecter*/
     void turnOffRealSAIEffecter();
 
@@ -696,6 +713,9 @@ class Handler : public oem_platform::Handler
     /** @brief Timer used for monitoring surveillance pings from host */
     sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
 
+    /** @brief vector of DBus property changed signal match for linkReset*/
+    std::vector<std::unique_ptr<sdbusplus::bus::match_t>> matches;
+
     /** @brief D-Bus Interface added signal match for virtual partition SAI */
     std::unique_ptr<sdbusplus::bus::match_t> partitionSAIMatch;
 
@@ -723,6 +743,10 @@ class Handler : public oem_platform::Handler
     /** @brief instanceDimmMap is a lookup data structure to lookup <EffecterID,
      * dimmID> */
     HostEffecterDimmMap instanceDimmMap;
+
+    /** @brief method to create matches for the proeprty changed signal for link
+     * reset on all slot paths */
+    void createMatches();
 };
 
 /** @brief Method to encode code update event msg

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -188,6 +188,12 @@ std::pair<std::string, std::string>
 std::string getObjectPathByLocationCode(const std::string& locationCode,
                                         const std::string& inventoryItemType);
 
+/** @brief method to get the BusId based on the path */
+uint32_t getLinkResetInstanceNumber(std::string& path);
+
+/** @brief method to find slot objects */
+void findSlotObjects(const std::string& boardObjPath,
+                     std::vector<std::string>& slotObjects);
 } // namespace utils
 
 namespace oem_ibm_utils


### PR DESCRIPTION
This commit implements the link reset feature. When the link reset property is set to true, a host state effecter is triggered following which the link reset property is set back to false again.

Tested: Using busctl command