### PR TITLE
1120: oem-ibm: Log pel on decode failure of new file available response (#699)

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1656,8 +1656,8 @@ int pldm::responder::oem_ibm_platform::Handler::checkBMCState()
             pldm::utils::DBusHandler().getDbusPropertyVariant(
                 bmcPath.str.c_str(), "CurrentBMCState", BMC::interface);
 
-        if (std::get<std::string>(propertyValue) ==
-            "xyz.openbmc_project.State.BMC.BMCState.NotReady")
+        if (std::get<std::string>(propertyValue) !=
+            "xyz.openbmc_project.State.BMC.BMCState.Ready")
         {
             error("GetPDR : PLDM stack is not ready for PDR exchange");
             return PLDM_ERROR_NOT_READY;

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -372,8 +372,11 @@ void DbusToFileHandler::newFileAvailableSendToHost(
             error(
                 "Failed to decode new file available response for vmi or remote terminus returned error, response code '{RC}' and completion code '{CC}'",
                 "RC", rc, "CC", completionCode);
-            pldm::utils::reportError(
-                "xyz.openbmc_project.PLDM.Error.DecodeNewFileResponseFail");
+            if (rc)
+            {
+                pldm::utils::reportError(
+                    "xyz.openbmc_project.PLDM.Error.DecodeNewFileResponseFail");
+            }
         }
     };
     rc = handler->registerRequest(


### PR DESCRIPTION
#### oem-ibm: Log pel on decode failure of new file available response (#699)
```
In the current code, the DecodeNewFileResponseFail PEL is logged
for both decode failure of the NewFileAvailable response and
when a non-success response is received for the command.

Added the fix to log the pel only if decode fails

Fixed: STGDefect 706264

Signed-off-by: Archana Kakani <archana.kakani@ibm.com>```