### PR TITLE
oem-ibm: Redesign of systemdump to write to the BMC flash

### DIFF
--- a/oem/ibm/libpldmresponder/file_io.cpp
+++ b/oem/ibm/libpldmresponder/file_io.cpp
@@ -1,6 +1,7 @@
 #include "file_io.hpp"
 
 #include "file_io_by_type.hpp"
+#include "file_io_type_dump.hpp"
 #include "file_table.hpp"
 #include "utils.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
@@ -1244,6 +1245,12 @@ Response Handler::newFileAvailable(const pldm_msg* request,
         error("Unknown file type '{TYPE}', error - {ERROR}", "TYPE", fileType,
               "ERROR", e);
         return CmdHandler::ccOnlyResponse(request, PLDM_INVALID_FILE_TYPE);
+    }
+
+    // Initialize event loop for DumpHandler before calling newFileAvailable
+    if (fileType == PLDM_FILE_TYPE_DUMP)
+    {
+        DumpHandler::setEventLoop(event);
     }
 
     rc = handler->newFileAvailable(length);

--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -5,6 +5,7 @@
 #include "utils.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
+#include <fcntl.h>
 #include <libpldm/base.h>
 #include <libpldm/oem/ibm/file_io.h>
 #include <systemd/sd-bus.h>
@@ -17,6 +18,7 @@
 #include <cstdint>
 #include <exception>
 #include <filesystem>
+#include <format>
 #include <type_traits>
 
 PHOSPHOR_LOG2_USING;
@@ -41,6 +43,13 @@ static constexpr auto bmcDumpObjPath = "/xyz/openbmc_project/dump/bmc/entry";
 // resource dumps.
 
 int DumpHandler::fd = -1;
+std::unordered_map<FileHandle, SysDumpTransferData> DumpHandler::sysDumpMap;
+sdeventplus::Event* DumpHandler::eventLoop = nullptr;
+
+// System dump file configuration
+constexpr auto sysDumpPath = "/tmp";
+constexpr auto sysDumpFilePrefix = "sysdump_";
+
 namespace fs = std::filesystem;
 
 uint32_t DumpHandler::getDumpIdPrefix(uint16_t dumpType)
@@ -203,6 +212,11 @@ int DumpHandler::newFileAvailable(uint64_t length)
         notifyDumpType =
             sdbusplus::common::com::ibm::dump::Notify::DumpType::Resource;
     }
+    else if (dumpType == PLDM_FILE_TYPE_DUMP) // for system dump start timer and
+                                              // open the file
+    {
+        return DumpHandler::initializeSystemDumpTransfer(fileHandle);
+    }
 
     try
     {
@@ -337,10 +351,33 @@ void DumpHandler::writeFromMemory(uint32_t, uint32_t length, uint64_t address,
                              sharedAIORespDataobj, event);
 }
 
