### PR TITLE
oem-ibm: Add new location codes in FRU table

### DIFF
--- a/oem/ibm/configurations/fru/CpuCore_LocationCode.json
+++ b/oem/ibm/configurations/fru/CpuCore_LocationCode.json
@@ -1,0 +1,17 @@
+{
+    "record_details": {
+        "fru_record_type": 254,
+        "fru_encoding_type": 1,
+        "dbus_interface_name": "xyz.openbmc_project.Inventory.Item.CpuCore"
+    },
+    "fru_fields": [
+        {
+            "fru_field_type": 254,
+            "dbus": {
+                "interface": "xyz.openbmc_project.Inventory.Decorator.LocationCode",
+                "property_name": "LocationCode",
+                "property_type": "string"
+            }
+        }
+    ]
+}

--- a/oem/ibm/configurations/fru/Cpu_LocationCode.json
+++ b/oem/ibm/configurations/fru/Cpu_LocationCode.json
@@ -1,0 +1,17 @@
+{
+    "record_details": {
+        "fru_record_type": 254,
+        "fru_encoding_type": 1,
+        "dbus_interface_name": "xyz.openbmc_project.Inventory.Item.Cpu"
+    },
+    "fru_fields": [
+        {
+            "fru_field_type": 254,
+            "dbus": {
+                "interface": "xyz.openbmc_project.Inventory.Decorator.LocationCode",
+                "property_name": "LocationCode",
+                "property_type": "string"
+            }
+        }
+    ]
+}

--- a/oem/ibm/configurations/fru/Dimm_LocationCode.json
+++ b/oem/ibm/configurations/fru/Dimm_LocationCode.json
@@ -1,0 +1,17 @@
+{
+    "record_details": {
+        "fru_record_type": 254,
+        "fru_encoding_type": 1,
+        "dbus_interface_name": "xyz.openbmc_project.Inventory.Item.Dimm"
+    },
+    "fru_fields": [
+        {
+            "fru_field_type": 254,
+            "dbus": {
+                "interface": "xyz.openbmc_project.Inventory.Decorator.LocationCode",
+                "property_name": "LocationCode",
+                "property_type": "string"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This commit adds the location codes for the inventory items such as Dimm, Cpu and CpuCore.

Tested By:
Verified the change in Huygens simics setup and location codes are now showing up for Dimm, Cpu and CpuCore.