### PR TITLE
Revert "Introduce New Response and Instance Expiry Timeouts (#661)"

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -105,19 +105,19 @@ option(
     'instance-id-expiration-interval',
     type: 'integer',
     min: 5,
-    max: 12,
-    value: 10,
+    max: 6,
+    value: 5,
     description: 'Instance ID expiration interval in seconds'
 )
 
-# Default response-time-out set to 5 seconds to facilitate a minimum retry of
-# the request of 5.
+# Default response-time-out set to 2 seconds to facilitate a minimum retry of
+# the request of 2.
 option(
     'response-time-out',
     type: 'integer',
     min: 300,
-    max: 12000,
-    value: 5000,
+    max: 4800,
+    value: 2000,
     description: '''The amount of time a requester has to wait for a response
                     message in milliseconds'''
 )


### PR DESCRIPTION
This reverts commit 3ade053d0e3d72f209c9832829d1b77143e29ee5.

There are cases where we have seen that instance id's are exhausted, having less instance id expiry timeout would help recover the instance ids faster.