### PR TITLE
1110: Clear PCIeSlot DBus Object LinkId/BusId property on topology refresh (#724)

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.cpp
@@ -212,6 +212,10 @@ int PCIeInfoHandler::fileAck(uint8_t /*fileStatus*/)
                 }
                 cables.clear();
 
+                // clears busids on all objects because only active links are
+                // updated by setTopologyAttrsOnDbus()
+                refreshAllPcieSlotBusIds();
+
                 // set topology properties & host cable dbus objects
                 setTopologyAttrsOnDbus();
                 // even when we fail to parse /set the topology infromation on
@@ -1214,6 +1218,51 @@ void PCIeInfoHandler::deleteTopologyFiles()
             error("Topology file deletion failed {PCIE_PATH} : {ERR_EXCEP}",
                   "PCIE_PATH", pciePath, "ERR_EXCEP", err.what());
         }
+    }
+}
+
+void PCIeInfoHandler::refreshAllPcieSlotBusIds()
+{
+    // Only setting BusIDs/LinkIDs to 0 for objects
+    // hosted by Inventory Manager
+    constexpr auto basePath =
+        "/xyz/openbmc_project/inventory/system/chassis/motherboard";
+    constexpr auto property = "BusId";
+    constexpr auto dbusProperties = "org.freedesktop.DBus.Properties";
+
+    try
+    {
+        auto& bus = pldm::utils::DBusHandler::getBus();
+        auto subTree =
+            pldm::utils::DBusHandler().getSubtree(basePath, 0, {itemPCIeSlot});
+
+        for (const auto& [objectPath, serviceMap] : subTree)
+        {
+            for (const auto& [service, interfaces] : serviceMap)
+            {
+                try
+                {
+                    auto method =
+                        bus.new_method_call(service.c_str(), objectPath.c_str(),
+                                            dbusProperties, "Set");
+                    uint32_t newBusIdValue = 0;
+                    std::variant<uint32_t> value =
+                        static_cast<uint32_t>(newBusIdValue);
+                    method.append(itemPCIeSlot, property, value);
+                    bus.call_noreply(method, dbusTimeout);
+                }
+                catch (const std::exception& e)
+                {
+                    error(
+                        "Error clearing BusId for {OBJPATH} from {SERVICE}: {ERROR}",
+                        "OBJPATH", objectPath, "SERVICE", service, "ERROR", e);
+                }
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        error("Failed to refresh PCIeSlot BusIds: {ERR}", "ERR", e);
     }
 }
 

--- a/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_pcie.hpp
@@ -324,6 +324,12 @@ class PCIeInfoHandler : public FileHandler
     static std::unordered_map<uint16_t, bool> receivedFiles;
 
     void deleteTopologyFiles();
+
+    /** @brief Sets bus IDs to 0 on all DBus Objects
+     *
+     *  @param[return] void
+     */
+    void refreshAllPcieSlotBusIds();
 };
 
 } // namespace responder


### PR DESCRIPTION
#### Clear PCIeSlot DBus Object LinkId/BusId property on topology refresh (#724)
```
This commit adds a function to clear BusId/LinkId
on DBus Objects which implement the PCIeSlot
interface, whenever a refresh for PCIe topology is
requested from GUI, ensuring stale links
are not seen on GUI

Tested for Host USB Enablement usecase where USB
will no longer show in PCIe topology on GUI if disabled

Signed-off-by: Rahul D S <rahulds.rahul@gmail.com>
```