### PR TITLE
oem-ibm: Fix MSBE dump offload issue

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -92,8 +92,6 @@ std::string DumpHandler::findDumpObjPath(uint32_t fileHandle)
     }
     else if (dumpType == PLDM_FILE_TYPE_SBE_DUMP)
     {
-        uint32_t dumpIdPrefix = getDumpIdPrefix(PLDM_FILE_TYPE_SBE_DUMP);
-        fileHandle |= dumpIdPrefix;
         std::string idStr = std::format("{:08X}", fileHandle);
 
         curDumpEntryPath = (std::string)dumpEntryObjPath + "/" + idStr;


### PR DESCRIPTION
There is no separate PLDM type for MSBE dumps; BMC sends MSBE dumps (identified by IDs starting with '4') using the SBE PLDM dump type. MSBE dump offload is failing due to an additional OR operation with '0x30000000' for SBE types. This OR operation has been removed, as converting the decimal dump ID recieved from PHYP to hexadecimal yields the correct dump ID without modification.

Tested both SBE and MSBE dump offload and it is working as expected.

Test Results:

MSBE offload:

```
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Watch propertiesChanged object path (/xyz/openbmc_project/dump/system/entry/40000041)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Queue enqueue dump (/xyz/openbmc_project/dump/system/entry/40000041) size of Q (0)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Queue start timer host running (true) hmcmanaged (false)Dumps size  (1)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Queue offload initiating offload (/xyz/openbmc_project/dump/system/entry/40000041) id (1073741889) type (1) size (228
733)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: sendNewDumpCmd Id(1073741889) Size(228733) Type(1) PldmDumpType(16)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: encode_new_file_req Instance ID (1) DumpID (1073741889) DumpType (16) DumpSize(228733)  ReqMsgSize(17)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Done. PLDM message, id: 1, RC: 0
Apr 14 08:16:05 p10bmc pldmd[9829]: FileHandle in findDumpObjPath is 1073741889
Apr 14 08:16:05 p10bmc pldmd[9829]: SBE dump entry path is /xyz/openbmc_project/dump/system/entry/40000041
Apr 14 08:16:24 p10bmc pvm_dump_offload[9803]: Watch interfaceRemoved path (/xyz/openbmc_project/dump/system/entry/40000041)
Apr 14 08:16:24 p10bmc pvm_dump_offload[9803]: Queue dequeue (/xyz/openbmc_project/dump/system/entry/40000041) size of Q (1)
Apr 14 08:16:24 p10bmc pvm_dump_offload[9803]: Queue offloaded dump completed (/xyz/openbmc_project/dump/system/entry/40000041)
Apr 14 08:16:24 p10bmc pvm_dump_offload[9803]: Queue stop timer host running (true) hmcmanaged (false)Dumps size  (0)
```

SBE offload:

```
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Watch propertiesChanged object path (/xyz/openbmc_project/dump/system/entry/30000040)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Queue enqueue dump (/xyz/openbmc_project/dump/system/entry/30000040) size of Q (0)
Apr 14 08:13:09 p10bmc pldmd[9829]: sdeventplus: ioCallback: Instance ID 0 for TID 9 was not previously allocated
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Queue start timer host running (true) hmcmanaged (false)Dumps size  (1)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Queue offload initiating offload (/xyz/openbmc_project/dump/system/entry/30000040) id (805306432) type (1) size (258641)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: sendNewDumpCmd Id(805306432) Size(258641) Type(1) PldmDumpType(16)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Got instanceId: 0 from PLDM eid: 9
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: encode_new_file_req Instance ID (0) DumpID (805306432) DumpType (16) DumpSize(258641)  ReqMsgSize(17)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Done. PLDM message, id: 0, RC: 0
Apr 14 08:13:39 p10bmc pldmd[9829]: FileHandle in findDumpObjPath is 805306432
Apr 14 08:13:39 p10bmc pldmd[9829]: SBE dump entry path is /xyz/openbmc_project/dump/system/entry/30000040
Apr 14 08:13:39 p10bmc pvm_dump_offload[9803]: Watch interfaceRemoved path (/xyz/openbmc_project/dump/system/entry/30000040)
Apr 14 08:13:39 p10bmc pvm_dump_offload[9803]: Queue dequeue (/xyz/openbmc_project/dump/system/entry/30000040) size of Q (1)
Apr 14 08:13:39 p10bmc pvm_dump_offload[9803]: Queue offloaded dump completed (/xyz/openbmc_project/dump/system/entry/30000040)
Apr 14 08:13:39 p10bmc pvm_dump_offload[9803]: Queue stop timer host running (true) hmcmanaged (false)Dumps size  (0)
```

Change-Id: Ic95d5f531a6578f40be78d934af1de1b73715e8c