### PR TITLE
libpldmresponder: Multiple EA PDR post CM fix

### DIFF
--- a/libpldmresponder/fru.cpp
+++ b/libpldmresponder/fru.cpp
@@ -684,13 +684,6 @@ void FruImpl::buildIndividualFRU(const std::string& fruInterface,
             pdrRepo, &entity, updatedRecordHdlHost);
         hostEventDataOps = PLDM_RECORDS_MODIFIED;
     }
-    else
-    {
-        pldm_entity_association_pdr_create_new(
-            pdrRepo, bmc_record_handle, &parent, &entity,
-            &updatedRecordHdlHost);
-        hostEventDataOps = PLDM_RECORDS_ADDED;
-    }
 
     // create the relevant state effecter and sensor PDRs for the new fru record
     std::vector<uint32_t> recordHdlList;


### PR DESCRIPTION
After we do a CM on PCIe Cable cards, we were observing 2 extra Entity Association PDRs in the repo. The commit removes the code that was causing this issue.

Tested CM on a PCIe cable card and checked the PDR repo of BMC.

Change-Id: If95cd3358e3d8ea1fbac5eba3054d2c26e4dbf2d
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>