### PR TITLE
oem-ibm: Set LinkWidth accurately over Dbus

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -434,14 +434,8 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                         linkSpeed[curLinkSpeed], itemPCIeDevice, "string");
 
             // set link width
-            auto& bus = pldm::utils::DBusHandler::getBus();
-            auto service = pldm::utils::DBusHandler().getService(
-                slotAndAdapter.second.c_str(), itemPCIeDevice);
-            auto method = bus.new_method_call(
-                service.c_str(), slotAndAdapter.second.c_str(),
-                "org.freedesktop.DBus.Properties", "Set");
-            method.append(itemPCIeDevice, "LanesInUse", linkWidth);
-
+            setProperty(slotAndAdapter.second, "LanesInUse",
+                        (size_t)(linkWidth), itemPCIeDevice, "uint32_t");
             std::filesystem::path adapter(slotAndAdapter.second);
 
             error(
@@ -487,13 +481,8 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                             linkSpeed[curLinkSpeed], itemPCIeDevice, "string");
 
                 // set link width
-                auto& bus = pldm::utils::DBusHandler::getBus();
-                auto service = pldm::utils::DBusHandler().getService(
-                    slotAndAdapter.second.c_str(), itemPCIeDevice);
-                auto method = bus.new_method_call(
-                    service.c_str(), slotAndAdapter.second.c_str(),
-                    "org.freedesktop.DBus.Properties", "Set");
-                method.append(itemPCIeDevice, "LanesInUse", linkWidth);
+                setProperty(slotAndAdapter.second, "LanesInUse",
+                            (size_t)(linkWidth), itemPCIeDevice, "uint32_t");
             }
 
             std::filesystem::path adapter(slotAndAdapter.second);


### PR DESCRIPTION
Currently LinkWidth is not getting updated over Dbus. This commit fixes the issue

Fixes: STGDefect 708131