### PR TITLE
Introduce New Response and Instance Expiry Timeouts

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -105,19 +105,19 @@ option(
     'instance-id-expiration-interval',
     type: 'integer',
     min: 5,
-    max: 6,
-    value: 5,
+    max: 12,
+    value: 10,
     description: 'Instance ID expiration interval in seconds'
 )
 
-# Default response-time-out set to 2 seconds to facilitate a minimum retry of
-# the request of 2.
+# Default response-time-out set to 5 seconds to facilitate a minimum retry of
+# the request of 5.
 option(
     'response-time-out',
     type: 'integer',
     min: 300,
-    max: 4800,
-    value: 2000,
+    max: 12000,
+    value: 5000,
     description: '''The amount of time a requester has to wait for a response
                     message in milliseconds'''
 )


### PR DESCRIPTION
Between releases 1020 and 1060, we successfully relied on the default PLDM timeouts for requests originating from the BMC.

However, starting with the 1110 drivers, we began encountering intermittent issues where the BMC was under heavy load due to CPU-intensive applications. As a result, PLDM often received limited CPU cycles during reset and reload operations. This meant that even though PHYP responded within the expected timeout window, PLDM was unable to process the requests in time.

To address this, this commit updates the response timeout to **5 seconds** and the instance ID expiry timeout to **12 seconds**.