### PR TITLE
Fix crash when handling socket closure early

### DIFF
--- a/host-bmc/dbus/linkreset.cpp
+++ b/host-bmc/dbus/linkreset.cpp
@@ -16,7 +16,6 @@ namespace dbus
 
 bool Link::linkReset(bool value)
 {
-    error("CustomDBus: Got a link reset on: {PATH}", "PATH", path);
     std::vector<set_effecter_state_field> stateField;
 
     if (value ==
@@ -39,6 +38,7 @@ bool Link::linkReset(bool value)
         {
             return false;
         }
+        error("CustomDBus: Got a link reset on: {PATH}", "PATH", path);
 
         error(
             "CustomDBus: Sending a effecter call to host with effecter id: {EFF_ID}",

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -329,7 +329,14 @@ int main(int argc, char** argv)
                      fwManager.get(), platformManager.get()});
     auto callback = [verbose, &invoker, &reqHandler, &fwManager, &pldmTransport,
                      TID](IO& io, int fd, uint32_t revents) mutable {
-        if (!(revents & EPOLLIN))
+        if (revents & (POLLHUP | POLLERR))
+        {
+            warning("Transport Socket hang-up or error. IO Exiting.");
+            io.get_event().exit(0);
+            return;
+        }
+
+        else if (!(revents & EPOLLIN))
         {
             return;
         }


### PR DESCRIPTION
When the MCTP daemon) closes the socket, the event loop may still deliver `EPOLLIN` alongside `POLLHUP`. Previously, the callback did not explicitly check for `POLLHUP` before attempting to receive data via `recvMsg()`.

This led to a scenario where `recvMsg()` was called on a socket that had already been closed, causing undefined behavior or memory corruption (e.g., during buffer allocation or cleanup). While `recvMsg()` returned a failure code (`PLDM_REQUESTER_RECV_FAIL`), the subsequent call to `io.get_event().exit(0)` would result in a crash due to the corrupted state.

This change adds an early check for `POLLHUP` (and `POLLERR`) at the beginning of the IO callback and exits the event loop immediately when detected. This prevents any further I/O operations on a dead socket and ensures a clean shutdown without triggering undefined behavior.

fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=689485

Change-Id: Idc5fb2cb849f2af7c12b67cdd509d81b2587c8ba