-int DumpHandler::write(const char* buffer, uint32_t, uint32_t& length,
+int DumpHandler::write(const char* buffer, uint32_t offset, uint32_t& length,
                        oem_platform::Handler* /*oemPlatformHandler*/,
                        struct fileack_status_metadata& /*metaDataObj*/)
 {
+    // Write to file for PLDM_FILE_TYPE_DUMP
+    if (dumpType == PLDM_FILE_TYPE_DUMP)
+    {
+        // Check if transfer exists for this fileHandle
+        if (!sysDumpMap.contains(fileHandle))
+        {
+            error(
+                "Write rejected for system dump: no active transfer for fileHandle {HANDLE}",
+                "HANDLE", fileHandle);
+            return PLDM_ERROR;
+        }
+        int dumpFd = sysDumpMap.at(fileHandle).fd;
+        int rc = ::pwrite(dumpFd, buffer, length, offset);
+        if (rc < 0)
+        {
+            error("Failed to write to dump file, with error:{ERRNO}", "ERRNO",
+                  errno);
+            return PLDM_ERROR;
+        }
+        length = rc; // Update length with actual bytes written
+        return PLDM_SUCCESS;
+    }
+
     int rc = writeToUnixSocket(DumpHandler::fd, buffer, length);
     if (rc < 0)
     {
@@ -359,6 +396,20 @@ int DumpHandler::write(const char* buffer, uint32_t, uint32_t& length,
 
 int DumpHandler::fileAck(uint8_t fileStatus)
 {
+    if (dumpType == PLDM_FILE_TYPE_DUMP) // for system dump
+    {
+        // Check if the fileHandle exists in the map
+        if (!sysDumpMap.contains(fileHandle))
+        {
+            error(
+                "System dump transfer session does not exist for fileHandle {FILE_HANDLE}",
+                "FILE_HANDLE", fileHandle);
+            return PLDM_INVALID_FILE_HANDLE;
+        }
+        sysDumpMap.erase(fileHandle);
+        return PLDM_SUCCESS;
+    }
+
     auto path = findDumpObjPath(fileHandle);
     if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP_PARMS)
     {
@@ -444,8 +495,7 @@ int DumpHandler::fileAck(uint8_t fileStatus)
             return PLDM_SUCCESS;
         }
 
-        if (dumpType == PLDM_FILE_TYPE_DUMP ||
-            dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
+        if (dumpType == PLDM_FILE_TYPE_RESOURCE_DUMP)
         {
             PropertyValue value{true};
             DBusMapping dbusMapping{path, dumpEntry, "Offloaded", "bool"};
@@ -784,5 +834,58 @@ int DumpHandler::fileAckWithMetaData(
 
     return PLDM_ERROR;
 }
+
+int DumpHandler::initializeSystemDumpTransfer(FileHandle fileHandle)
+{
+    // Check if transfer already exists for this fileHandle
+    if (sysDumpMap.contains(fileHandle))
+    {
+        warning(
+            "Dump transfer already active for fileHandle {FILE_HANDLE}, cleaning up old transfer",
+            "FILE_HANDLE", fileHandle);
+        sysDumpMap.erase(fileHandle);
+    }
+
+    // Open file for writing system dump
+    std::string dumpFilePath =
+        std::format("{}/{}{}", sysDumpPath, sysDumpFilePrefix, fileHandle);
+    int dumpFd = open(dumpFilePath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (dumpFd < 0)
+    {
+        error("Failed to open dump file {PATH}, with error: {ERRNO}", "PATH",
+              dumpFilePath, "ERRNO", errno);
+        return PLDM_ERROR;
+    }
+    // Create timer, start it, and add to map with fd
+    try
+    {
+        auto timer = std::make_unique<SysDumpTimer>(
+            *DumpHandler::eventLoop, [fileHandle](SysDumpTimer&) {
+                DumpHandler::onDumpTransferTimeout(fileHandle);
+            });
+        timer->restart(
+            std::chrono::minutes(DumpHandler::sysDumpTimeoutMinutes));
+        sysDumpMap.emplace(fileHandle,
+                           SysDumpTransferData(std::move(timer), dumpFd));
+    }
+    catch (const std::exception& e)
+    {
+        error(
+            "Failed to create dump transfer for fileHandle {FILE_HANDLE}: {ERROR}",
+            "FILE_HANDLE", fileHandle, "ERROR", e.what());
+        close(dumpFd);
+        return PLDM_ERROR;
+    }
+    return PLDM_SUCCESS;
+}
+
+void DumpHandler::onDumpTransferTimeout(FileHandle fileHandle)
+{
+    error(
+        "System dump transfer aborted due to timeout for fileHandle {FILEHANDLE}. File may be incomplete.",
+        "FILEHANDLE", fileHandle);
+    sysDumpMap.erase(fileHandle);
+}
+
 } // namespace responder
 } // namespace pldm

--- a/oem/ibm/libpldmresponder/file_io_type_dump.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.hpp
@@ -2,11 +2,66 @@
 
 #include "file_io_by_type.hpp"
 
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/utility/timer.hpp>
+
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
 namespace pldm
 {
 namespace responder
 {
 using DumpEntryInterface = std::string;
+using FileHandle = uint32_t;
+using SysDumpTimer =
+    sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic>;
+
+/** @struct SysDumpTransferData
+ *
+ *  @brief Wrapper for systemdump that owns timer and fd
+ */
+struct SysDumpTransferData
+{
+    std::unique_ptr<SysDumpTimer> timer;
+    int fd;
+
+    SysDumpTransferData(std::unique_ptr<SysDumpTimer>&& t, int f) :
+        timer(std::move(t)), fd(f)
+    {}
+
+    ~SysDumpTransferData()
+    {
+        if (fd >= 0)
+        {
+            close(fd);
+        }
+    }
+
+    // Prevent copying
+    SysDumpTransferData(const SysDumpTransferData&) = delete;
+    SysDumpTransferData& operator=(const SysDumpTransferData&) = delete;
+    SysDumpTransferData(SysDumpTransferData&& other) noexcept :
+        timer(std::move(other.timer)), fd(other.fd)
+    {
+        other.fd = -1;
+    }
+    SysDumpTransferData& operator=(SysDumpTransferData&& other) noexcept
+    {
+        if (this != &other)
+        {
+            if (fd >= 0)
+            {
+                close(fd);
+            }
+            timer = std::move(other.timer);
+            fd = other.fd;
+            other.fd = -1;
+        }
+        return *this;
+    }
+};
 
 /** @class DumpHandler
  *
@@ -16,6 +71,9 @@ using DumpEntryInterface = std::string;
 class DumpHandler : public FileHandler
 {
   public:
+    // System dump transfer timeout in minutes
+    static constexpr auto sysDumpTimeoutMinutes = 15;
+
     /** @brief DumpHandler constructor
      */
     DumpHandler(uint32_t fileHandle, uint16_t fileType) :
@@ -63,6 +121,25 @@ class DumpHandler : public FileHandler
         const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
         const struct fileack_status_metadata& /*metaDataObj*/) {};
 
+    /** @brief Set event loop for timer management
+     *  @param[in] event - Event loop reference
+     */
+    static void setEventLoop(sdeventplus::Event& event)
+    {
+        eventLoop = &event;
+    }
+
+    /** @brief Callback when dump transfer timeout expires
+     *  @param[in] fileHandle - File handle that timed out
+     */
+    static void onDumpTransferTimeout(FileHandle fileHandle);
+
+    /** @brief Initialize system dump transfer
+     *  @param[in] fileHandle - File handle for the dump transfer
+     *  @return PLDM completion code
+     */
+    static int initializeSystemDumpTransfer(FileHandle fileHandle);
+
     /** @brief DumpHandler destructor
      */
     ~DumpHandler() {}
@@ -74,6 +151,11 @@ class DumpHandler : public FileHandler
         resDumpRequestDirPath; //!< directory where the resource
                                //!< dump request parameter file is stored
     int unixFd;                //!< fd to temporarily hold the fd created.
+
+    static std::unordered_map<FileHandle, SysDumpTransferData>
+        sysDumpMap; //!< Map of fileHandle to SysDumpTransferData (timer + fd)
+                    //!< for system dumps
+    static sdeventplus::Event* eventLoop; //!< Event loop for timer management
 
     enum DumpRequestStatus
     {


### PR DESCRIPTION
This commit implements a redesign of the system dump
handling mechanism for system dumps from HB to store
dumps directly to the BMC file system instead
of offloading to Unix Sockets without using DMA

Key changes:

1. File System Storage:
   - System dumps are now written to /tmp/dump_<fileHandle>

2. Timeout Protection:
   - Implemented timeout mechanism using sdeventplus timer
   - Timer starts on newfileavailable
   - Automatically closes file descriptor on timeout to prevent resource leaks
   - Timer stops on successful FileAck completion

3. DumpHandler Changes:
   - Modified newfileavailable() to start the timer instead of notifying dumphandler
   - Modified write() method to handle file system operations
   - Updated fileAck() to properly close file descriptor
   - Maintained original behavior for other dump types

4. Handler Timer Management:
   - Added startDumpTransferTimer() to initiate countdown
   - Added stopDumpTransferTimer() to cancel active timer
   - Added onDumpTransferTimeout() callback for timeout handling
   
   Tested By:
1. pldmtool commands to simulate writefilebytype for file type
   systemdump(PLDM_FILE_TYPE_DUMP)
2. Verified that on timeout, fd is closed and no new writes
   are accepted
3. Enforces 1 systemdump is transferred at a time