### PR TITLE
oem-ibm: Dynamic I/O drawer attachment updata

### DIFF
--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/bios_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Everest/bios_attrs.json
@@ -991,7 +991,7 @@
             "lower_bound": 0,
             "upper_bound": 9,
             "scalar_increment": 1,
-            "default_value": 9,
+            "default_value": 2,
             "help_text": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
             "display_name": "Dynamic I/O Drawer Attachment"
         },
@@ -1001,7 +1001,7 @@
             "lower_bound": 0,
             "upper_bound": 9,
             "scalar_increment": 1,
-            "default_value": 9,
+            "default_value": 2,
             "read_only": true,
             "help_text": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
             "display_name": "Dynamic I/O Drawer Attachment"

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/bios_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier1S4U/bios_attrs.json
@@ -987,27 +987,6 @@
         },
         {
             "attribute_type": "integer",
-            "attribute_name": "hb_storage_preallocation_for_drawer_attach",
-            "lower_bound": 0,
-            "upper_bound": 4,
-            "scalar_increment": 1,
-            "default_value": 4,
-            "help_text": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
-            "display_name": "Dynamic I/O Drawer Attachment"
-        },
-        {
-            "attribute_type": "integer",
-            "attribute_name": "hb_storage_preallocation_for_drawer_attach_current",
-            "lower_bound": 0,
-            "upper_bound": 4,
-            "scalar_increment": 1,
-            "default_value": 4,
-            "read_only": true,
-            "help_text": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
-            "display_name": "Dynamic I/O Drawer Attachment"
-        },
-        {
-            "attribute_type": "integer",
             "attribute_name": "pvm_rpd_scheduled_tod",
             "lower_bound": 0,
             "upper_bound": 86399,

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/bios_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier2U/bios_attrs.json
@@ -987,27 +987,6 @@
         },
         {
             "attribute_type": "integer",
-            "attribute_name": "hb_storage_preallocation_for_drawer_attach",
-            "lower_bound": 0,
-            "upper_bound": 4,
-            "scalar_increment": 1,
-            "default_value": 4,
-            "help_text": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
-            "display_name": "Dynamic I/O Drawer Attachment"
-        },
-        {
-            "attribute_type": "integer",
-            "attribute_name": "hb_storage_preallocation_for_drawer_attach_current",
-            "lower_bound": 0,
-            "upper_bound": 4,
-            "scalar_increment": 1,
-            "default_value": 4,
-            "read_only": true,
-            "help_text": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
-            "display_name": "Dynamic I/O Drawer Attachment"
-        },
-        {
-            "attribute_type": "integer",
             "attribute_name": "pvm_rpd_scheduled_tod",
             "lower_bound": 0,
             "upper_bound": 86399,

--- a/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/bios_attrs.json
+++ b/oem/ibm/configurations/bios/com.ibm.Hardware.Chassis.Model.Rainier4U/bios_attrs.json
@@ -987,27 +987,6 @@
         },
         {
             "attribute_type": "integer",
-            "attribute_name": "hb_storage_preallocation_for_drawer_attach",
-            "lower_bound": 0,
-            "upper_bound": 4,
-            "scalar_increment": 1,
-            "default_value": 4,
-            "help_text": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
-            "display_name": "Dynamic I/O Drawer Attachment"
-        },
-        {
-            "attribute_type": "integer",
-            "attribute_name": "hb_storage_preallocation_for_drawer_attach_current",
-            "lower_bound": 0,
-            "upper_bound": 4,
-            "scalar_increment": 1,
-            "default_value": 4,
-            "read_only": true,
-            "help_text": "This option allocates platform memory during IPL for PCI-E slots to enable dynamic I/O drawer attachment.",
-            "display_name": "Dynamic I/O Drawer Attachment"
-        },
-        {
-            "attribute_type": "integer",
             "attribute_name": "pvm_rpd_scheduled_tod",
             "lower_bound": 0,
             "upper_bound": 86399,


### PR DESCRIPTION
This commit contains below changes
1. Update the updates in Everest/Fuji configuration
2. Removes the attribute from Rainier/Blu ridge systems

Tested By:
Verified that changes got reflected in BMC GUI. System power on operation worked good

Change-Id: Id321650b04b9ea2c47f8fe7a8550d1b0b863f048