### PR TITLE
oem-ibm: Clear the staging directory in inband codeupdate flow

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.cpp
@@ -1428,6 +1428,7 @@ void pldm::responder::oem_ibm_platform::Handler::_processEndUpdate(
     assembleImageEvent.reset();
     info("Starting assembleCodeUpdateImage");
     int retc = codeUpdate->assembleCodeUpdateImage();
+    codeUpdate->clearDirPath(LID_STAGING_DIR);
     if (retc != PLDM_SUCCESS)
     {
         codeUpdate->setCodeUpdateProgress(false);


### PR DESCRIPTION
Currently staging directory is removed only two times
1. During starting PLDM
2. After receiving the Code update abort from phyp.

Without cleaning up the staging directory, the 2nd update will start trying to repackage the same lid files and eventually fail with a signature error.
Multiple code updates in a row is a IBMi only usecase.

To support multiple code updates in a row, removing the staging directory just before sending the sensor event for end code update to phyp.

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=757992