### PR TITLE
oem-ibm: Change systemdump file write path

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_dump.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_dump.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<SysDumpTransferData> DumpHandler::sysDumpTransfer;
 sdeventplus::Event* DumpHandler::eventLoop = nullptr;
 
 // System dump file configuration
-constexpr auto sysDumpPath = "/tmp";
+constexpr auto sysDumpPath = "/var/lib/phosphor-debug-collector/tmp";
 constexpr auto sysDumpFilePrefix = "sysdump_";
 
 namespace fs = std::filesystem;


### PR DESCRIPTION
Systemdump sent down from the host will now be written to /var/lib/phosphor-debug-collector/tmp/
Dump manager will pick the dump from here for further process and offload

Tested:
systemdump initiated and written with pldmtoool was written to /var/lib/phosphor-debug-collector/tmp/