### PR TITLE
host-bmc: Fix incorrect non-functional core status after concurrent code update or reboot

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -415,8 +415,8 @@ void CustomDBus::implementObjectEnableIface(const std::string& path, bool value)
         enabledStatus.emplace(
             path, std::make_unique<Enable>(pldm::utils::DBusHandler::getBus(),
                                            path.c_str()));
+        enabledStatus.at(path)->enabled(value);
     }
-    enabledStatus.at(path)->enabled(value);
 }
 
 void CustomDBus::implementFabricAdapter(const std::string& path)


### PR DESCRIPTION
Fix incorrect non-functional core status after concurrent code update or reboot