### PR TITLE
oem-ibm: NVRAM service file changes

### DIFF
--- a/oem/ibm/service_files/pldm-create-phyp-nvram.service
+++ b/oem/ibm/service_files/pldm-create-phyp-nvram.service
@@ -6,7 +6,7 @@ Wants=obmc-flash-bios-init.service
 After=obmc-flash-bios-init.service
 
 [Service]
-ExecStart=/bin/sh -c "if [ -f /var/lib/pldm/PHYP-NVRAM ]; then mv /var/lib/pldm/PHYP-NVRAM /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; else truncate -s $((1024 * 145408)) /var/lib/phosphor-software-manager/hostfw/nvram/PHYP-NVRAM; fi"
+ExecStart=/usr/bin/create-NVRAM-file
 Type=oneshot
 RemainAfterExit=no
 


### PR DESCRIPTION
The condition check removal in PR #696 caused us to create the NVRAM file always with zeroes as the call was not going to the updated script written in PR #696. This commit fixes it.

Fixes: Defect 721932

Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>