### PR TITLE
oem-ibm: Add support for targeted ACF file

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -751,6 +751,7 @@ class Handler : public CmdHandler
                 msg.read(path, interfaces);
                 std::string vspstring;
                 std::string userchallenge;
+                std::string acfFile;
 
                 for (const auto& interface : interfaces)
                 {
@@ -768,6 +769,11 @@ class Handler : public CmdHandler
                                 userchallenge =
                                     std::get<std::string>(property.second);
                             }
+                            else if (property.first == "AcfFile")
+                            {
+                                acfFile =
+                                    std::get<std::string>(property.second);
+                            }
                         }
                         dbusToFileHandlers
                             .emplace_back(
@@ -775,7 +781,8 @@ class Handler : public CmdHandler
                                                      DbusToFileHandler>(
                                     hostSockFd, hostEid, instanceIdDb, path,
                                     handler))
-                            ->processNewResourceDump(vspstring, userchallenge);
+                            ->processNewResourceDump(vspstring, userchallenge,
+                                                     acfFile);
                         break;
                     }
                     if (interface.first == sysDumpEntry)

--- a/oem/ibm/requester/dbus_to_file_handler.cpp
+++ b/oem/ibm/requester/dbus_to_file_handler.cpp
@@ -119,7 +119,8 @@ void DbusToFileHandler::reportResourceDumpFailure(const std::string_view& str)
 }
 
 void DbusToFileHandler::processNewResourceDump(
-    const std::string& vspString, const std::string& resDumpReqPass)
+    const std::string& vspString, const std::string& resDumpReqPass,
+    const std::string& acfFilePath)
 {
     try
     {
@@ -193,9 +194,9 @@ void DbusToFileHandler::processNewResourceDump(
     fileFunc(resDumpReqPass);
 
     std::string str;
-    if (!resDumpReqPass.empty())
+    if (vspString != "system")
     {
-        str = getAcfFileContent();
+        str = getAcfFileContent(acfFilePath);
     }
 
     fileFunc(str);
@@ -206,10 +207,14 @@ void DbusToFileHandler::processNewResourceDump(
     sendNewFileAvailableCmd(fileSize);
 }
 
-std::string DbusToFileHandler::getAcfFileContent()
+std::string DbusToFileHandler::getAcfFileContent(const std::string& acfPath)
 {
     std::string str;
-    static constexpr auto acfDirPath = "/etc/acf/service.acf";
+    const std::string& acfDirPath =
+        acfPath.empty() ? "/etc/acf/service.acf" : acfPath;
+
+    info("Using acf file : {ACF_FILE_PATH}", "ACF_FILE_PATH", acfDirPath);
+
     if (fs::exists(acfDirPath))
     {
         std::ifstream file;

--- a/oem/ibm/requester/dbus_to_file_handler.hpp
+++ b/oem/ibm/requester/dbus_to_file_handler.hpp
@@ -48,9 +48,11 @@ class DbusToFileHandler
     /** @brief Process the new resource dump request
      *  @param[in] vspString - vsp string
      *  @param[in] resDumpReqPass - resource dump password
+     *  @param[in] acfFilePath - ACF file path
      */
     void processNewResourceDump(const std::string& vspString,
-                                const std::string& resDumpReqPass);
+                                const std::string& resDumpReqPass,
+                                const std::string& acfFilePath = "");
 
     /** @brief Process the new CSR file available
      *  @param[in] csr - CSR string
@@ -106,8 +108,10 @@ class DbusToFileHandler
      */
     void reportResourceDumpFailure(const std::string_view& str);
 
-    /** @brief method to get the acf file contents */
-    std::string getAcfFileContent();
+    /** @brief method to get the acf file contents
+     * @param[in] acfDirPath ACF file path
+     */
+    std::string getAcfFileContent(const std::string& acfDirPath);
 
     /** @brief MCTP EID of host firmware */
     uint8_t mctp_eid;


### PR DESCRIPTION
This commit introduces support for specifying a targeted ACF (Access Control File) for resource dumps. The ACF file path and name are passed to PLDM via the D-Bus property "AcfFile". This property is populated when the CreateDump method of the dump manager is invoked. The specified ACF file is then used for the resource dump, while the existing resource dump workflow remains unchanged.