### PR TITLE
oem-ibm: Additional changes for TACF feature

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.hpp
+++ b/oem/ibm/libpldmresponder/file_io.hpp
@@ -774,7 +774,7 @@ class Handler : public CmdHandler
                                 userchallenge =
                                     std::get<std::string>(property.second);
                             }
-                            else if (property.first == "AcfFile")
+                            else if (property.first == "ACFPath")
                             {
                                 acfFile =
                                     std::get<std::string>(property.second);

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -717,6 +717,41 @@ int DumpHandler::fileAckWithMetaData(
         {
             fs::remove_all(resDumpRequestDirPath);
         }
+
+        try
+        {
+            const std::string objectPath =
+                std::string(dumpEntryObjPath) + "/" + idStr;
+
+            std::string acfPath =
+                pldm::utils::DBusHandler().getDbusProperty<std::string>(
+                    objectPath.c_str(), "ACFPath", resDumpEntry);
+
+            if (!fs::exists(acfPath))
+            {
+                error("ACF file not found: '{ACF_FILE}'", "ACF_FILE", acfPath);
+            }
+            else
+            {
+                std::error_code ec;
+                if (!fs::remove(acfPath, ec))
+                {
+                    error("Failed to delete ACF file '{ACF_FILE}': {ERROR}",
+                          "ACF_FILE", acfPath, "ERROR", ec.message());
+                }
+                else
+                {
+                    info("Successfully deleted ACF file - {ACF_FILE}",
+                         "ACF_FILE", acfPath);
+                }
+            }
+        }
+        catch (const sdbusplus::exception_t& e)
+        {
+            error(
+                "Failed to get ACFPath property for resource dump entry: {ERROR}",
+                "ERROR", e);
+        }
         return PLDM_SUCCESS;
     }
 


### PR DESCRIPTION
- Change targeted ACF dbus property name to 'ACFPath'. [(PR link)](https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/181/commits/0e1a69af6d6245e234b061850799fbb4e729c893)

- Delete the target ACF from filesystem after getting response from PHYP.