### PR TITLE
oem-ibm: Fix for the PEL parsing issue

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -245,6 +245,17 @@ int DMA::transferDataHost(int fd, uint32_t offset, uint32_t length,
                 "OFFSET", offset);
             return rc;
         }
+        
+        int retCode = fsync(fd);
+        if (retCode == -1)
+        {
+            retCode = -errno;
+            error("Failed to perform unix FD fsync of '{UPSTREAM}' data transfer between BMC and remote terminus with errno as '{RC}', length as '{LEN}' at offset '{OFFSET}'",
+                  "UPSTREAM",upstream, "RC", retCode, "LEN", length,
+                  "OFFSET", offset);
+            return retCode;
+        }
+
         responseByte = rc;
     }
 

--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -162,6 +162,14 @@ void FileHandler::transferFileData(
         {
             if (sharedAIORespDataobj.functionPtr != nullptr)
             {
+                rc = close(fd);
+                if (rc == -1)
+                {
+                    rc = -errno;
+                    error("Failed to close the unix FD with errno as '{ERROR_NUM}', length as '{LENGTH}', offset at '{OFFSET}' and upstream flag as '{UPSTREAM}'",
+                          "ERROR_NUM", rc, "LENGTH", length, "OFFSET", offset,
+                          "UPSTREAM", upstream);
+                }
                 rc = sharedAIORespDataobj.functionPtr->postDataTransferCallBack(
                     command == PLDM_WRITE_FILE_BY_TYPE_FROM_MEMORY,
                     data.length);


### PR DESCRIPTION
This commit contains the fix for the invalid PEL issue where the PEL send by the remote end point could not get parsed properly. Fix is to explicitly execute the unix FD sync and close after the write FD operation.

Fixes : STG Defect 678010

Change-Id: Ib81fd21e160423f103218e8839133119a5a89cc1