### PR TITLE
Fetch the inventory data rather than using saved one

### DIFF
--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -333,9 +333,9 @@ class DBusHandler : public DBusHandlerInterface
      *  @return A reference to the cached inventory objects.
      */
     template <typename ClassType>
-    static auto& getInventoryObjects()
+    static const auto getInventoryObjects()
     {
-        static ObjectValueTree object = ClassType::getManagedObj(
+        ObjectValueTree object = ClassType::getManagedObj(
             inventoryManager::interface, inventoryPath);
         return object;
     }


### PR DESCRIPTION
Inventory data can be modified should be  during runtime should be taken into consideration while building the topology data. Whenever PLDM read the inventory data, it should be fetched from Dbus.