### PR TITLE
1120: oem-ibm: Set LinkWidth accurately over Dbus (#703) & pldm: Core Count and DIMM Persistency (#701) & oem-ibm: Invalid pel fix (#691)

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -315,11 +315,45 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
         auto& bus = getBus();
         auto service =
             getService(dBusMap.objectPath.c_str(), dBusMap.interface.c_str());
-        auto method = bus.new_method_call(
-            service.c_str(), dBusMap.objectPath.c_str(), dbusProperties, "Set");
-        method.append(dBusMap.interface.c_str(), dBusMap.propertyName.c_str(),
-                      variant);
-        bus.call_noreply(method, dbusTimeout);
+        if (service == "xyz.openbmc_project.Inventory.Manager")
+        {
+            ObjectValueTree objectValueTree;
+            InterfaceMap interfaceMap;
+            PropertyMap propertyMap;
+            propertyMap.emplace(dBusMap.propertyName.c_str(),
+                                std::get<0>(variant));
+            std::string objPath = dBusMap.objectPath.c_str();
+            std::string toReplace("/xyz/openbmc_project/inventory/system");
+            size_t pos = objPath.find(toReplace);
+            objPath.replace(pos, toReplace.length(), "/system");
+            interfaceMap.emplace(dBusMap.interface.c_str(), propertyMap);
+            objectValueTree.emplace(std::move(objPath),
+                                    std::move(interfaceMap));
+            auto method = bus.new_method_call(
+                service.c_str(), "/xyz/openbmc_project/inventory",
+                "xyz.openbmc_project.Inventory.Manager", "Notify");
+            method.append(std::move(objectValueTree));
+            bus.call_noreply(method, dbusTimeout);
+        }
+        else
+        {
+            auto method =
+                bus.new_method_call(service.c_str(), dBusMap.objectPath.c_str(),
+                                    dbusProperties, "Set");
+            if (dBusMap.objectPath ==
+                    "/xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0" ||
+                dBusMap.objectPath ==
+                    "/xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0")
+            {
+                info(
+                    " service :{SERV} , interface : {INTF} , path : {DBUS_OBJ_PATH}",
+                    "SERV", service.c_str(), "INTF", dBusMap.interface.c_str(),
+                    "DBUS_OBJ_PATH", dBusMap.objectPath.c_str());
+            }
+            method.append(dBusMap.interface.c_str(),
+                          dBusMap.propertyName.c_str(), variant);
+            bus.call_noreply(method, dbusTimeout);
+        }
     };
 
     if (dBusMap.propertyType == "uint8_t")
