### PR TITLE
host-bmc: Fix missing PCIeSlot interface

### DIFF
--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1678,6 +1678,12 @@ void HostPDRHandler::createDbusObjects()
                 CustomDBus::getCustomDBus().implementMotherboardInterface(
                     entity.first);
                 break;
+            case PLDM_ENTITY_SLOT:
+                CustomDBus::getCustomDBus().implementPCIeSlotInterface(
+                    entity.first);
+                CustomDBus::getCustomDBus().setLinkReset(
+                    entity.first, false, hostEffecterParser, mctp_eid);
+                break;
             case PLDM_ENTITY_CONNECTOR:
                 CustomDBus::getCustomDBus().implementConnecterInterface(
                     entity.first);


### PR DESCRIPTION
Adding PLDM_ENTITY_SLOT entity type to support
hosting dbus PCIeSlot interface in 1120.

Fixes Defect 742527