### PR TITLE
oem-ibm: NVRAM service file changes

### DIFF
--- a/oem/ibm/service_files/pldm-create-phyp-nvram.service
+++ b/oem/ibm/service_files/pldm-create-phyp-nvram.service
@@ -4,7 +4,6 @@ Wants=obmc-vpnor-updatesymlinks.service
 After=obmc-vpnor-updatesymlinks.service
 Wants=obmc-flash-bios-init.service
 After=obmc-flash-bios-init.service
-ConditionPathExists=!/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM
 
 [Service]
 ExecStart=/bin/sh -c "if [ -f /var/lib/pldm/PHYP-NVRAM ]; then mv /var/lib/pldm/PHYP-NVRAM /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; else truncate -s $((1024 * 145408)) /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; fi"

--- a/oem/ibm/service_files/scripts/create-NVRAM-file
+++ b/oem/ibm/service_files/scripts/create-NVRAM-file
@@ -1,7 +1,36 @@
 #!/bin/sh
+mkdir -p /var/lib/phosphor-software-manager/hostfw/nvram
+NVRAM=/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM
+BACKUP=/var/lib/pldm/PHYP-NVRAM
+SIZE=$((1024 * 145408))
 
-if [ -f /var/lib/pldm/PHYP-NVRAM ]; then
-    mv /var/lib/pldm/PHYP-NVRAM /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM;
+if [ ! -f "$NVRAM" ]; then
+    echo "NVRAM file not found"
+    NEED_CREATE=true
+elif [ "$(stat -c%s "$NVRAM")" -ne "$SIZE" ]; then
+    CURRENT_SIZE=$(stat -c%s "$NVRAM")
+    echo "Invalid NVRAM size: $CURRENT_SIZE bytes, recreating NVRAM file"
+    rm -f "$NVRAM"
+    NEED_CREATE=true
 else
-    dd if=/dev/zero of=/var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM bs=1024 count=145408;
+    CURRENT_SIZE=$(stat -c%s "$NVRAM")
+    echo "NVRAM file found with correct size: $CURRENT_SIZE bytes"
+    NEED_CREATE=false
+fi
+
+if $NEED_CREATE; then
+    if [ -f "$BACKUP" ]; then
+        BACKUP_SIZE=$(stat -c%s "$BACKUP")
+        if [ "$BACKUP_SIZE" -eq "$SIZE" ]; then
+            echo "Backup file size valid ($BACKUP_SIZE bytes), moving to NVRAM path"
+            mv "$BACKUP" "$NVRAM"
+        else
+            echo "Backup file size invalid ($BACKUP_SIZE bytes), deleting backup"
+            rm -f "$BACKUP"
+            truncate -s "$SIZE" "$NVRAM"
+        fi
+    else
+        echo "Backup file not found, creating new NVRAM file"
+        truncate -s "$SIZE" "$NVRAM"
+    fi
 fi


### PR DESCRIPTION
The NVRAM file size could be wrong in manufactuing itself or somewhere in between the process and it becomes difficult to check where could the file size go wrong.
Earlier PLDM service would not create the NVRAM file if it already exists. But the file could have the wrong file size which could lead to issues.
There was a need to check the NVRAM file size.

This change in PLDM NVRAM service files handles below conditions
1. If the file /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM exists and if it has a bad size we have to remove it and recreate it.
2. if /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM file does not exist then check if /var/lib/pldm/PHYP-NVRAM exists if so then move /var/lib/pldm/PHYP-NVRAM to /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM if not...or if the file exists with bad size then create /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM using truncate


Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>