### PR TITLE
1110: pldm: Ignore timeout errors during activation (#761)

### DIFF
--- a/oem/ibm/libpldmresponder/inband_code_update.cpp
+++ b/oem/ibm/libpldmresponder/inband_code_update.cpp
@@ -165,9 +165,34 @@ int CodeUpdate::setRequestedActivation()
     dbusMapping.interface = "xyz.openbmc_project.Software.Activation";
     dbusMapping.propertyName = "RequestedActivation";
     dbusMapping.propertyType = "string";
+
+    info("Calling RequestedActivation for object path: {PATH}", "PATH",
+         dbusMapping.objectPath);
+
     try
     {
         pldm::utils::DBusHandler().setDbusProperty(dbusMapping, value);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        if (e.name() != nullptr &&
+            strcmp("org.freedesktop.DBus.Error.Timeout", e.name()) != 0)
+        {
+            // log error
+            error(
+                "Failed to set property {PROPERTY} at path '{PATH}' and interface "
+                "'{INTERFACE}', error - {ERROR}",
+                "PATH", dbusMapping.objectPath, "INTERFACE",
+                dbusMapping.interface, "PROPERTY", dbusMapping.propertyName,
+                "ERROR", e);
+            rc = PLDM_ERROR;
+        }
+        else
+        {
+            info(
+                "Timeout error for RequestedActivation at path '{PATH}' is ignored",
+                "PATH", dbusMapping.objectPath);
+        }
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
#### pldm: Ignore timeout errors during activation (#761)
```
As part of inband update, PLDM requests the code update app
to start the update by setting a D-Bus property
(RequestedActivation).

PLDM may not receive a response from the set-property call
within 5 seconds and times out, aborting the update. This
can occur when the BMC/D-Bus is busy and takes longer to
respond.

Modify setRequestedActivation() to ignore D-Bus timeout
errors.

With this change, PLDM no longer aborts the update if a
response is not received within 5 seconds. If the code
update fails to start, PHYP will timeout and abort after
5 minutes, providing a safety net.

Signed-off-by: Archana Kakani <archana.kakani@ibm.com>```