### PR TITLE
1110: bios: Add a debug log trace in setDateTime command (#708)

### DIFF
--- a/libpldmresponder/bios.cpp
+++ b/libpldmresponder/bios.cpp
@@ -169,6 +169,11 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
         "xyz.openbmc_project.Time.Synchronization";
     constexpr auto timeSyncProperty = "TimeSyncMethod";
 
+    info("Got a setDateTime command from host to configure the BMC time");
+
+    info("Current BMC time: {TIME}", "TIME",
+         pldm::utils::getCurrentSystemTime());
+
     // The time is correct on BMC when in NTP mode, so we do not want to
     // try and set the time again and cause potential time drifts.
     try
@@ -179,6 +184,7 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
 
         if (mode == "xyz.openbmc_project.Time.Synchronization.Method.NTP")
         {
+            error("Mode in which the system is: {MODE}", "MODE", mode);
             return ccOnlyResponse(request, PLDM_SUCCESS);
         }
     }
@@ -206,6 +212,12 @@ Response Handler::setDateTime(const pldm_msg* request, size_t payloadLength)
                             std::chrono::seconds(timeSec))
                             .count();
     PropertyValue value{timeUsec};
+
+    info(
+        "The time set is : epoch={EPOCH} sec, usec={USEC} ({HR}:{MIN}:{SEC} {DAY}/{MON}/{YR})",
+        "EPOCH", timeSec, "USEC", timeUsec, "HR", hours, "MIN", minutes, "SEC",
+        seconds, "DAY", day, "MON", month, "YR", year);
+
     try
     {
         DBusMapping dbusMapping{setTimePath, setTimeInterface, timeSetPro,


### PR DESCRIPTION
#### bios: Add a debug log trace in setDateTime command (#708)
```
When a Time Reference Partition (TRP) is configured on the LPAR,
PHYP sends down the SetDateTime command to BMC inorder to set the
same time on the BMC. There was a debug trace in our code that
told BMC that the command is sent down from PHYP.

Adding the debug trace back in the code because it would be
helpful for BMC to understand if we ever got the setDateTime
command from PHYP when the TRP was set.

Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>```