### PR TITLE
libresponder: Fixing issues in CM path

### DIFF
--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -361,6 +361,12 @@ uint32_t FruImpl::populateRecords(
 void FruImpl::removeIndividualFRU(const std::string& fruObjPath)
 {
     uint16_t rsi = objectPathToRSIMap[fruObjPath];
+    if (!rsi)
+    {
+        info("No Pdrs to delete for the object path {PATH}", "PATH",
+             fruObjPath);
+        return;
+    }
     pldm_entity removeEntity;
     uint16_t terminusHdl{};
     uint16_t entityType{};
@@ -530,6 +536,12 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
     pldm_entity parentEntity{};
     static uint32_t last_bmc_record_handle = 0;
     uint32_t newRecordHdl{};
+    if (fruInterface == "xyz.openbmc_project.Inventory.Item.PCIeDevice")
+    {
+        // Delete the existing adapter PDR before creating new one
+        info("Removing old PDRs {PATH}", "PATH", fruObjectPath);
+        removeIndividualFRU(fruObjectPath);
+    }
     try
     {
         entity.entity_type = parser.getEntityType(fruInterface);
@@ -588,6 +600,7 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
             bmcEntityTree, &entity, 0xFFFF, bmcTreeParentNode,
             PLDM_ENTITY_ASSOCIAION_PHYSICAL, false, true, last_container_id);
 
+        objects = DBusHandler::getManagedObj(inventoryService, inventoryPath);
         for (const auto& object : objects)
         {
             if (object.first.str == fruObjectPath)
@@ -903,40 +916,60 @@ void FruImpl::processFruPresenceChange(const DbusChangedProps& chProperties,
     }
 
     std::vector<std::string> portObjects;
-    static constexpr auto portInterface =
-        "xyz.openbmc_project.Inventory.Item.Connector";
 
+    if (newPropVal)
+    {
+        info("Presence changed to true for {PATH}", "PATH", fruObjPath);
+        if (fruInterface == "xyz.openbmc_project.Inventory.Item.PCIeDevice")
+        {
 #ifdef OEM_IBM
-    if (fruInterface == "xyz.openbmc_project.Inventory.Item.PCIeDevice")
-    {
-        if (!pldm::responder::utils::checkIfIBMCableCard(fruObjPath))
-        {
-            return;
-        }
-        pldm::responder::utils::findPortObjects(fruObjPath, portObjects);
-        /*   std::cout << "after finding the port objects " <<
-           portObjects.size()
-                     << std::endl;*/
-    }
-    // as per current code the ports do not have Present property
-#endif
-
-    // if(fruInterface != "xyz.openbmc_project.Inventory.Item.PCIeDevice")
-    {
-        if (newPropVal)
-        {
-            buildIndividualFRU(fruInterface, fruObjPath);
-            for (auto portObject : portObjects)
+            if (pldm::responder::utils::checkIfIBMCableCard(fruObjPath))
             {
-                buildIndividualFRU(portInterface, portObject);
+                static constexpr auto portInterface =
+                    "xyz.openbmc_project.Inventory.Item.Connector";
+
+                // if the added fru is IBM cable card, build the adapter
+                // PDRs and the port PDRs.
+                buildIndividualFRU(fruInterface, fruObjPath);
+                pldm::responder::utils::findPortObjects(fruObjPath,
+                                                        portObjects);
+                info("Ports under the cable card: {NUM}", "NUM",
+                     (int)portObjects.size());
+                for (auto portObject : portObjects)
+                {
+                    buildIndividualFRU(portInterface, portObject);
+                }
+                return;
             }
+            else
+            {
+                // PDRs realted to industry standard card are not
+                // rebuilt.
+                return;
+            }
+#endif
         }
-        else
+        buildIndividualFRU(fruInterface, fruObjPath);
+    }
+    else
+    {
+        info("Presence changed to false for {PATH}", "PATH", fruObjPath);
+        if (fruInterface == "xyz.openbmc_project.Inventory.Item.PCIeDevice")
         {
+            // If the card is removed from the system, we do remove the port
+            // pdrs(if present) but not the adapter PDR as adapter PDR should be
+            // always there inspite of the presence of the card.
+#ifdef OEM_IBM
+            pldm::responder::utils::findPortObjects(fruObjPath, portObjects);
             for (auto portObject : portObjects)
             {
                 removeIndividualFRU(portObject);
             }
+#endif
+        }
+        else
+        {
+            info("Removing Individual FRU {PATH}", "PATH", fruObjPath);
             removeIndividualFRU(fruObjPath);
         }
     }

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -469,22 +469,30 @@ bool checkFruPresence(const char* objPath)
     // the port is considered as present. this is so because
     // the ports do not have "Present" property
     std::string pcieAdapter("pcie_card");
+    std::string nvmeAdapter("_drive");
     std::string portStr("cxp_");
+    std::string connectorStr("_connector");
     std::string newObjPath = objPath;
     bool isPresent = true;
 
-    if ((newObjPath.find(pcieAdapter) != std::string::npos) &&
-        !checkIfIBMCableCard(newObjPath))
+    if ((newObjPath.find(pcieAdapter) != std::string::npos) ||
+        (newObjPath.find(nvmeAdapter) != std::string::npos))
     {
-        return true; // industry std cards
+        if ((newObjPath.find(portStr) != std::string::npos) ||
+            (newObjPath.find(connectorStr) != std::string::npos))
+        {
+            newObjPath = pldm::utils::findParent(objPath);
+        }
+        else
+        {
+            // Adapter PDRs are always created underneath the slot for
+            // Insustry standard cards as well as IBM cable cards.
+            // Phyp expects the FRU records for industry std cards to be always
+            // built, irrespective of presence. This is needed by PHYP to send
+            // the Fan floor information
+            return true; // industry std cards/IBM cable cards
+        }
     }
-    else if (newObjPath.find(portStr) != std::string::npos)
-    {
-        newObjPath = pldm::utils::findParent(objPath);
-    }
-
-    // Phyp expects the FRU records for industry std cards to be always
-    // built, irrespective of presence
 
     static constexpr auto presentInterface =
         "xyz.openbmc_project.Inventory.Item";
@@ -496,7 +504,11 @@ bool checkFruPresence(const char* objPath)
         isPresent = std::get<bool>(propVal);
     }
     catch (const sdbusplus::exception::SdBusError& e)
-    {}
+    {
+        error(
+            "D-Bus method call to get the FRU presence of {FRU} failed ERROR={ERR} and return is {V}",
+            "FRU", newObjPath, "ERR", e.what(), "V", (int)isPresent);
+    }
     return isPresent;
 }
 


### PR DESCRIPTION
There is multiple issues faced during the CM. This commit fixes below issues
1. Port PDRs not getting generated after adding cable card concurrently
2. Multiple adapter were seen under single I/O Slot
3. No adapter PDRs for the cards under NVMe Slots (Drive Backplane)

When resolving issues, the design is that the Adapter PDR will always remain in the PDR repository, regardless of whether the card is physically present or absent.

Tested:
Using busctl commands