### PR TITLE
Fix platform-mc terminus error traces

### DIFF
--- a/platform-mc/manager.hpp
+++ b/platform-mc/manager.hpp
@@ -147,9 +147,12 @@ class Manager : public pldm::MctpDiscoveryHandlerIntf
         auto eventData = reinterpret_cast<const uint8_t*>(request->payload) +
                          eventDataOffset;
         auto eventDataSize = payloadLength - eventDataOffset;
-        eventManager.handlePlatformEvent(tid, PLDM_PLATFORM_EVENT_ID_NULL,
-                                         PLDM_SENSOR_EVENT, eventData,
-                                         eventDataSize);
+        if (!termini.empty())
+        {
+            eventManager.handlePlatformEvent(tid, PLDM_PLATFORM_EVENT_ID_NULL,
+                                             PLDM_SENSOR_EVENT, eventData,
+                                             eventDataSize);
+        }
         return PLDM_SUCCESS;
     }
 


### PR DESCRIPTION
Adds check in platform-mc sensor event handling to ensure that the discovered terminus list is non
empty. This fix reduces the error traces for
undiscovered termini sensor event handling as these events are handled elsewhere