### PR TITLE
topology: Fix to solve multiple associations

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1728,6 +1728,10 @@ void HostPDRHandler::setFRUDynamicAssociations()
         for (const auto& [rightPath, rightEntity] : objPathMap)
         {
             uint16_t rightEntityType = rightEntity.entity_type;
+
+            std::string leftPath1 = leftPath.string() + "/";
+            std::string rightPath1 = rightPath.string() + "/";
+
             // if leftpath is same as rightPath
             // then both dbus objects are same, so
             // no need to create any associations
@@ -1735,8 +1739,10 @@ void HostPDRHandler::setFRUDynamicAssociations()
             {
                 continue;
             }
-            else if ((rightPath.string().find(leftPath) != std::string::npos) ||
-                     (leftPath.string().find(rightPath) != std::string::npos))
+
+            else if ((rightPath.string().find(leftPath1) !=
+                      std::string::npos) ||
+                     (leftPath.string().find(rightPath1) != std::string::npos))
             {
                 // this means left path dbus object is parent of the
                 // right path dbus object, something like this


### PR DESCRIPTION
The PCIeDevice was associated with multiple PCIeSlots due to the error when creating the association between devices and slots. The commit fixes the association issues present.

Tested: Checked the associations and the topology page loaded fine.

Change-Id: I782f8b8b9f31ea2a8bd9ab68cbfd168eed01602f
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>