### PR TITLE
oem-ibm: Handle the Disruptive System Dump

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -789,6 +789,13 @@ class Handler : public CmdHandler
                                 {
                                     vspstring = "system";
                                 }
+                                else if (
+                                    std::get<std::string>(property.second) ==
+                                    "xyz.openbmc_project.Dump.Entry.System.SystemImpact.Disruptive")
+                                {
+                                    return; // it is a disruptive system dump,
+                                            // ignore
+                                }
                             }
                             else if (property.first == "UserChallenge")
                             {


### PR DESCRIPTION
Earlier dump manager was not creating a system dump entry when a disruptive system dump was triggered. Recent changes in dump manager started creating a dump entry and we had to handle the scenario when the SystemImpact was Disruptive. When it is a disruptive system dump we must ignore and do not process it.

Change-Id: I5afb3d4ee1e9f20afbe264ba613073b11faf6199
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>