### PR TITLE
oem-ibm: Set LinkWidth and GenerationInUse in link topology

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -441,6 +441,7 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                 service.c_str(), slotAndAdapter.second.c_str(),
                 "org.freedesktop.DBus.Properties", "Set");
             method.append(itemPCIeDevice, "LanesInUse", linkWidth);
+            bus.call_noreply(method, dbusTimeout);
 
             std::filesystem::path adapter(slotAndAdapter.second);
 
@@ -494,6 +495,7 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                     service.c_str(), slotAndAdapter.second.c_str(),
                     "org.freedesktop.DBus.Properties", "Set");
                 method.append(itemPCIeDevice, "LanesInUse", linkWidth);
+                bus.call_noreply(method, dbusTimeout);
             }
 
             std::filesystem::path adapter(slotAndAdapter.second);


### PR DESCRIPTION
Currently LinkWidth and GenerationInUse are not getting updated over dbus. This commit fixes the issue

Fixes: STGDefect 708131