### PR TITLE
oem-ibm: Invalid pel fix

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -741,12 +741,6 @@ void HostPDRHandler::processHostPDRs(
                     pdrTerminusHandle =
                         extractTerminusHandle<pldm_state_effecter_pdr>(pdr);
                     updateContainerId<pldm_state_effecter_pdr>(entityTree, pdr);
-                    if (oemPlatformHandler)
-                    {
-                        oemPlatformHandler->modifyPDROemActions(
-                            (PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD | 0x8000),
-                            PLDM_OEM_IBM_PANEL_TRIGGER_STATE);
-                    }
                 }
                 else if (pdrHdr->type == PLDM_NUMERIC_EFFECTER_PDR)
                 {
@@ -901,6 +895,12 @@ void HostPDRHandler::processHostPDRs(
         {
             info("Host is UP & Completed the PDR Exchange with host");
             this->setHostSensorState();
+            if (oemPlatformHandler)
+            {
+                oemPlatformHandler->modifyPDROemActions(
+                    (PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD | 0x8000),
+                    PLDM_OEM_IBM_PANEL_TRIGGER_STATE);
+            }
         }
         entityAssociations.clear();
 

--- a/requester/handler.hpp
+++ b/requester/handler.hpp
@@ -223,14 +223,6 @@ class Handler
             instanceIdDb.free(key.eid, key.instanceId);
             handlers.erase(key);
         }
-        else
-        {
-            // Got a response for a PLDM request message not registered with the
-            // request handler, so freeing up the instance ID, this can be other
-            // OpenBMC applications relying on PLDM D-Bus apis like
-            // openpower-occ-control and softoff
-            instanceIdDb.free(key.eid, key.instanceId);
-        }
     }
 
   private:


### PR DESCRIPTION
Phyp copies the error log data to the XDMA memory and then it sends the `WriteFileByTypeFromMemory` to PLDM.  From PLDM side, setting the struct AspeedXdmaOp instructs DMA controller to copy the data to bmc side. Because of slow data copy, we have partial data in the BMC XDMA buffer. As we have mmapped the VGA memory to the length of the Pel, we fetch the exact length which contains partial data and remaining bytes as garbage.

To fix the issue, added a check to make sure that if the DMA data copy is completed successfuly before copying the pel data to temporary file.

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=678010