### PR TITLE
Build file table lazily

### DIFF
--- a/oem/ibm/libpldmresponder/file_table.cpp
+++ b/oem/ibm/libpldmresponder/file_table.cpp
@@ -129,14 +129,21 @@ Table FileTable::operator()() const
     return table;
 }
 
+/** Single instance of filetable*/
+static FileTable fileTable;
+
 FileTable& buildFileTable(const std::string& fileTablePath)
 {
-    static FileTable table;
-    if (table.isEmpty())
+    if (fileTable.isEmpty())
     {
-        table = FileTable(fileTablePath);
+        fileTable = FileTable(fileTablePath);
     }
-    return table;
+    return fileTable;
+}
+
+void clearFileTable()
+{
+    fileTable.clear();
 }
 
 } // namespace filetable

--- a/oem/ibm/libpldmresponder/file_table.hpp
+++ b/oem/ibm/libpldmresponder/file_table.hpp
@@ -121,5 +121,7 @@ class FileTable
 
 FileTable& buildFileTable(const std::string& fileTablePath);
 
+/** @brief Clear the file table instance */
+void clearFileTable();
 } // namespace filetable
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -3,6 +3,7 @@
 #include "collect_slot_vpd.hpp"
 #include "common/types.hpp"
 #include "common/utils.hpp"
+#include "file_table.hpp"
 #include "inband_code_update.hpp"
 #include "libpldmresponder/oem_handler.hpp"
 #include "libpldmresponder/pdr_utils.hpp"
@@ -169,6 +170,7 @@ class Handler : public oem_platform::Handler
                         disableWatchDogTimer();
                         startStopTimer(false);
                         pldm::responder::utils::clearLicenseStatus();
+                        pldm::filetable::clearFileTable();
                     }
                     else if (propVal ==
                              "xyz.openbmc_project.State.Host.HostState.Running")


### PR DESCRIPTION
Support for HB lid files patching
Solves an issue where when lid files are patched on host poweroff, filetable is not updated unless pldmd is restarted resulting in file transfer of wrong size Here filetable is built before hostboot