### PR TITLE
host-bmc: Fix in the panel flow for Reset Reload

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -741,6 +741,12 @@ void HostPDRHandler::processHostPDRs(
                     pdrTerminusHandle =
                         extractTerminusHandle<pldm_state_effecter_pdr>(pdr);
                     updateContainerId<pldm_state_effecter_pdr>(entityTree, pdr);
+                    if (oemPlatformHandler)
+                    {
+                        oemPlatformHandler->modifyPDROemActions(
+                            (PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD | 0x8000),
+                            PLDM_OEM_IBM_PANEL_TRIGGER_STATE);
+                    }
                 }
                 else if (pdrHdr->type == PLDM_NUMERIC_EFFECTER_PDR)
                 {

--- a/host-bmc/host_pdr_handler.hpp
+++ b/host-bmc/host_pdr_handler.hpp
@@ -12,6 +12,7 @@
 #include "utils.hpp"
 
 #include <libpldm/base.h>
+#include <libpldm/oem/ibm/state_set.h>
 #include <libpldm/platform.h>
 
 #include <sdeventplus/event.hpp>

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1881,8 +1881,11 @@ void pldm::responder::oem_ibm_platform::Handler::modifyPDROemActions(
         if (!std::empty(pdrs))
         {
             auto bitMap = responder::pdr_utils::fetchBitMap(pdrs);
-            setBitmapMethodCall("/com/ibm/panel_app", "toggleFunctionState",
-                                "com.ibm.panel", bitMap);
+            if (!bitMap.empty())
+            {
+                setBitmapMethodCall("/com/ibm/panel_app", "toggleFunctionState",
+                                    "com.ibm.panel", bitMap);
+            }
         }
     }
 }


### PR DESCRIPTION
The op-panel function enabling will be sent down from PHYP with a modify event after the PDR exchange in the normal poweron path. But after a Reset Reload the function bitmaps will be sent down from PHYP with a Added event. To trigger the panel app even during the added event (reset reload case) this change is made.

Tested: Triggered the functions using the paneltool and the functions are persisted post reset reload also.

Fixes: 689601