### PR TITLE
pldm: LI 1TM IBM OEM FRU Names Support

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -114,8 +114,9 @@ void CustomDBus::setLinkReset(
     link.at(path)->linkReset(value);
 }
 
-void CustomDBus::updateItemPresentStatus(const std::string& path,
-                                         bool isPresent)
+void CustomDBus::updateInventoryItemProperties(
+    const std::string& path, bool isPresent,
+    const std::optional<std::string>& prettyName)
 {
     if (presentStatus.find(path) == presentStatus.end())
     {
@@ -127,14 +128,28 @@ void CustomDBus::updateItemPresentStatus(const std::string& path,
         // Hardcode the present dbus property to true
         presentStatus.at(path)->present(true);
 
-        // Set the pretty name dbus property to the filename
-        // form the dbus path object
-        presentStatus.at(path)->prettyName(ObjectPath.filename());
+        if (prettyName.has_value() && !prettyName.value().empty())
+        {
+            // Set the pretty name dbus property
+            presentStatus.at(path)->prettyName(prettyName.value());
+        }
+        else
+        {
+            // Set the pretty name dbus property to the filename
+            // form the dbus path object
+            presentStatus.at(path)->prettyName(ObjectPath.filename());
+        }
     }
     else
     {
         // object is already created
         presentStatus.at(path)->present(isPresent);
+
+        if (prettyName.has_value() && !prettyName.value().empty())
+        {
+            // Set the pretty name dbus property
+            presentStatus.at(path)->prettyName(prettyName.value());
+        }
     }
 }
 

--- a/host-bmc/dbus/custom_dbus.hpp
+++ b/host-bmc/dbus/custom_dbus.hpp
@@ -119,11 +119,14 @@ class CustomDBus
         const std::string& path,
         pldm::responder::oem_fileio::Handler* dbusToFilehandlerObj);
 
-    /** @brief Set the Inventory Item property
+    /** @brief Update the Inventory item presence and pretty name properties
      *  @param[in] path - The object path
      *  @param[in] bool - the presence of fru
+     *  @param[in] prettyName - the pretty name of fru
      */
-    void updateItemPresentStatus(const std::string& path, bool isPresent);
+    void updateInventoryItemProperties(
+        const std::string& path, bool isPresent,
+        const std::optional<std::string>& prettyName = std::nullopt);
 
     /** @brief get Bus ID
      *  @param[in] path - The object path

--- a/host-bmc/dbus/deserialize.cpp
+++ b/host-bmc/dbus/deserialize.cpp
@@ -61,8 +61,9 @@ std::unordered_map<std::string, callback> dBusInterfaceHandler{
      [](const std::string& path, Properties values) {
          if (values.contains("present"))
          {
-             pldm::dbus::CustomDBus::getCustomDBus().updateItemPresentStatus(
-                 path, std::get<bool>(values.at("present")));
+             pldm::dbus::CustomDBus::getCustomDBus()
+                 .updateInventoryItemProperties(
+                     path, std::get<bool>(values.at("present")));
          }
      }},
     {"Enable",

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -327,17 +327,36 @@ class HostPDRHandler
      *  @return
      */
     void setOperationStatus();
+
+    /** @brief Fetch the pretty name if present
+     *
+     *  @param[in] entity - PLDM PDR Entity data
+     *
+     *  @return the resultant string
+     */
+    std::optional<std::string_view> fetchPrettyName(const pldm_entity& entity);
+
+    /** @brief Get the remote terminus handle
+     *
+     *  @return the remote terminus handle
+     */
+    uint16_t getRemoteTerminusHandle();
+
     /** @brief Get the Validity of a Terminus ID
      *
      *  @param[out] bool - true if valid, false otherwise
      */
     bool getValidity(const pldm::pdr::TerminusID& tid);
 
-    /** @brief Set the Present dbus Property
+    /** @brief Set the present status and pretty name dbus properties under
+     * Invenotory Manager
      *  @param[in] path     - object path
+     *  @param[in] prettyName - the pretty name of fru
+     *
      *  @return
      */
