### PR TITLE
pdr: Core count numeric effecter support

### DIFF
--- a/configurations/pdr/11.json
+++ b/configurations/pdr/11.json
@@ -147,6 +147,134 @@
                         "property_name": "ScheduledTime",
                         "property_type": "uint64_t"
                     }
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm",
+                    "base_unit": 67,
+                    "rate_unit": 0,
+                    "effecter_resolutioninit": 1,
+                    "effecter_data_size": 2,
+                    "range_field_format": 3,
+                    "min_settable": 1,
+                    "max_settable": 32,
+                    "dbus": {
+                        "path": "/xyz/openbmc_project/inventory/system/chassis1/motherboard/mcm",
+                        "interface": "xyz.openbmc_project.Inventory.Item.Cpu",
+                        "property_name": "CoreCount",
+                        "property_type": "uint16_t"
+                    }
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm",
+                    "base_unit": 67,
+                    "rate_unit": 0,
+                    "effecter_resolutioninit": 1,
+                    "effecter_data_size": 2,
+                    "range_field_format": 3,
+                    "min_settable": 1,
+                    "max_settable": 32,
+                    "dbus": {
+                        "path": "/xyz/openbmc_project/inventory/system/chassis2/motherboard/mcm",
+                        "interface": "xyz.openbmc_project.Inventory.Item.Cpu",
+                        "property_name": "CoreCount",
+                        "property_type": "uint16_t"
+                    }
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm",
+                    "base_unit": 67,
+                    "rate_unit": 0,
+                    "effecter_resolutioninit": 1,
+                    "effecter_data_size": 2,
+                    "range_field_format": 3,
+                    "min_settable": 1,
+                    "max_settable": 32,
+                    "dbus": {
+                        "path": "/xyz/openbmc_project/inventory/system/chassis3/motherboard/mcm",
+                        "interface": "xyz.openbmc_project.Inventory.Item.Cpu",
+                        "property_name": "CoreCount",
+                        "property_type": "uint16_t"
+                    }
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm",
+                    "base_unit": 67,
+                    "rate_unit": 0,
+                    "effecter_resolutioninit": 1,
+                    "effecter_data_size": 2,
+                    "range_field_format": 3,
+                    "min_settable": 1,
+                    "max_settable": 32,
+                    "dbus": {
+                        "path": "/xyz/openbmc_project/inventory/system/chassis4/motherboard/mcm",
+                        "interface": "xyz.openbmc_project.Inventory.Item.Cpu",
+                        "property_name": "CoreCount",
+                        "property_type": "uint16_t"
+                    }
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis5/motherboard/mcm",
+                    "base_unit": 67,
+                    "rate_unit": 0,
+                    "effecter_resolutioninit": 1,
+                    "effecter_data_size": 2,
+                    "range_field_format": 3,
+                    "min_settable": 1,
+                    "max_settable": 32,
+                    "dbus": {
+                        "path": "/xyz/openbmc_project/inventory/system/chassis5/motherboard/mcm",
+                        "interface": "xyz.openbmc_project.Inventory.Item.Cpu",
+                        "property_name": "CoreCount",
+                        "property_type": "uint16_t"
+                    }
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis6/motherboard/mcm",
+                    "base_unit": 67,
+                    "rate_unit": 0,
+                    "effecter_resolutioninit": 1,
+                    "effecter_data_size": 2,
+                    "range_field_format": 3,
+                    "min_settable": 1,
+                    "max_settable": 32,
+                    "dbus": {
+                        "path": "/xyz/openbmc_project/inventory/system/chassis6/motherboard/mcm",
+                        "interface": "xyz.openbmc_project.Inventory.Item.Cpu",
+                        "property_name": "CoreCount",
+                        "property_type": "uint16_t"
+                    }
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis7/motherboard/mcm",
+                    "base_unit": 67,
+                    "rate_unit": 0,
+                    "effecter_resolutioninit": 1,
+                    "effecter_data_size": 2,
+                    "range_field_format": 3,
+                    "min_settable": 1,
+                    "max_settable": 32,
+                    "dbus": {
+                        "path": "/xyz/openbmc_project/inventory/system/chassis7/motherboard/mcm",
+                        "interface": "xyz.openbmc_project.Inventory.Item.Cpu",
+                        "property_name": "CoreCount",
+                        "property_type": "uint16_t"
+                    }
+                },
+                {
+                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis8/motherboard/mcm",
+                    "base_unit": 67,
+                    "rate_unit": 0,
+                    "effecter_resolutioninit": 1,
+                    "effecter_data_size": 2,
+                    "range_field_format": 3,
+                    "min_settable": 1,
+                    "max_settable": 32,
+                    "dbus": {
+                        "path": "/xyz/openbmc_project/inventory/system/chassis8/motherboard/mcm",
+                        "interface": "xyz.openbmc_project.Inventory.Item.Cpu",
+                        "property_name": "CoreCount",
+                        "property_type": "uint16_t"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
This adds the numeric effecter support to update the core count value under each of the mcm units.

Tested By:
Verified the changes in Huygens simics setup.

1. Set the core count as 10 for first node

pldmtool platform SetNumericEffecterValue -i 266 -s 2 -d 10 -v pldmtool: Tx: 80 02 31 0a 01 02 0a 00 00 00
pldmtool: Rx: 00 02 31 00
{
    "Response": "SUCCESS"
}

xyz.openbmc_project.Inventory.Item.Cpu
.CoreCount            property  q         10

2. Setting of invalid value of 0 returned with error

pldmtool platform SetNumericEffecterValue -i 266 -s 2 -d 0 -v pldmtool: Tx: 80 02 31 0a 01 02 00 00 00 00
pldmtool: Rx: 00 02 31 02
Response Message Error: rc=0,cc=2