### PR TITLE
Corrected EventDataOp during removal of fru

### DIFF
--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -608,24 +608,30 @@ bool pldm::responder::oem_ibm_utils::Handler::checkFruPresence(
     // the port is considered as present. this is so because
     // the ports do not have "Present" property
     std::string pcieAdapter("pcie_card");
+    std::string nvmeAdapter("_drive");
     std::string portStr("cxp_");
+    std::string connectorStr("_connector");
     std::string newObjPath = objPath;
     bool isPresent = true;
 
-    if (newObjPath.find(pcieAdapter) != std::string::npos)
+    if ((newObjPath.find(pcieAdapter) != std::string::npos) ||
+        (newObjPath.find(nvmeAdapter) != std::string::npos))
     {
-        if (newObjPath.find(portStr) != std::string::npos)
+        if ((newObjPath.find(portStr) != std::string::npos) ||
+            (newObjPath.find(connectorStr) != std::string::npos))
         {
             newObjPath = pldm::utils::findParent(objPath);
         }
         else
         {
-            return true; // industry std cards
+            // Adapter PDRs are always created underneath the slot for
+            // Insustry standard cards as well as IBM cable cards.
+            // Phyp expects the FRU records for industry std cards to be always
+            // built, irrespective of presence. This is needed by PHYP to send
+            // the Fan floor information
+            return true; // industry std cards/IBM cable cards
         }
     }
-
-    // Phyp expects the FRU records for industry std cards to be always
-    // built, irrespective of presence
 
     static constexpr auto presentInterface =
         "xyz.openbmc_project.Inventory.Item";
@@ -638,8 +644,9 @@ bool pldm::responder::oem_ibm_utils::Handler::checkFruPresence(
     }
     catch (const sdbusplus::exception::SdBusError& e)
     {
-        error("D-Bus method call to get the FRU presence failed ERROR={ERROR}",
-              "ERROR", e);
+        error(
+            "D-Bus method call to get the FRU presence of {FRU} failed ERROR={ERR} and return is {V}",
+            "FRU", newObjPath, "ERR", e.what(), "V", (int)isPresent);
     }
     return isPresent;
 }


### PR DESCRIPTION
During removal of fru, we do remove the contained entity from entity association pdr. If this is the only contained entity in the PDR, the entity association PDR is removed. Based on if the entity association PDR is modified or deleted the EventDataOp is set.

Added the check for presence of record inside PDR repo to know if the PDR is modified and deleted.

Tested:
busctl commands