### PR TITLE
1110: oem-ibm: Fix incorrect error codes in SMS menu (#771) & oem-ibm: Fix out-of-bounds vector access in SMS menu (#770)

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_type_smsmenu.cpp
+++ b/oem/ibm/libpldmresponder/file_io_type_smsmenu.cpp
@@ -21,12 +21,44 @@ uint32_t SmsMenuHandler::readVecContent(
 {
     uint32_t size = 0;
     constexpr auto bitPos = 8;
-    std::vector<char> userPassLenArr(inputVec.begin() + startIdx,
-                                     inputVec.begin() + endIdx);
-    for (uint32_t idx = 0; idx < bitPos; idx++)
+    constexpr auto bytesPerUint32 = sizeof(uint32_t);
+
+    // Validate indices
+    if (endIdx <= startIdx || (endIdx - startIdx) < bytesPerUint32)
     {
-        size |= (uint32_t)userPassLenArr[idx] << bitPos * idx;
+        error(
+            "Invalid indices for readVecContent: startIdx={START}, endIdx={END}",
+            "START", startIdx, "END", endIdx);
+        return 0;
     }
+
+    // Validate endIdx
+    if (endIdx > inputVec.size())
+    {
+        error("endIdx {END} exceeds vector size {SIZE}", "END", endIdx, "SIZE",
+              inputVec.size());
+        return 0;
+    }
+
+    // Validate that we can safely read bytesPerUint32 bytes starting
+    // from startIdx
+    if (startIdx + bytesPerUint32 > inputVec.size())
+    {
+        error(
+            "startIdx {START} + bytesPerUint32 {BYTES} exceeds vector size {SIZE}",
+            "START", startIdx, "BYTES", bytesPerUint32, "SIZE",
+            inputVec.size());
+        return 0;
+    }
+
+    // Read 4 bytes to construct uint32_t
+    for (uint32_t idx = 0; idx < bytesPerUint32; idx++)
+    {
+        size |= static_cast<uint32_t>(
+                    static_cast<uint8_t>(inputVec[startIdx + idx]))
+                << (bitPos * idx);
+    }
+
     return size;
 }
 
@@ -72,12 +104,22 @@ int SmsMenuHandler::write(const char* buffer, uint32_t /*offset*/,
 
     // Read the size of User Name which is the content of first four bytes
     auto userNameLen = readVecContent(smsBuf, 0, sizeof(uint32_t));
+    if (!userNameLen)
+    {
+        error("SMS Menu username is empty");
+        return PLDM_ERROR;
+    }
 
     // Read the size of Password/Old Password which is the content of four
     // bytes after User Name
     auto userPassLen =
         readVecContent(smsBuf, sizeof(uint32_t) + userNameLen,
                        sizeof(uint32_t) + userNameLen + sizeof(uint32_t));
+    if (!userPassLen)
+    {
+        error("SMS Menu user password is empty");
+        return PLDM_ERROR;
+    }
     if (smsMenuType == PLDM_FILE_TYPE_USER_PASSWORD_CHANGE)
     {
         // Read the size of New Password which is the content of four bytes
@@ -87,6 +129,11 @@ int SmsMenuHandler::write(const char* buffer, uint32_t /*offset*/,
             sizeof(uint32_t) + userNameLen + sizeof(uint32_t) + userPassLen,
             sizeof(uint32_t) + userNameLen + sizeof(uint32_t) + userPassLen +
                 sizeof(uint32_t));
+        if (!userNewPassLen)
+        {
+            error("SMS Menu new user password is empty");
+            return PLDM_ERROR;
+        }
     }
 
     // Split the vector to retrieve the User Name

--- a/oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp
+++ b/oem/ibm/pfw-sms-utils/pfw_sms_menu.cpp
@@ -80,15 +80,17 @@ static int pamConversationFunction(
                 {
                     return PAM_BUF_ERR; // *authenticated = false
                 }
-                pfw_sms_appdata_ptr->reasonCode =
-                    PASSWORD_CHANGE_SUCCESSFUL; // working assumption
-                response_ptr[msg_index]->resp = local_userpass;
+                // Removing this assumption code as this is overwriting the
+                // actual error codes
+                // pfw_sms_appdata_ptr->reasonCode =
+                //    PASSWORD_CHANGE_SUCCESSFUL; // working assumption
+                (*response_ptr)[msg_index].resp = local_userpass;
                 break;
             case PAM_PROMPT_ECHO_ON:
                 // This is not expected
                 // Allocate a response for PAM to free().  Note that PAM
                 // uses malloc/calloc/strdup style memory management.
-                response_ptr[msg_index]->resp = ::strdup("Unexpected");
+                (*response_ptr)[msg_index].resp = ::strdup("Unexpected");
                 break;
             case PAM_ERROR_MSG:
                 // fall through
@@ -269,7 +271,13 @@ enum changePasswordReasonCode changePassword(
     {
         pam_end(pamHandle, retval); // ignore retval
         // Return the specific reason gathered from the conversation function
-        return appdata.reasonCode;
+        if (appdata.reasonCode != PASSWORD_CHANGE_FAILED_UNKNOWN_REASON)
+        {
+            return appdata.reasonCode;
+        }
+
+        // Password quality check failed with unknown reason
+        return PASSWORD_CHANGE_FAILED_UNKNOWN_REASON;
     }
 
     pam_end(pamHandle, retval); // ignore the return value


### PR DESCRIPTION
#### oem-ibm: Fix incorrect error codes in SMS menu (#771)
```
This commit fixes the incorrect error code returned by the
password validation function.

Tested By:
Verified the the changes good in a balcones system with executing
different types of error scenarios.

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>```
#### oem-ibm: Fix out-of-bounds vector access in SMS menu (#770)
```
This commit fixes the out-of-bounds vector access in SMS menu. Below
changes are made:
1. Added bounds checking
2. Fixed the indexing
3. Returned error on empty lengths

Tested By:
Tested the changes in one of balcones systems and operation was
successful without pldm crash

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>```