### PR TITLE
pdr: Fix entity path for system power state

### DIFF
--- a/configurations/pdr/11.json
+++ b/configurations/pdr/11.json
@@ -4,7 +4,7 @@
             "pdrType": 11,
             "entries": [
                 {
-                    "entity_path": "/xyz/openbmc_project/inventory/system/chassis",
+                    "entity_path": "/xyz/openbmc_project/inventory/system",
                     "effecters": [
                         {
                             "set": {


### PR DESCRIPTION
This commit fixes the entity path for the system power state PDR entry.

Tested By:
Verified the change using the soft off and obmcutil commands.