### PR TITLE
oem-ibm: NVRAM service file changes.

### DIFF
--- a/oem/ibm/service_files/pldm-create-phyp-nvram.service
+++ b/oem/ibm/service_files/pldm-create-phyp-nvram.service
@@ -4,12 +4,29 @@ Wants=obmc-vpnor-updatesymlinks.service
 After=obmc-vpnor-updatesymlinks.service
 Wants=obmc-flash-bios-init.service
 After=obmc-flash-bios-init.service
-ConditionPathExists=!/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM
 
 [Service]
-ExecStart=/usr/bin/create-NVRAM-file
 Type=oneshot
 RemainAfterExit=no
+ExecStart=/bin/sh -c '\
+  mkdir -p /var/lib/phosphor-software-manager/hostfw/nvram; \
+  if [ ! -f /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM ]; then \
+    NEED_CREATE=true; \
+  elif [ "$(stat -c%s /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM)" -ne $((1024 * 145408)) ]; then \
+    echo "Invalid size, recreating file"; \
+    rm -f /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; \
+    NEED_CREATE=true; \
+  else \
+    NEED_CREATE=false; \
+  fi; \
+  if $NEED_CREATE; then \
+    if [ -f /var/lib/pldm/PHYP-NVRAM ] && [ "$(stat -c%s /var/lib/pldm/PHYP-NVRAM)" -eq $((1024 * 145408)) ]; then \
+      mv /var/lib/pldm/PHYP-NVRAM /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; \
+    else \
+      rm -f /var/lib/pldm/PHYP-NVRAM; \
+      truncate -s $((1024 * 145408)) /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; \
+    fi; \
+  fi'
 
 [Install]
 WantedBy=pldmd.service


### PR DESCRIPTION
The NVRAM file size could be wrong in manufactuing itself or somewhere in between the process and it becomes difficult to check where could the file size go wrong.
Earlier PLDM service would not create the NVRAM file if it already exists. But the file could have the wrong file size which could lead to issues.
There was a need to check the NVRAM file size.

This change in PLDM NVRAM service files handles below conditions
1. If the file /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM exists and if it has a bad size we have to remove it and recreate it.
2. if /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM file does not exist then check if /var/lib/pldm/PHYP-NVRAM exists if so then move /var/lib/pldm/PHYP-NVRAM to /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM if not...or if the file exists with bad size then create /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM using truncate.

Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>
