### PR TITLE
pldm: Processor core presence support

### DIFF
--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Huygens/11.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Huygens/11.json
@@ -4,6 +4,2438 @@
             "pdrType": 11,
             "entries": [
                 {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis0",
                     "effecters": [
                         {

--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Huygens/4.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Huygens/4.json
@@ -4,6 +4,2438 @@
             "pdrType": 4,
             "entries": [
                 {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis0",
                     "sensors": [
                         {

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -1644,12 +1644,6 @@ void HostPDRHandler::createDbusObjects()
 
         switch (entity.second.entity_type)
         {
-            case PLDM_ENTITY_PROC | 0x8000:
-                CustomDBus::getCustomDBus().implementCpuCoreInterface(
-                    entity.first);
-                CustomDBus::getCustomDBus().implementObjectEnableIface(
-                    entity.first, false);
-                break;
             case PLDM_ENTITY_SYSTEM_CHASSIS:
                 CustomDBus::getCustomDBus().implementChassisInterface(
                     entity.first);
@@ -1739,14 +1733,10 @@ void HostPDRHandler::deleteDbusObjects(const std::vector<uint16_t> types)
 
         for (const auto& [path, entites] : savedObjs.at(type))
         {
-            if (type !=
-                (PLDM_ENTITY_PROC | 0x8000)) // other than CPU core object
-            {
-                // Delete the Mex Led Dbus Object paths
-                auto ledGroupPath = updateLedGroupPath(path);
-                pldm::dbus::CustomDBus::getCustomDBus().deleteObject(
-                    ledGroupPath);
-            }
+            // Delete the Mex Led Dbus Object paths
+            auto ledGroupPath = updateLedGroupPath(path);
+            pldm::dbus::CustomDBus::getCustomDBus().deleteObject(ledGroupPath);
+
             pldm::dbus::CustomDBus::getCustomDBus().deleteObject(path);
         }
     }

--- a/pldmtool/pldm_platform_cmd.cpp
+++ b/pldmtool/pldm_platform_cmd.cpp
@@ -636,6 +636,10 @@ class GetPDR : public CommandInterface
          "Intermediate State-2"},
         {PLDM_STATE_SET_ACPI_DEVICE_POWER_STATE_OFF, "Off"}};
 
+    static inline const std::map<uint8_t, std::string> setPresenceState{
+        {PLDM_STATE_SET_PRESENCE_PRESENT, "Present"},
+        {PLDM_STATE_SET_PRESENCE_NOT_PRESENT, "Not Present"}};
+
     static inline const std::map<uint16_t, const std::map<uint8_t, std::string>>
         populatePStateMaps{
             {PLDM_STATE_SET_THERMAL_TRIP, setThermalTrip},
@@ -649,6 +653,7 @@ class GetPDR : public CommandInterface
             {PLDM_STATE_SET_OPERATIONAL_RUNNING_STATUS,
              setOperationalRunningState},
             {PLDM_STATE_SET_DEVICE_POWER_STATE, setPowerDeviceState},
+            {PLDM_STATE_SET_PRESENCE, setPresenceState},
         };
 
     const std::map<std::string, uint8_t> strToPdrType = {


### PR DESCRIPTION
Below are the changes in this commit:
1. Added core presence state sensor and effecter PDRs
2. Removed the core dbus implementation trigger code
3. Updated entity map json with core info

Tested By:

Tested and verified the State Sensor PDR and State Effecter PDR for the Processor Core in Huygens simics

Presence state set id for Processor Core
{
    "nextRecordHandle": 351,
    "responseCount": 29,
    "recordHandle": 350,
    "PDRHeaderVersion": 1,
    "PDRType": "State Effecter PDR",
    "recordChangeNumber": 0,
    "dataLength": 19,
    "PLDMTerminusHandle": 1,
    "effecterID": 138,
    "entityType": "[Physical] Processor Core",
    "entityInstanceNumber": 1,
    "containerID": 7,
    "effecterSemanticID": 0,
    "effecterInit": "noInit",
    "effecterDescriptionPDR": false,
    "compositeEffecterCount": 1,
    "stateSetID[0]": "Presence(13)",
    "possibleStatesSize[0]": 1,
    "possibleStates[0]": [
        "Present(1)",
        "Absent(2)"
    ]
}