### PR TITLE
Build file table lazily

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -3,6 +3,7 @@
 #include "collect_slot_vpd.hpp"
 #include "common/types.hpp"
 #include "common/utils.hpp"
+#include "file_table.hpp"
 #include "inband_code_update.hpp"
 #include "libpldmresponder/oem_handler.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
@@ -176,11 +177,18 @@ class Handler : public oem_platform::Handler
                         hostOff = false;
                         hostTransitioningToOff = false;
                     }
-                    else if (
-                        propVal ==
-                        "xyz.openbmc_project.State.Host.HostState.TransitioningToOff")
+                    else if (propVal ==
+                             "xyz.openbmc_project.State.Host.HostState.TransitioningToOff")
                     {
                         hostTransitioningToOff = true;
+                    }
+                    else if (propVal ==
+                             "xyz.openbmc_project.State.Host.HostState.TransitioningToRunning")
+                    {
+                        using namespace pldm::filetable;
+                        auto& fileTable=buildFileTable(FILE_TABLE_JSON);
+                        fileTable.clear();
+                        fileTable=buildFileTable(FILE_TABLE_JSON);
                     }
                 }
             });


### PR DESCRIPTION
Solves an issue where when lid files are patched on host poweroff, filetable is not updated unless pldmd is restarted resulting in file transfer of wrong size Here filetable is built before hostboot