### PR TITLE
1210: meson: fixed the configurations for dbus-config.json (#736)

### DIFF
--- a/configurations/meson.build
+++ b/configurations/meson.build
@@ -37,6 +37,10 @@ if get_option('oem-ibm').allowed()
         '../oem/ibm/configurations/host_eid',
         install_dir: package_datadir,
     )
+    install_data(
+        '../oem/ibm/configurations/dbus-config.json',
+        install_dir: get_option('datadir') / 'pldm',
+    )
     install_symlink(
         'com.ibm.Hardware.Chassis.Model.Balcones',
         pointing_to: 'com.ibm.Hardware.Chassis.Model.Bonnell',


### PR DESCRIPTION
#### meson: fixed the configurations for dbus-config.json (#736)
```
Fixed the issue for not creating cores under PLDM

Signed-off-by: RameshaR45 <ramesharohit45@gmail.com>```