### PR TITLE
Call CheckIfIBMFru only when OEM_IBM is enabled

### DIFF
--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -949,7 +949,7 @@ void FruImpl::processFruPresenceChange(const DbusChangedProps& chProperties,
         if (fruInterface == "xyz.openbmc_project.Inventory.Item.PCIeDevice" &&
             oemUtilsHandler)
         {
-            if (pldm::responder::utils::checkIfIBMFru(fruObjPath))
+            if (oemUtilsHandler->checkIfIBMFru(fruObjPath))
             {
                 static constexpr auto portInterface =
                     "xyz.openbmc_project.Inventory.Item.Connector";

--- a/libpldmresponder/oem_handler.hpp
+++ b/libpldmresponder/oem_handler.hpp
@@ -236,6 +236,14 @@ class Handler : public CmdHandler
      */
     virtual bool checkFruPresence(const char* objPath) = 0;
 
+    /** @brief checks if given FRU is IBM specific
+     *
+     *  @param[in] objPath - FRU object path
+     *
+     *  @return bool - true if IBM specific FRU
+     */
+    virtual bool checkIfIBMFru(const std::string& objPath) = 0;
+
     /** @brief finds the ports under an adapter
      *
      *  @param[in] adapterObjPath - D-Bus object path for the adapter

--- a/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.cpp
@@ -125,7 +125,7 @@ void Handler::updateDBusProperty(
                 entityType == value.entity_type &&
                 containerId == value.entity_container_id)
             {
-                if (!(pldm::responder::utils::checkIfIBMFru(key)))
+                if (oemUtilsHandler && !(oemUtilsHandler->checkIfIBMFru(key)))
                 {
                     pldm::utils::setFruPresence(key, true);
                 }

--- a/oem/ibm/libpldmresponder/fru_oem_ibm.hpp
+++ b/oem/ibm/libpldmresponder/fru_oem_ibm.hpp
@@ -44,6 +44,15 @@ class Handler : public oem_fru::Handler
      */
     void setIBMFruHandler(pldm::responder::fru::Handler* handler);
 
+    /** @brief Method to set the oem utils handler
+     *
+     *  @param[in] handler - pointer to OEM Utils handler
+     */
+    inline void setOemUtilsHandler(pldm::responder::oem_utils::Handler* handler)
+    {
+        oemUtilsHandler = handler;
+    }
+
     /** @brief Process OEM FRU table
      *
      *  @param[in] fruData - the data of the fru records
@@ -64,6 +73,9 @@ class Handler : public oem_fru::Handler
     const pldm_pdr* pdrRepo;
 
     pldm::responder::fru::Handler* fruHandler; //!< pointer to PLDM fru handler
+
+    pldm::responder::oem_utils::Handler*
+        oemUtilsHandler; //!< pointer to OEM utils handler
 
     /** @brief update the DBus property
      *

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -185,28 +185,6 @@ int writeToUnixSocket(const int sock, const char* buf, const uint64_t blockSize)
     return 0;
 }
 
-bool checkIfIBMFru(const std::string& objPath)
-{
-    using DecoratorAsset =
-        sdbusplus::client::xyz::openbmc_project::inventory::decorator::Asset<>;
-
-    try
-    {
-        auto propVal = pldm::utils::DBusHandler().getDbusPropertyVariant(
-            objPath.c_str(), "Model", DecoratorAsset::interface);
-        const auto& model = std::get<std::string>(propVal);
-        if (!model.empty())
-        {
-            return true;
-        }
-    }
-    catch (const std::exception&)
-    {
-        return false;
-    }
-    return false;
-}
-
 Json convertBinFileToJson(const fs::path& path)
 {
     std::ifstream file(path, std::ios::in | std::ios::binary);
@@ -607,6 +585,29 @@ int pldm::responder::oem_ibm_utils::Handler::setCoreCount(
         }
     }
     return coreCount;
+}
+
+bool pldm::responder::oem_ibm_utils::Handler::checkIfIBMFru(
+    const std::string& objPath)
+{
+    using DecoratorAsset =
+        sdbusplus::client::xyz::openbmc_project::inventory::decorator::Asset<>;
+
+    try
+    {
+        auto propVal = pldm::utils::DBusHandler().getDbusPropertyVariant(
+            objPath.c_str(), "Model", DecoratorAsset::interface);
+        const auto& model = std::get<std::string>(propVal);
+        if (!model.empty())
+        {
+            return true;
+        }
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+    return false;
 }
 
 bool pldm::responder::oem_ibm_utils::Handler::checkModelPresence(

--- a/oem/ibm/libpldmresponder/utils.hpp
+++ b/oem/ibm/libpldmresponder/utils.hpp
@@ -90,14 +90,6 @@ int setupUnixSocket(const std::string& socketInterface);
 int writeToUnixSocket(const int sock, const char* buf,
                       const uint64_t blockSize);
 
-/** @brief checks if given FRU is IBM specific
- *
- *  @param[in] objPath - FRU object path
- *
- *  @return bool - true if IBM specific FRU
- */
-bool checkIfIBMFru(const std::string& objPath);
-
 /** @brief Converts a binary file to json data
  *  This function converts bson data stored in a binary file to
  *  nlohmann json data
@@ -311,6 +303,14 @@ class Handler : public oem_utils::Handler
      *  @return bool to indicate presence or absence
      */
     virtual bool checkFruPresence(const char* objPath);
+
+    /** @brief checks if given FRU is IBM specific
+     *
+     *  @param[in] objPath - FRU object path
+     *
+     *  @return bool - true if IBM specific FRU
+     */
+    virtual bool checkIfIBMFru(const std::string& objPath);
 
     /** @brief finds the ports under an adapter
      *

--- a/pldmd/oem_ibm.hpp
+++ b/pldmd/oem_ibm.hpp
@@ -91,6 +91,7 @@ class OemIBM
         platformHandler->setOemPlatformHandler(oemPlatformHandler.get());
         baseHandler->setOemPlatformHandler(oemPlatformHandler.get());
         slotHandler->setOemPlatformHandler(oemPlatformHandler.get());
+        oemIbmFruHandler->setOemUtilsHandler(oemUtilsHandler.get());
 
         createOemIbmPlatformHandler();
         oemIbmPlatformHandler->setPlatformHandler(platformHandler);

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -291,8 +291,6 @@ int main(int argc, char** argv)
         hostPDRHandler.get(), dbusToPLDMEventHandler.get(), fruHandler.get(),
         bmcEntityTree.get(), platformConfigHandler.get(), &reqHandler, event,
         true);
-    // bmcEntityTree.get(), oemPlatformHandler.get(),
-    // platformConfigHandler.get(), &reqHandler, event, true);
 
     auto biosHandler = std::make_unique<bios::Handler>(
         pldmTransport.getEventSource(), hostEID, &instanceIdDb, &reqHandler,


### PR DESCRIPTION
The CheckIfIBMFru function is defined in OEM path and should only be invoked when oem_ibm is enabled.
Adding this fix to solve the huygen's build error