### PR TITLE
oem-ibm: New PDR support in Huygens

### DIFF
--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Huygens/11.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Huygens/11.json
@@ -4,6 +4,728 @@
             "pdrType": 11,
             "entries": [
                 {
+                    "entity_path": "/xyz/openbmc_project/inventory/system",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power0",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power1",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power2",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power3",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power4",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
                     "effecters": [
                         {
@@ -603,6 +1325,633 @@
                             },
                             "dbus": {
                                 "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm31",
                                 "interface": "xyz.openbmc_project.Inventory.Item",
                                 "property_name": "Present",
                                 "property_type": "bool",
@@ -1220,6 +2569,633 @@
                     ]
                 },
                 {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
                     "effecters": [
                         {
@@ -1819,6 +3795,633 @@
                             },
                             "dbus": {
                                 "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm31",
                                 "interface": "xyz.openbmc_project.Inventory.Item",
                                 "property_name": "Present",
                                 "property_type": "bool",
@@ -2429,6 +5032,5022 @@
                                 "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
                                 "interface": "xyz.openbmc_project.Inventory.Item",
                                 "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core0",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core1",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core2",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core3",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core4",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core5",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core6",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core7",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core8",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core9",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core10",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core11",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core12",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core13",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core14",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core15",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core16",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core17",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core18",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core19",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core20",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core21",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core22",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core23",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core24",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core25",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core26",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core27",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core28",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core29",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core30",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
+                    "effecters": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
                                 "property_type": "bool",
                                 "property_values": [true, false]
                             }
@@ -3260,9 +10879,7 @@
                     ]
                 },
                 {
-                    "type": 67,
-                    "instance": 1,
-                    "container": 3,
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm",
                     "effecters": [
                         {
                             "set": {
@@ -4827,9 +12444,7 @@
                     ]
                 },
                 {
-                    "type": 67,
-                    "instance": 1,
-                    "container": 3,
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm",
                     "effecters": [
                         {
                             "set": {
@@ -6394,9 +14009,7 @@
                     ]
                 },
                 {
-                    "type": 67,
-                    "instance": 1,
-                    "container": 3,
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm",
                     "effecters": [
                         {
                             "set": {
@@ -7961,9 +15574,7 @@
                     ]
                 },
                 {
-                    "type": 67,
-                    "instance": 1,
-                    "container": 3,
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm",
                     "effecters": [
                         {
                             "set": {

--- a/configurations/pdr/com.ibm.Hardware.Chassis.Model.Huygens/4.json
+++ b/configurations/pdr/com.ibm.Hardware.Chassis.Model.Huygens/4.json
@@ -4,6 +4,728 @@
             "pdrType": 4,
             "entries": [
                 {
+                    "entity_path": "/xyz/openbmc_project/inventory/system",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power0",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power1",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power2",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power3",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 257,
+                                "size": 1,
+                                "states": [1, 4]
+                            },
+                            "dbus": {
+                                "path": "/org/openbmc/control/power4",
+                                "interface": "org.openbmc.control.Power",
+                                "property_name": "pgood",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
                     "sensors": [
                         {
@@ -603,6 +1325,633 @@
                             },
                             "dbus": {
                                 "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm31",
                                 "interface": "xyz.openbmc_project.Inventory.Item",
                                 "property_name": "Present",
                                 "property_type": "bool",
@@ -1220,6 +2569,633 @@
                     ]
                 },
                 {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
                     "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
                     "sensors": [
                         {
@@ -1819,6 +3795,633 @@
                             },
                             "dbus": {
                                 "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 13,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm31",
                                 "interface": "xyz.openbmc_project.Inventory.Item",
                                 "property_name": "Present",
                                 "property_type": "bool",
@@ -2429,6 +5032,5022 @@
                                 "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
                                 "interface": "xyz.openbmc_project.Inventory.Item",
                                 "property_name": "Present",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/dimm31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core0",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core0",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core1",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core1",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core2",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core2",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core3",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core3",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core4",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core4",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core5",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core5",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core6",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core6",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core7",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core7",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core8",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core8",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core9",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core9",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core10",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core10",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core11",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core11",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core12",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core12",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core13",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core13",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core14",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core14",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core15",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core15",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core16",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core16",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core17",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core17",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core18",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core18",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core19",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core19",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core20",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core20",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core21",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core21",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core22",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core22",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core23",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core23",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core24",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core24",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core25",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core25",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core26",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core26",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core27",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core27",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core28",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core28",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core29",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core29",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core30",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core30",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
+                                "property_type": "bool",
+                                "property_values": [true, false]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
+                    "sensors": [
+                        {
+                            "set": {
+                                "id": 2,
+                                "size": 1,
+                                "states": [1, 2]
+                            },
+                            "dbus": {
+                                "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm/core31",
+                                "interface": "xyz.openbmc_project.Object.Enable",
+                                "property_name": "Enabled",
                                 "property_type": "bool",
                                 "property_values": [true, false]
                             }
@@ -3260,9 +10879,7 @@
                     ]
                 },
                 {
-                    "type": 67,
-                    "instance": 1,
-                    "container": 3,
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm",
                     "sensors": [
                         {
                             "set": {
@@ -4827,9 +12444,7 @@
                     ]
                 },
                 {
-                    "type": 67,
-                    "instance": 1,
-                    "container": 3,
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm",
                     "sensors": [
                         {
                             "set": {
@@ -6394,9 +14009,7 @@
                     ]
                 },
                 {
-                    "type": 67,
-                    "instance": 1,
-                    "container": 3,
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm",
                     "sensors": [
                         {
                             "set": {
@@ -7961,9 +15574,7 @@
                     ]
                 },
                 {
-                    "type": 67,
-                    "instance": 1,
-                    "container": 3,
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm",
                     "sensors": [
                         {
                             "set": {

--- a/oem/ibm/configurations/fru_master.json
+++ b/oem/ibm/configurations/fru_master.json
@@ -4,6 +4,7 @@
         "xyz.openbmc_project.Inventory.Item.Board": 60,
         "xyz.openbmc_project.Inventory.Item.PCIeDevice": 61,
         "xyz.openbmc_project.Inventory.Item.Board.Motherboard": 64,
+        "xyz.openbmc_project.Inventory.Item.Dimm": 66,
         "xyz.openbmc_project.Inventory.Item.Panel": 69,
         "xyz.openbmc_project.Inventory.Item.DiskBackplane": 73,
         "xyz.openbmc_project.Inventory.Item.Fan": 93,
@@ -15,7 +16,7 @@
         "xyz.openbmc_project.Inventory.Item.CpuCore": 151,
         "xyz.openbmc_project.Inventory.Item.Connector": 185,
         "xyz.openbmc_project.Inventory.Item.PCIeSlot": 186,
-        "xyz.openbmc_project.Inventory.Item.System": 11521,
+        "xyz.openbmc_project.Inventory.Item.System": 32813,
         "xyz.openbmc_project.Inventory.Item.Tpm": 24576
     }
 }


### PR DESCRIPTION
This commit contains below changes
1. FRU Record Set support for dimms
2. Change the system entity id to 32813 (logical system)
3. Presence changes for chassis and dimms
4. pgood additions for chassis
5. Enable property additons for mcm, node, dimm and processor cores

Tested By:
Verified the changes in Huygens simics setup