### PR TITLE
1050: libpldmresponder: Use async call in storePel (#675)

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pel.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pel.cpp
@@ -329,9 +329,17 @@ int PelHandler::storePel(std::string&& pelFileName)
                                           logInterface, "Create");
         method.append("xyz.openbmc_project.Host.Error.Event", severity,
                       addlData);
-        bus.call_noreply(
-            method,
-            std::chrono::duration_cast<microsec>(sec(DBUS_TIMEOUT)).count());
+
+        auto callback = [pelFileName](sdbusplus::message_t&& msg) {
+            if (msg.is_method_error())
+            {
+                error(
+                    "Async DBus call failed for PEL file name - '{FILE}', ERROR - {ERROR}",
+                    "FILE", pelFileName, "ERROR", msg.get_error()->message);
+            }
+        };
+
+        [[maybe_unused]] auto slot = method.call_async(callback);
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
#### libpldmresponder: Use async call in storePel (#675)
```
The storePel function used call_noreply, a synchronous D-Bus method
with timeout of 5 secs, which caused it to timeout in some scenarios.

To mitigate this issue, it has been replaced with call_async method.
Additionally, PLDM_SUCCESS is being returned now regardless of
the method call outcome. In case of any error during the async
method call, it will be logged by the callback function.

Change-Id: Ifbb80585ace516c8d4bf484c08356c3734d351fc

Signed-off-by: Jino Abraham <jinoabraham26@gmail.com>
```