### PR TITLE
oem-ibm: Increased wait for connection during dump offload

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -203,9 +203,9 @@ class DMA
                        MAP_SHARED, xdmaFd, 0);
         if (MAP_FAILED == memAddr)
         {
-            error("Failed to get memory location with err num '{ERRNO}'",
-                  "ERRNO", errno);
-            return nullptr;
+            error(
+                "Failed to map XDMA get memory location of length {LENGTH} with err num '{ERRNO}'",
+                "LENGTH", pageAlignedLength, "ERRNO", errno);
         }
 
         return memAddr;

--- a/oem/ibm/libpldmresponder/utils.cpp
+++ b/oem/ibm/libpldmresponder/utils.cpp
@@ -92,7 +92,7 @@ int setupUnixSocket(const std::string& socketInterface)
 
     fd_set rfd;
     struct timeval tv;
-    tv.tv_sec = 1;
+    tv.tv_sec = 2;
     tv.tv_usec = 0;
 
     FD_ZERO(&rfd);
@@ -123,6 +123,14 @@ int setupUnixSocket(const std::string& socketInterface)
         }
         close(sock);
     }
+
+    if (retval == 0)
+    {
+        error(
+            "Timed out while waiting for connection on unix socket from external module");
+        close(sock);
+    }
+
     return fd;
 }
 


### PR DESCRIPTION
We are facing issues with dump offload where PLDM is timing out while waiting for connection from BMCWeb on unix socket which is used to transfer dump data.
Increased select timeout to 2sec to solve the dump download failure.

Fixes: STG Defect 690577