@@ -330,6 +364,24 @@ void DBusHandler::setDbusProperty(const DBusMapping& dBusMap,
     else if (dBusMap.propertyType == "bool")
     {
         std::variant<bool> v = std::get<bool>(value);
+        if (dBusMap.objectPath ==
+                "/xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0" ||
+            dBusMap.objectPath ==
+                "/xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0")
+        {
+            info(" value : {VAL}", "VAL", std::get<bool>(value));
+        }
+        if (strstr(dBusMap.objectPath.c_str(), "dimm") &&
+            (dBusMap.interface ==
+             "xyz.openbmc_project.State.Decorator.OperationalStatus"))
+        {
+            if (!std::get<bool>(value))
+            {
+                error("Guard event on DIMM : [ {DBUS_OBJ_PATH} ]",
+                      "DBUS_OBJ_PATH", dBusMap.objectPath.c_str());
+            }
+        }
+
         setDbusValue(v);
     }
     else if (dBusMap.propertyType == "int16_t")

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -741,12 +741,6 @@ void HostPDRHandler::processHostPDRs(
                     pdrTerminusHandle =
                         extractTerminusHandle<pldm_state_effecter_pdr>(pdr);
                     updateContainerId<pldm_state_effecter_pdr>(entityTree, pdr);
-                    if (oemPlatformHandler)
-                    {
-                        oemPlatformHandler->modifyPDROemActions(
-                            (PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD | 0x8000),
-                            PLDM_OEM_IBM_PANEL_TRIGGER_STATE);
-                    }
                 }
                 else if (pdrHdr->type == PLDM_NUMERIC_EFFECTER_PDR)
                 {
@@ -901,6 +895,12 @@ void HostPDRHandler::processHostPDRs(
         {
             info("Host is UP & Completed the PDR Exchange with host");
             this->setHostSensorState();
+            if (oemPlatformHandler)
+            {
+                oemPlatformHandler->modifyPDROemActions(
+                    (PLDM_ENTITY_CHASSIS_FRONT_PANEL_BOARD | 0x8000),
+                    PLDM_OEM_IBM_PANEL_TRIGGER_STATE);
+            }
         }
         entityAssociations.clear();
 

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -434,14 +434,8 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                         linkSpeed[curLinkSpeed], itemPCIeDevice, "string");
 
             // set link width
-            auto& bus = pldm::utils::DBusHandler::getBus();
-            auto service = pldm::utils::DBusHandler().getService(
-                slotAndAdapter.second.c_str(), itemPCIeDevice);
-            auto method = bus.new_method_call(
-                service.c_str(), slotAndAdapter.second.c_str(),
-                "org.freedesktop.DBus.Properties", "Set");
-            method.append(itemPCIeDevice, "LanesInUse", linkWidth);
-
+            setProperty(slotAndAdapter.second, "LanesInUse",
+                        (size_t)(linkWidth), itemPCIeDevice, "uint32_t");
             std::filesystem::path adapter(slotAndAdapter.second);
 
             error(
@@ -487,13 +481,8 @@ void PCIeInfoHandler::setTopologyOnSlotAndAdapter(
                             linkSpeed[curLinkSpeed], itemPCIeDevice, "string");
 
                 // set link width
-                auto& bus = pldm::utils::DBusHandler::getBus();
-                auto service = pldm::utils::DBusHandler().getService(
-                    slotAndAdapter.second.c_str(), itemPCIeDevice);
-                auto method = bus.new_method_call(
-                    service.c_str(), slotAndAdapter.second.c_str(),
-                    "org.freedesktop.DBus.Properties", "Set");
-                method.append(itemPCIeDevice, "LanesInUse", linkWidth);
+                setProperty(slotAndAdapter.second, "LanesInUse",
+                            (size_t)(linkWidth), itemPCIeDevice, "uint32_t");
             }
 
             std::filesystem::path adapter(slotAndAdapter.second);

--- a/requester/handler.hpp
+++ b/requester/handler.hpp
@@ -223,14 +223,6 @@ class Handler
             instanceIdDb.free(key.eid, key.instanceId);
             handlers.erase(key);
         }
-        else
-        {
-            // Got a response for a PLDM request message not registered with the
-            // request handler, so freeing up the instance ID, this can be other
-            // OpenBMC applications relying on PLDM D-Bus apis like
-            // openpower-occ-control and softoff
-            instanceIdDb.free(key.eid, key.instanceId);
-        }
     }
 
   private:


### PR DESCRIPTION
#### oem-ibm: Set LinkWidth accurately over Dbus (#703)
```
Currently LinkWidth is not getting updated over Dbus.
This commit fixes the issue

Fixes: STGDefect 708131

Signed-off-by: Archana Kakani <archana.kakani@ibm.com>```
#### pldm: Core Count and DIMM Persistency (#701)
```
In the current code we use Set-Property to set the Core count.
This value is reverted to 0 post reboot as inventory manager will
only persist the data if it is set through Notify.

Changes added to persist the CPU core count and DIMM Operational
status across reboots when host is powered off.

Fixes: STGDefect 709813

Signed-off-by: Archana Kakani <archana.kakani@ibm.com>```
#### oem-ibm: Invalid pel fix (#691)
```
Phyp copies the error log data to the XDMA memory and then it sends the
`WriteFileByTypeFromMemory` to PLDM.  From PLDM side, setting the struct
AspeedXdmaOp instructs DMA controller to copy the data to bmc side.
Because of slow data copy, we have partial data in the BMC XDMA buffer.
As we have mmapped the VGA memory to the length of the Pel, we fetch the
exact length which contains partial data and remaining bytes as garbage.

To fix the issue, added a check to make sure that if the DMA data copy
is completed successfuly before copying the pel data to temporary file.

Also added a fix to avoid freeing instance IDs acquired by other apps.
And also sending the panel bitmap request only once to panel app

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=678010

Signed-off-by: Archana Kakani <archana.kakani@ibm.com>```