### PR TITLE
Inband Code Update fix

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1428,6 +1428,9 @@ void pldm::responder::oem_ibm_platform::Handler::_processEndUpdate(
     assembleImageEvent.reset();
     info("Starting assembleCodeUpdateImage");
     int retc = codeUpdate->assembleCodeUpdateImage();
+    // Staging directory is being cleared as part of End Update because ibm-i
+    // may not reboot the BMC
+    codeUpdate->clearDirPath(LID_STAGING_DIR);
     if (retc != PLDM_SUCCESS)
     {
         codeUpdate->setCodeUpdateProgress(false);


### PR DESCRIPTION
Currently staging directory is removed only two times
1. During starting PLDM
2. After receiving the Code update abort from phyp.

Multiple code updates in a row is a IBMi only usecase. Current code update is failing with the image signature validation failed after 2nd code update.

To support multiple code updates in a row, removing the staging directory just before sending the success/failure sensor event for end code update to phyp.

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=757992