### PR TITLE
libresponder: Get record handles from RepoChangeEvent

### DIFF
--- a/libpldmresponder/platform.cpp
+++ b/libpldmresponder/platform.cpp
@@ -610,27 +610,23 @@ int Handler::pldmPDRRepositoryChgEvent(
                 return rc;
             }
 
-            if (eventDataOperation == PLDM_RECORDS_ADDED ||
-                eventDataOperation == PLDM_RECORDS_MODIFIED)
+            if (eventDataOperation == PLDM_RECORDS_MODIFIED)
             {
-                if (eventDataOperation == PLDM_RECORDS_MODIFIED)
-                {
-                    info("Got a modified event from tid: {TID}", "TID", tid);
-                    hostPDRHandler->isHostPdrModified = true;
-                    hostPDRHandler->modifiedCounter += pdrRecordHandles.size();
-                }
+                info("Got a modified event from tid: {TID}", "TID", tid);
+                hostPDRHandler->isHostPdrModified = true;
+                hostPDRHandler->modifiedCounter += pdrRecordHandles.size();
+            }
 
-                rc = getPDRRecordHandles(
-                    reinterpret_cast<const ChangeEntry*>(
-                        changeRecordData + dataOffset),
-                    changeRecordDataSize - dataOffset,
-                    static_cast<size_t>(numberOfChangeEntries),
-                    pdrRecordHandles);
+            rc = getPDRRecordHandles(
+                reinterpret_cast<const ChangeEntry*>(
+                    changeRecordData + dataOffset),
+                changeRecordDataSize - dataOffset,
+                static_cast<size_t>(numberOfChangeEntries), pdrRecordHandles);
 
-                if (rc != PLDM_SUCCESS)
-                {
-                    return rc;
-                }
+            if (rc != PLDM_SUCCESS)
+            {
+                error("Invalid data, no pdr handles found");
+                return rc;
             }
 
             changeRecordData +=


### PR DESCRIPTION
Added support to fetch record handles from the repository change request for the Records Deleted Event.

Fixes: STG Defect 692402