### PR TITLE
requester: Remove the extra check

### DIFF
--- a/requester/handler.hpp
+++ b/requester/handler.hpp
@@ -160,14 +160,6 @@ class Handler
             }
         };
 
-        if (handlers.contains(key))
-        {
-            error(
-                "Register request for EID '{EID}' is using InstanceID '{INSTANCEID}'",
-                "EID", eid, "INSTANCEID", instanceId);
-            return PLDM_ERROR;
-        }
-
         auto request = std::make_unique<RequestInterface>(
             pldmTransport, eid, event, std::move(requestMsg), numRetries,
             responseTimeOut, verbose);


### PR DESCRIPTION
The queue logic of queuing the requests to a endpoint was removed/reverted in 1110. There was a extra check that was added as part of it to check duplicate key when we call registerRequest.

This check is removed in this commit.

Change-Id: I721b5d287ac657c9c7709b9530d09323af842dba
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>