### PR TITLE
1120: Draft: Sample: Add contained_by association for CpuCore interface

### DIFF
--- a/host-bmc/dbus/custom_dbus.cpp
+++ b/host-bmc/dbus/custom_dbus.cpp
@@ -1,5 +1,7 @@
 #include "custom_dbus.hpp"
 
+#include <filesystem>
+
 namespace pldm
 {
 namespace dbus
@@ -366,6 +368,17 @@ void CustomDBus::implementCpuCoreInterface(const std::string& path)
     {
         cpuCore.emplace(path, std::make_unique<CPUCore>(
                                   pldm::utils::DBusHandler::getBus(), path));
+
+        // Create contained_by association to parent CPU
+        std::filesystem::path corePath(path);
+        std::string parentCpuPath = corePath.parent_path().string();
+
+        if (!parentCpuPath.empty())
+        {
+            std::vector<std::tuple<std::string, std::string, std::string>>
+                associations{{"contained_by", "containing", parentCpuPath}};
+            setAssociations(path, associations);
+        }
     }
 }
 


### PR DESCRIPTION
Cpu & CpuCore is expressed via associations `{containing, contained_by}` in the phosphor-dbus-interfaces specification [1].

This commit is to implement an example code change to create the association in pldm.

Example:
  CpuCore: /xyz/openbmc_project/inventory/.../cpu0/core0
  Association: contained_by -> /xyz/openbmc_project/inventory/.../cpu0

This association is going to be used in bmcweb - e.g. upstream commits [2][3]

[1] https://github.com/openbmc/phosphor-dbus-interfaces/commit/8c79b1dc0270d01c0b713a345c8ec39533c542e4
[2] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/38570
[3] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/64982