### PR TITLE
1210: Fixed The Issue of Not Listing MEX CHASSIS after Restart PLDM (#745)

### DIFF
--- a/host-bmc/dbus/asset.hpp
+++ b/host-bmc/dbus/asset.hpp
@@ -14,14 +14,13 @@ namespace pldm
 namespace dbus
 {
 
-using ItemAsset = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Asset>;
+using ItemAsset =
+    sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Asset;
 
 class Asset : public ItemAsset
 {
   public:
     Asset() = delete;
-    ~Asset() = default;
     Asset(const Asset&) = delete;
     Asset& operator=(const Asset&) = delete;
     Asset(Asset&&) = delete;
@@ -30,7 +29,11 @@ class Asset : public ItemAsset
     Asset(sdbusplus::bus_t& bus, const std::string& objPath) :
         ItemAsset(bus, objPath.c_str())
     {
-        // no need to save this in pldm memory
+        emit_added();
+    }
+    ~Asset()
+    {
+        emit_removed();
     }
 
     /** Set Part Number */

--- a/host-bmc/dbus/associations.hpp
+++ b/host-bmc/dbus/associations.hpp
@@ -22,7 +22,6 @@ class Associations : public AssociationsIntf
 {
   public:
     Associations() = delete;
-    ~Associations() = default;
     Associations(const Associations&) = delete;
     Associations& operator=(const Associations&) = delete;
     Associations(Associations&&) = delete;
@@ -31,7 +30,13 @@ class Associations : public AssociationsIntf
     Associations(sdbusplus::bus_t& bus, const std::string& objPath,
                  const std::map<std::string, PropertiesVariant>& vals) :
         AssociationsIntf(bus, objPath.c_str(), vals), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~Associations()
+    {
+        emit_removed();
+    }
 
     /** Get value of Associations */
     AssociationsObj associations() const override;

--- a/host-bmc/dbus/availability.hpp
+++ b/host-bmc/dbus/availability.hpp
@@ -11,14 +11,13 @@ namespace pldm
 {
 namespace dbus
 {
-using AvailabilityIntf = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::State::Decorator::server::Availability>;
+using AvailabilityIntf =
+    sdbusplus::xyz::openbmc_project::State::Decorator::server::Availability;
 
 class Availability : public AvailabilityIntf
 {
   public:
     Availability() = delete;
-    ~Availability() = default;
     Availability(const Availability&) = delete;
     Availability& operator=(const Availability&) = delete;
     Availability(Availability&&) = delete;
@@ -26,7 +25,13 @@ class Availability : public AvailabilityIntf
 
     Availability(sdbusplus::bus_t& bus, const std::string& objPath) :
         AvailabilityIntf(bus, objPath.c_str()), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~Availability()
+    {
+        emit_removed();
+    }
 
     /** Get value of Available */
     bool available() const override;

--- a/host-bmc/dbus/board.hpp
+++ b/host-bmc/dbus/board.hpp
@@ -13,14 +13,13 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemBoard = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Board>;
+using ItemBoard =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Board;
 
 class Board : public ItemBoard
 {
   public:
     Board() = delete;
-    ~Board() = default;
     Board(const Board&) = delete;
     Board& operator=(const Board&) = delete;
     Board(Board&&) = delete;
@@ -30,6 +29,11 @@ class Board : public ItemBoard
         ItemBoard(bus, objPath.c_str())
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath, "Board");
+        emit_added();
+    }
+    ~Board()
+    {
+        emit_removed();
     }
 };
 

--- a/host-bmc/dbus/cable.hpp
+++ b/host-bmc/dbus/cable.hpp
@@ -12,8 +12,8 @@ namespace pldm
 namespace dbus
 {
 
-using ItemCable = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Cable>;
+using ItemCable =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Cable;
 
 /**
  * @class Cable
@@ -23,7 +23,6 @@ class Cable : public ItemCable
 {
   public:
     Cable() = delete;
-    ~Cable() = default;
     Cable(const Cable&) = delete;
     Cable& operator=(const Cable&) = delete;
 
@@ -31,6 +30,11 @@ class Cable : public ItemCable
         ItemCable(bus, objPath.c_str())
     {
         // cable objects does not need to be store in serialized memory
+        emit_added();
+    }
+    ~Cable()
+    {
+        emit_removed();
     }
 
     /** Get length of the cable in meters */

--- a/host-bmc/dbus/chapdata.hpp
+++ b/host-bmc/dbus/chapdata.hpp
@@ -13,8 +13,7 @@ namespace pldm
 {
 namespace dbus
 {
-using ChapDataObj =
-    sdbusplus::server::object_t<sdbusplus::com::ibm::PLDM::server::ChapData>;
+using ChapDataObj = sdbusplus::com::ibm::PLDM::server::ChapData;
 
 /** @brief Hosting chapdata properties
  *
@@ -26,7 +25,6 @@ class ChapDatas : public ChapDataObj
 {
   public:
     ChapDatas() = delete;
-    ~ChapDatas() = default;
     ChapDatas(const ChapDatas&) = delete;
     ChapDatas& operator=(const ChapDatas&) = delete;
     ChapDatas(ChapDatas&&) = delete;
@@ -36,7 +34,13 @@ class ChapDatas : public ChapDataObj
               pldm::responder::oem_fileio::Handler* dbusToFilehandlerObj) :
         ChapDataObj(bus, objPath.c_str()),
         dbusToFilehandler(dbusToFilehandlerObj), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~ChapDatas()
+    {
+        emit_removed();
+    }
 
     std::string chapName(std::string value) override;
 

--- a/host-bmc/dbus/chassis.hpp
+++ b/host-bmc/dbus/chassis.hpp
@@ -13,14 +13,13 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemChassisIntf = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Chassis>;
+using ItemChassisIntf =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Chassis;
 
 class ItemChassis : public ItemChassisIntf
 {
   public:
     ItemChassis() = delete;
-    ~ItemChassis() = default;
     ItemChassis(const ItemChassis&) = delete;
     ItemChassis& operator=(const ItemChassis&) = delete;
     ItemChassis(ItemChassis&&) = delete;
@@ -31,6 +30,11 @@ class ItemChassis : public ItemChassisIntf
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath,
                                                              "ItemChassis");
+        emit_added();
+    }
+    ~ItemChassis()
+    {
+        emit_removed();
     }
 
     /** Get value of Type */

--- a/host-bmc/dbus/connector.hpp
+++ b/host-bmc/dbus/connector.hpp
@@ -13,14 +13,13 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemConnector = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Connector>;
+using ItemConnector =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Connector;
 
 class Connector : public ItemConnector
 {
   public:
     Connector() = delete;
-    ~Connector() = default;
     Connector(const Connector&) = delete;
     Connector& operator=(const Connector&) = delete;
     Connector(Connector&&) = delete;
@@ -31,6 +30,11 @@ class Connector : public ItemConnector
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath,
                                                              "Connector");
+        emit_added();
+    }
+    ~Connector()
+    {
+        emit_removed();
     }
 };
 

--- a/host-bmc/dbus/cpu_core.hpp
+++ b/host-bmc/dbus/cpu_core.hpp
@@ -13,8 +13,8 @@ namespace pldm
 {
 namespace dbus
 {
-using CoreIntf = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::CpuCore>;
+using CoreIntf =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::CpuCore;
 
 /** @class CPUCore
  *  @brief This class is mapped to CPUCore properties in D-Bus interface path
@@ -24,7 +24,6 @@ class CPUCore : public CoreIntf
 {
   public:
     CPUCore() = delete;
-    ~CPUCore() = default;
     CPUCore(const CPUCore&) = delete;
     CPUCore& operator=(const CPUCore&) = delete;
     CPUCore(CPUCore&&) = delete;
@@ -34,6 +33,11 @@ class CPUCore : public CoreIntf
         CoreIntf(bus, objPath.c_str()), path(objPath)
     {
         pldm::serialize::Serialize::getSerialize().serialize(path, "CPUCore");
+        emit_added();
+    }
+    ~CPUCore()
+    {
+        emit_removed();
     }
 
     /** Get value of Microcode */

--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -598,6 +598,11 @@ void CustomDBus::deleteObject(const std::string& path)
     {
         panel.erase(panel.find(path));
     }
+
+    if (link.contains(path))
+    {
+        link.erase(link.find(path));
+    }
 }
 
 void CustomDBus::removeDBus(const std::vector<uint16_t> types)

--- a/host-bmc/dbus/decorator_revision.hpp
+++ b/host-bmc/dbus/decorator_revision.hpp
@@ -11,14 +11,13 @@ namespace pldm
 {
 namespace dbus
 {
-using DecoratorRevisionIntf = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Revision>;
+using DecoratorRevisionIntf =
+    sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Revision;
 
 class DecoratorRevision : public DecoratorRevisionIntf
 {
   public:
     DecoratorRevision() = delete;
-    ~DecoratorRevision() = default;
     DecoratorRevision(const DecoratorRevision&) = delete;
     DecoratorRevision& operator=(const DecoratorRevision&) = delete;
     DecoratorRevision(DecoratorRevision&&) = delete;
@@ -26,7 +25,13 @@ class DecoratorRevision : public DecoratorRevisionIntf
 
     DecoratorRevision(sdbusplus::bus_t& bus, const std::string& objPath) :
         DecoratorRevisionIntf(bus, objPath.c_str()), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~DecoratorRevision()
+    {
+        emit_removed();
+    }
 
     /** Get value of Version */
     std::string version() const override;

--- a/host-bmc/dbus/enable.hpp
+++ b/host-bmc/dbus/enable.hpp
@@ -13,20 +13,24 @@ namespace pldm
 {
 namespace dbus
 {
-using EnableIface = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Object::server::Enable>;
+using EnableIface = sdbusplus::xyz::openbmc_project::Object::server::Enable;
 
 class Enable : public EnableIface
 {
   public:
     Enable() = delete;
-    ~Enable() = default;
     Enable(const Enable&) = delete;
     Enable& operator=(const Enable&) = delete;
 
     Enable(sdbusplus::bus_t& bus, const std::string& objPath) :
         EnableIface(bus, objPath.c_str()), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~Enable()
+    {
+        emit_removed();
+    }
 
     /** Get value of Enabled */
     bool enabled() const override;

--- a/host-bmc/dbus/fabric_adapter.hpp
+++ b/host-bmc/dbus/fabric_adapter.hpp
@@ -13,14 +13,13 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemFabricAdapter = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::FabricAdapter>;
+using ItemFabricAdapter =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::FabricAdapter;
 
 class FabricAdapter : public ItemFabricAdapter
 {
   public:
     FabricAdapter() = delete;
-    ~FabricAdapter() = default;
     FabricAdapter(const FabricAdapter&) = delete;
     FabricAdapter& operator=(const FabricAdapter&) = delete;
     FabricAdapter(FabricAdapter&&) = delete;
@@ -31,6 +30,11 @@ class FabricAdapter : public ItemFabricAdapter
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath,
                                                              "FabricAdapter");
+        emit_added();
+    }
+    ~FabricAdapter()
+    {
+        emit_removed();
     }
 };
 

--- a/host-bmc/dbus/fan.hpp
+++ b/host-bmc/dbus/fan.hpp
@@ -13,14 +13,12 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemFan = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Fan>;
+using ItemFan = sdbusplus::xyz::openbmc_project::Inventory::Item::server::Fan;
 
 class Fan : public ItemFan
 {
   public:
     Fan() = delete;
-    ~Fan() = default;
     Fan(const Fan&) = delete;
     Fan& operator=(const Fan&) = delete;
     Fan(Fan&&) = delete;
@@ -30,6 +28,11 @@ class Fan : public ItemFan
         ItemFan(bus, objPath.c_str())
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath, "Fan");
+        emit_added();
+    }
+    ~Fan()
+    {
+        emit_removed();
     }
 };
 

--- a/host-bmc/dbus/global.hpp
+++ b/host-bmc/dbus/global.hpp
@@ -13,14 +13,13 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemGlobal = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Global>;
+using ItemGlobal =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Global;
 
 class Global : public ItemGlobal
 {
   public:
     Global() = delete;
-    ~Global() = default;
     Global(const Global&) = delete;
     Global& operator=(const Global&) = delete;
     Global(Global&&) = delete;
@@ -30,6 +29,11 @@ class Global : public ItemGlobal
         ItemGlobal(bus, objPath.c_str())
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath, "Global");
+        emit_added();
+    }
+    ~Global()
+    {
+        emit_removed();
     }
 };
 

--- a/host-bmc/dbus/inventory_item.hpp
+++ b/host-bmc/dbus/inventory_item.hpp
@@ -11,14 +11,12 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemIntf = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::server::Item>;
+using ItemIntf = sdbusplus::xyz::openbmc_project::Inventory::server::Item;
 
 class InventoryItem : public ItemIntf
 {
   public:
     InventoryItem() = delete;
-    ~InventoryItem() = default;
     InventoryItem(const InventoryItem&) = delete;
     InventoryItem& operator=(const InventoryItem&) = delete;
     InventoryItem(InventoryItem&&) = delete;
@@ -26,7 +24,13 @@ class InventoryItem : public ItemIntf
 
     InventoryItem(sdbusplus::bus_t& bus, const std::string& objPath) :
         ItemIntf(bus, objPath.c_str()), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~InventoryItem()
+    {
+        emit_removed();
+    }
 
     /** Get value of PrettyName */
     std::string prettyName() const override;

--- a/host-bmc/dbus/led_group.hpp
+++ b/host-bmc/dbus/led_group.hpp
@@ -16,14 +16,12 @@ namespace pldm
 {
 namespace dbus
 {
-using AssertedIntf = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Led::server::Group>;
+using AssertedIntf = sdbusplus::xyz::openbmc_project::Led::server::Group;
 
 class LEDGroup : public AssertedIntf
 {
   public:
     LEDGroup() = delete;
-    ~LEDGroup() = default;
     LEDGroup(const LEDGroup&) = delete;
     LEDGroup& operator=(const LEDGroup&) = delete;
     LEDGroup(LEDGroup&&) = delete;
@@ -32,12 +30,15 @@ class LEDGroup : public AssertedIntf
     LEDGroup(sdbusplus::bus_t& bus, const std::string& objPath,
              pldm::host_effecters::HostEffecterParser* hostEffecterParser,
              const pldm_entity entity, uint8_t mctpEid) :
-        AssertedIntf(bus, objPath.c_str(), AssertedIntf::action::defer_emit),
+        AssertedIntf(bus, objPath.c_str()),
         hostEffecterParser(hostEffecterParser), entity(entity),
         mctpEid(mctpEid), objectPath(objPath)
     {
-        // Emit deferred signal.
-        emit_object_added();
+        emit_added();
+    }
+    ~LEDGroup()
+    {
+        emit_removed();
     }
 
     /** @brief Property SET Override function

--- a/host-bmc/dbus/license_entry.hpp
+++ b/host-bmc/dbus/license_entry.hpp
@@ -11,14 +11,12 @@ namespace pldm
 {
 namespace dbus
 {
-using LicIntf = sdbusplus::server::object_t<
-    sdbusplus::com::ibm::License::Entry::server::LicenseEntry>;
+using LicIntf = sdbusplus::com::ibm::License::Entry::server::LicenseEntry;
 
 class LicenseEntry : public LicIntf
 {
   public:
     LicenseEntry() = delete;
-    ~LicenseEntry() = default;
     LicenseEntry(const LicenseEntry&) = delete;
     LicenseEntry& operator=(const LicenseEntry&) = delete;
     LicenseEntry(LicenseEntry&&) = delete;
@@ -26,7 +24,13 @@ class LicenseEntry : public LicIntf
 
     LicenseEntry(sdbusplus::bus_t& bus, const std::string& objPath) :
         LicIntf(bus, objPath.c_str()), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~LicenseEntry()
+    {
+        emit_removed();
+    }
 
     /** Get value of Name */
     std::string name() const override;

--- a/host-bmc/dbus/linkreset.hpp
+++ b/host-bmc/dbus/linkreset.hpp
@@ -17,14 +17,12 @@ namespace pldm
 {
 namespace dbus
 {
-using Itemlink = sdbusplus::server::object_t<
-    sdbusplus::com::ibm::Control::Host::server::PCIeLink>;
+using Itemlink = sdbusplus::com::ibm::Control::Host::server::PCIeLink;
 
 class Link : public Itemlink
 {
   public:
     Link() = delete;
-    ~Link() = default;
     Link(const Link&) = delete;
     Link& operator=(const Link&) = delete;
     Link(Link&&) = delete;
@@ -36,7 +34,11 @@ class Link : public Itemlink
         Itemlink(bus, objPath.c_str()), path(objPath),
         hostEffecterParser(hostEffecterParser), mctpEid(mctpEid)
     {
-        // no need to save this in pldm memory
+        emit_added();
+    }
+    ~Link()
+    {
+        emit_removed();
     }
     /** set link reset */
     bool linkReset(bool value) override;

--- a/host-bmc/dbus/location_code.hpp
+++ b/host-bmc/dbus/location_code.hpp
@@ -12,14 +12,12 @@ namespace pldm
 namespace dbus
 {
 using LocationIntf =
-    sdbusplus::server::object_t<sdbusplus::xyz::openbmc_project::Inventory::
-                                    Decorator::server::LocationCode>;
+    sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::LocationCode;
 
 class LocationCode : public LocationIntf
 {
   public:
     LocationCode() = delete;
-    ~LocationCode() = default;
     LocationCode(const LocationCode&) = delete;
     LocationCode& operator=(const LocationCode&) = delete;
     LocationCode(LocationCode&&) = delete;
@@ -27,7 +25,13 @@ class LocationCode : public LocationIntf
 
     LocationCode(sdbusplus::bus_t& bus, const std::string& objPath) :
         LocationIntf(bus, objPath.c_str()), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~LocationCode()
+    {
+        emit_removed();
+    }
 
     /** Get value of LocationCode */
     std::string locationCode() const override;

--- a/host-bmc/dbus/motherboard.hpp
+++ b/host-bmc/dbus/motherboard.hpp
@@ -13,9 +13,8 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemMotherboard =
-    sdbusplus::server::object_t<sdbusplus::xyz::openbmc_project::Inventory::
-                                    Item::Board::server::Motherboard>;
+using ItemMotherboard = sdbusplus::xyz::openbmc_project::Inventory::Item::
+    Board::server::Motherboard;
 
 /** @class Motherboard
  *  @brief This class is mapped to Inventory.Item.Board.Motherboard properties
@@ -25,7 +24,6 @@ class Motherboard : public ItemMotherboard
 {
   public:
     Motherboard() = delete;
-    ~Motherboard() = default;
     Motherboard(const Motherboard&) = delete;
     Motherboard& operator=(const Motherboard&) = delete;
     Motherboard(Motherboard&&) = delete;
@@ -36,6 +34,11 @@ class Motherboard : public ItemMotherboard
     {
         pldm::serialize::Serialize::getSerialize().serialize(path,
                                                              "Motherboard");
+        emit_added();
+    }
+    ~Motherboard()
+    {
+        emit_removed();
     }
 
   private:

--- a/host-bmc/dbus/operational_status.hpp
+++ b/host-bmc/dbus/operational_status.hpp
@@ -11,15 +11,13 @@ namespace pldm
 {
 namespace dbus
 {
-using OperationalStatusIntf =
-    sdbusplus::server::object_t<sdbusplus::xyz::openbmc_project::State::
-                                    Decorator::server::OperationalStatus>;
+using OperationalStatusIntf = sdbusplus::xyz::openbmc_project::State::
+    Decorator::server::OperationalStatus;
 
 class OperationalStatus : public OperationalStatusIntf
 {
   public:
     OperationalStatus() = delete;
-    ~OperationalStatus() = default;
     OperationalStatus(const OperationalStatus&) = delete;
     OperationalStatus& operator=(const OperationalStatus&) = delete;
     OperationalStatus(OperationalStatus&&) = delete;
@@ -27,7 +25,13 @@ class OperationalStatus : public OperationalStatusIntf
 
     OperationalStatus(sdbusplus::bus_t& bus, const std::string& objPath) :
         OperationalStatusIntf(bus, objPath.c_str()), path(objPath)
-    {}
+    {
+        emit_added();
+    }
+    ~OperationalStatus()
+    {
+        emit_removed();
+    }
 
     /** Get value of Functional */
     bool functional() const override;

--- a/host-bmc/dbus/panel.hpp
+++ b/host-bmc/dbus/panel.hpp
@@ -13,14 +13,13 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemPanel = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Panel>;
+using ItemPanel =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Panel;
 
 class Panel : public ItemPanel
 {
   public:
     Panel() = delete;
-    ~Panel() = default;
     Panel(const Panel&) = delete;
     Panel& operator=(const Panel&) = delete;
     Panel(Panel&&) = delete;
@@ -30,6 +29,11 @@ class Panel : public ItemPanel
         ItemPanel(bus, objPath.c_str()), path(objPath)
     {
         pldm::serialize::Serialize::getSerialize().serialize(path, "Panel");
+        emit_added();
+    }
+    ~Panel()
+    {
+        emit_removed();
     }
 
   private:

--- a/host-bmc/dbus/pcie_device.hpp
+++ b/host-bmc/dbus/pcie_device.hpp
@@ -14,8 +14,8 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemDevice = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::PCIeDevice>;
+using ItemDevice =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::PCIeDevice;
 using Generations = sdbusplus::common::xyz::openbmc_project::inventory::item::
     PCIeSlot::Generations;
 
@@ -28,7 +28,6 @@ class PCIeDevice : public ItemDevice
 {
   public:
     PCIeDevice() = delete;
-    ~PCIeDevice() = default;
     PCIeDevice(const PCIeDevice&) = delete;
     PCIeDevice& operator=(const PCIeDevice&) = delete;
 
@@ -37,6 +36,11 @@ class PCIeDevice : public ItemDevice
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath,
                                                              "PCIeDevice");
+        emit_added();
+    }
+    ~PCIeDevice()
+    {
+        emit_removed();
     }
 
     /** Get lanes in use */

--- a/host-bmc/dbus/pcie_slot.hpp
+++ b/host-bmc/dbus/pcie_slot.hpp
@@ -13,8 +13,8 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemSlot = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::PCIeSlot>;
+using ItemSlot =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::PCIeSlot;
 
 /**
  * @class PCIeSlot
@@ -24,7 +24,6 @@ class PCIeSlot : public ItemSlot
 {
   public:
     PCIeSlot() = delete;
-    ~PCIeSlot() = default;
     PCIeSlot(const PCIeSlot&) = delete;
     PCIeSlot& operator=(const PCIeSlot&) = delete;
 
@@ -33,6 +32,11 @@ class PCIeSlot : public ItemSlot
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath,
                                                              "PCIeSlot");
+        emit_added();
+    }
+    ~PCIeSlot()
+    {
+        emit_removed();
     }
 
     /** Get value of Generation */

--- a/host-bmc/dbus/pcie_topology.hpp
+++ b/host-bmc/dbus/pcie_topology.hpp
@@ -17,14 +17,12 @@ namespace pldm
 {
 namespace dbus
 {
-using TopologyObj = sdbusplus::server::object_t<
-    sdbusplus::com::ibm::PLDM::server::PCIeTopology>;
+using TopologyObj = sdbusplus::com::ibm::PLDM::server::PCIeTopology;
 
 class PCIETopology : public TopologyObj
 {
   public:
     PCIETopology() = delete;
-    ~PCIETopology() = default;
     PCIETopology(const PCIETopology&) = delete;
     PCIETopology& operator=(const PCIETopology&) = delete;
     PCIETopology(PCIETopology&&) = delete;
@@ -36,7 +34,13 @@ class PCIETopology : public TopologyObj
         TopologyObj(bus, objPath.c_str()),
         hostEffecterParser(hostEffecterParser), mctpEid(mctpEid)
 
-    {}
+    {
+        emit_added();
+    }
+    ~PCIETopology()
+    {
+        emit_removed();
+    }
 
     bool pcIeTopologyRefresh(bool value) override;
 

--- a/host-bmc/dbus/port.hpp
+++ b/host-bmc/dbus/port.hpp
@@ -13,14 +13,13 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemPort = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Connector::server::Port>;
+using ItemPort =
+    sdbusplus::xyz::openbmc_project::Inventory::Connector::server::Port;
 
 class Port : public ItemPort
 {
   public:
     Port() = delete;
-    ~Port() = default;
     Port(const Port&) = delete;
     Port& operator=(const Port&) = delete;
 
@@ -28,6 +27,11 @@ class Port : public ItemPort
         ItemPort(bus, objPath.c_str())
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath, "Port");
+        emit_added();
+    }
+    ~Port()
+    {
+        emit_removed();
     }
 };
 

--- a/host-bmc/dbus/power_supply.hpp
+++ b/host-bmc/dbus/power_supply.hpp
@@ -13,14 +13,13 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemPowerSupply = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::PowerSupply>;
+using ItemPowerSupply =
+    sdbusplus::xyz::openbmc_project::Inventory::Item::server::PowerSupply;
 
 class PowerSupply : public ItemPowerSupply
 {
   public:
     PowerSupply() = delete;
-    ~PowerSupply() = default;
     PowerSupply(const PowerSupply&) = delete;
     PowerSupply& operator=(const PowerSupply&) = delete;
     PowerSupply(PowerSupply&&) = delete;
@@ -31,6 +30,11 @@ class PowerSupply : public ItemPowerSupply
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath,
                                                              "PowerSupply");
+        emit_added();
+    }
+    ~PowerSupply()
+    {
+        emit_removed();
     }
 };
 

--- a/host-bmc/dbus/vrm.hpp
+++ b/host-bmc/dbus/vrm.hpp
@@ -13,14 +13,12 @@ namespace pldm
 {
 namespace dbus
 {
-using ItemVRM = sdbusplus::server::object_t<
-    sdbusplus::xyz::openbmc_project::Inventory::Item::server::Vrm>;
+using ItemVRM = sdbusplus::xyz::openbmc_project::Inventory::Item::server::Vrm;
 
 class VRM : public ItemVRM
 {
   public:
     VRM() = delete;
-    ~VRM() = default;
     VRM(const VRM&) = delete;
     VRM& operator=(const VRM&) = delete;
     VRM(VRM&&) = delete;
@@ -30,6 +28,11 @@ class VRM : public ItemVRM
         ItemVRM(bus, objPath.c_str())
     {
         pldm::serialize::Serialize::getSerialize().serialize(objPath, "VRM");
+        emit_added();
+    }
+    ~VRM()
+    {
+        emit_removed();
     }
 };
 

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1742,7 +1742,6 @@ void HostPDRHandler::deleteDbusObjects(const std::vector<uint16_t> types)
             if (type !=
                 (PLDM_ENTITY_PROC | 0x8000)) // other than CPU core object
             {
-                objPathMap.erase(path);
                 // Delete the Mex Led Dbus Object paths
                 auto ledGroupPath = updateLedGroupPath(path);
                 pldm::dbus::CustomDBus::getCustomDBus().deleteObject(

--- a/host-bmc/utils.cpp
+++ b/host-bmc/utils.cpp
@@ -135,14 +135,15 @@ void addObjectPathEntityAssociations(
             }
             try
             {
-                pldm::utils::DBusHandler().getService(entity_path.c_str(),
-                                                      nullptr);
+                auto serviceName = pldm::utils::DBusHandler().getService(
+                    entity_path.c_str(), nullptr);
                 // If the entity obtained from the remote PLDM terminal is not
                 // in the MAP, or there is no auxiliary name PDR, add it
                 // directly. Otherwise, check whether the DBus service of
                 // entity_path exists, and overwrite the entity if it does not
                 // exist.
-                if (objPathMap.contains(entity_path))
+                if (objPathMap.contains(entity_path) ||
+                    serviceName == ObjectMapper::default_service)
                 {
                     objPathMap[entity_path] = node_entity;
                 }
@@ -180,8 +181,10 @@ void addObjectPathEntityAssociations(
         }
         try
         {
-            pldm::utils::DBusHandler().getService(dbusPath.c_str(), nullptr);
-            if (objPathMap.contains(dbusPath))
+            auto serviceName = pldm::utils::DBusHandler().getService(
+                dbusPath.c_str(), nullptr);
+            if (objPathMap.contains(dbusPath) ||
+                serviceName == ObjectMapper::default_service)
             {
                 objPathMap[dbusPath] = node_entity;
             }


### PR DESCRIPTION
#### Fixed The Issue of Not Listing MEX CHASSIS after Restart PLDM (#745)
```
* meson: fixed the configurations for dbus-config.json

Fixed the issue for not creating cores under PLDM

Signed-off-by: RameshaR45 <ramesharohit45@gmail.com>

* Fixed Mex Chassis Issue

which was not creating after the PLDM Restart and poweroff

Signed-off-by: RameshaR45 <ramesharohit45@gmail.com>

---------

Signed-off-by: RameshaR45 <ramesharohit45@gmail.com>```