### PR TITLE
oem-ibm: Fixes the issue in resource dump entry

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -74,9 +74,6 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
 
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
     {
-        uint32_t dumpIdPrefix =
-            getDumpIdPrefix(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS);
-        fileHandle |= dumpIdPrefix;
         std::string idStr = std::format("{:08X}", fileHandle);
 
         resDumpRequestDirPath = "/var/lib/pldm/resourcedump/" + idStr;
@@ -621,9 +618,6 @@ int DumpHandler::fileAckWithMetaData(
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
     {
         DBusMapping dbusMapping;
-        uint32_t dumpIdPrefix =
-            getDumpIdPrefix(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS);
-        fileHandle |= dumpIdPrefix;
         std::string idStr = std::format("{:08X}", fileHandle);
 
         dbusMapping.objectPath = (std::string)dumpEntryObjPath + "/" + idStr;
@@ -659,9 +653,6 @@ int DumpHandler::fileAckWithMetaData(
         {
             DBusMapping dbusMapping;
 
-            uint32_t dumpIdPrefix =
-                getDumpIdPrefix(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS);
-            fileHandle |= dumpIdPrefix;
             std::string idStr = std::format("{:08X}", fileHandle);
 
             dbusMapping.objectPath =
@@ -705,9 +696,6 @@ int DumpHandler::fileAckWithMetaData(
 
             PropertyValue value{
                 "xyz.openbmc_project.Common.Progress.OperationStatus.Failed"};
-            uint32_t dumpIdPrefix =
-                getDumpIdPrefix(PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS);
-            fileHandle |= dumpIdPrefix;
             std::string idStr = std::format("{:08X}", fileHandle);
 
             DBusMapping dbusMapping{(std::string)dumpEntryObjPath + "/" + idStr,


### PR DESCRIPTION
When a resource dump is created with an empty resource selector from GUI, a system dump is generated and this was entering our resource dump path and was creating wrong entry name.

This is seen in 1110 because of the recent changes in the naming format of the dumps.
Resource dump starts with 'B' and System dump starts with 'A'.

Tested with the fix and it worked good.

Change-Id: Iac7d1455f568e928132c80abb562978184109294
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>