### PR TITLE
oem: Verify connector presence for cable association in topology

### DIFF
--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -572,12 +572,16 @@ std::string getObjectPathByLocationCode(const std::string& locationCode,
                 if (get<std::string>(properties["LocationCode"]) ==
                     locationCode)
                 {
+                    // Return the object path for Slots/adapters withoot
+                    // checking its presence.
                     // Return the object path only if either
                     // The "xyz.openbmc_project.Inventory.Item" interface is not
                     // present or
                     // The "Present" property is not populated or it is present
                     // and its value is true
-                    if (!interfaces.contains(
+                    if ((inventoryItemType !=
+                         "xyz.openbmc_project.Inventory.Item.Connector") ||
+                        !interfaces.contains(
                             "xyz.openbmc_project.Inventory.Item") ||
                         !presentInfo.contains("Present") ||
                         get<bool>(presentInfo["Present"]))


### PR DESCRIPTION
Topology information contains GenerationsInUse and LanesInUse details which are populated under PCIeDevice interface. ObjectPaths are created for all the adapters present/absent.
Topology data is expected to be populated for all the adapters regardless of their presence.