-    void setPresentPropertyStatus(const std::string& path);
+    void setInventoryItemProperties(
+        const std::string& path, const std::string& prettyName = std::string());
 
     /** @brief Set the availabilty dbus Property
      *  @param[in] path     - object path
@@ -455,6 +474,13 @@ class HostPDRHandler
 
     PDRList stateSensorPDRs;
     PDRList fruRecordSetPDRs{};
+
+    /** @brief Entity Auxiliary Name PDRs list */
+    PDRList entityAuxNamesPDRs{};
+
+    /** @brief Entity Auxiliary Names list */
+    std::vector<std::shared_ptr<pldm::hostbmc::utils::EntityAuxiliaryNames>>
+        entityAuxiliaryNamesList{};
 
     uint16_t terminusID = 0;
 

--- a/host-bmc/utils.hpp
+++ b/host-bmc/utils.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common/utils.hpp"
 #include "libpldmresponder/oem_handler.hpp"
 
@@ -22,6 +24,34 @@ namespace hostbmc
 namespace utils
 {
 
+using ContainerID = uint16_t;
+using EntityInstanceNumber = uint16_t;
+using EntityType = uint16_t;
+
+/** @struct EntityKey
+ *
+ *  EntityKey uniquely identifies the PLDM entity and a combination of Entity
+ *  Type, Entity Instance Number, Entity Container ID
+ *
+ */
+struct EntityKey
+{
+    EntityType type;                  //!< Entity type
+    EntityInstanceNumber instanceIdx; //!< Entity instance number
+    ContainerID containerId;          //!< Entity container ID
+
+    bool operator==(const EntityKey& e) const
+    {
+        return ((type == e.type) && (instanceIdx == e.instanceIdx) &&
+                (containerId == e.containerId));
+    }
+};
+
+using NameLanguageTag = std::string;
+using AuxiliaryNames = std::vector<std::pair<NameLanguageTag, std::string>>;
+using EntityKey = struct EntityKey;
+using EntityAuxiliaryNames = std::tuple<EntityKey, AuxiliaryNames>;
+
 /** @brief Vector a entity name to pldm_entity from entity association tree
  *  @param[in]  entityAssoc    - Vector of associated pldm entities
  *  @param[in]  entityTree     - entity association tree
@@ -42,6 +72,15 @@ void updateEntityAssociation(
  *  @return returns the entity to DBus string mapping object
  */
 pldm::utils::EntityMaps parseEntityMap(const fs::path& filePath);
+
+/** @brief Parse the enitity auxilliary names PDRs
+ *
+ *  @param[in] pdrData - the response PDRs from GetPDR command
+ *
+ *  @return - EntityAuxiliaryNames details
+ */
+std::shared_ptr<EntityAuxiliaryNames>
+    parseEntityAuxNamesPDR(std::vector<uint8_t>& pdrData);
 
 } // namespace utils
 } // namespace hostbmc

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -462,7 +462,8 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                     // There is no adapter plugged in so set the adapter present
                     // property to false
                     pldm::dbus::CustomDBus::getCustomDBus()
-                        .updateItemPresentStatus(slotAndAdapter.second, false);
+                        .updateInventoryItemProperties(slotAndAdapter.second,
+                                                       false);
                 }
                 else if (
                     linkStatus ==
@@ -472,7 +473,8 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                     // operational, so change the present property of the
                     // adapter to true
                     pldm::dbus::CustomDBus::getCustomDBus()
-                        .updateItemPresentStatus(slotAndAdapter.second, true);
+                        .updateInventoryItemProperties(slotAndAdapter.second,
+                                                       true);
                 }
                 pldm::dbus::CustomDBus::getCustomDBus().setPCIeDeviceProps(
                     slotAndAdapter.second, linkWidth, linkSpeed[curLinkSpeed]);
@@ -810,7 +812,7 @@ void PCIeInfoHandler::setTopologyAttrsOnDbus()
             cableObjectPath.string());
 
         // Implement Inventory.Item Interface on it
-        pldm::dbus::CustomDBus::getCustomDBus().updateItemPresentStatus(
+        pldm::dbus::CustomDBus::getCustomDBus().updateInventoryItemProperties(
             cableObjectPath.string(), true);
 
         // Implement Inventory.Decorator.Asset on it


### PR DESCRIPTION
This commit supports the addition of IBM OEM FRU Names. Pretty name of the inventory item is updated by extracting the Entity Auxiliary Names PDR passed from host.

Tested By:
Verified that the decode of Entity Auxiliary Names PDR results in the intended pretty name string.