### PR TITLE
Add reconfig loop support

### DIFF
--- a/oem/ibm/libpldmresponder/file_io_by_type.cpp
+++ b/oem/ibm/libpldmresponder/file_io_by_type.cpp
@@ -8,6 +8,7 @@
 #include "file_io_type_pcie.hpp"
 #include "file_io_type_pel.hpp"
 #include "file_io_type_progress_src.hpp"
+#include "file_io_type_reconfig_loop.hpp"
 #include "file_io_type_smsmenu.hpp"
 #include "file_io_type_vpd.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
@@ -485,6 +486,10 @@ std::unique_ptr<FileHandler> getHandlerByType(
             return std::make_unique<SmsMenuHandler>(fileHandle, fileType,
                                                     instanceIdDb, handler);
         }
+        case PLDM_FILE_TYPE_RECONFIG_LOOP:
+        {
+            return std::make_unique<ReconfigLoopHandler>(fileHandle);
+        }
         default:
         {
             throw InternalFailure();
@@ -561,6 +566,10 @@ std::shared_ptr<FileHandler> getSharedHandlerByType(
         {
             return std::make_unique<SmsMenuHandler>(fileHandle, fileType,
                                                     instanceIdDb, handler);
+        }
+        case PLDM_FILE_TYPE_RECONFIG_LOOP:
+        {
+            return std::make_unique<ReconfigLoopHandler>(fileHandle);
         }
         default:
         {

--- a/oem/ibm/libpldmresponder/file_io_type_reconfig_loop.hpp
+++ b/oem/ibm/libpldmresponder/file_io_type_reconfig_loop.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "file_io_by_type.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm
+{
+namespace responder
+{
+
+/** @class ReconfigLoopHandler
+ *
+ *  @brief Inherits and implements FileHandler. This class is used
+ *  to handle the reconfig loop notification from Hostboot by
+ *  creating a marker file at /run/openbmc/reconfigloop.
+ */
+class ReconfigLoopHandler : public FileHandler
+{
+  public:
+    ReconfigLoopHandler(uint32_t fileHandle) : FileHandler(fileHandle) {}
+
+    int newFileAvailable(uint64_t /*length*/) override
+    {
+        static constexpr auto reconfigLoopFile = "/run/openbmc/reconfigloop";
+
+        std::ofstream file(reconfigLoopFile);
+        if (!file)
+        {
+            error("Failed to create reconfig loop marker file '{PATH}'", "PATH",
+                  reconfigLoopFile);
+            return PLDM_ERROR;
+        }
+        return PLDM_SUCCESS;
+    }
+
+    void writeFromMemory(uint32_t /*offset*/, uint32_t length,
+                         uint64_t /*address*/,
+                         oem_platform::Handler* /*oemPlatformHandler*/,
+                         SharedAIORespData& sharedAIORespDataobj,
+                         sdeventplus::Event& /*event*/) override
+    {
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+    }
+
+    void readIntoMemory(uint32_t /*offset*/, uint32_t length,
+                        uint64_t /*address*/,
+                        oem_platform::Handler* /*oemPlatformHandler*/,
+                        SharedAIORespData& sharedAIORespDataobj,
+                        sdeventplus::Event& /*event*/) override
+    {
+        FileHandler::dmaResponseToRemoteTerminus(
+            sharedAIORespDataobj, PLDM_ERROR_UNSUPPORTED_PLDM_CMD, length);
+        FileHandler::deleteAIOobjects(nullptr, sharedAIORespDataobj);
+    }
+
+    int read(uint32_t /*offset*/, uint32_t& /*length*/, Response& /*response*/,
+             oem_platform::Handler* /*oemPlatformHandler*/) override
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    int write(const char* /*buffer*/, uint32_t /*offset*/, uint32_t& /*length*/,
+              oem_platform::Handler* /*oemPlatformHandler*/,
+              struct fileack_status_metadata& /*metaDataObj*/) override
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    int fileAck(uint8_t /*fileStatus*/) override
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    int fileAckWithMetaData(uint8_t /*fileStatus*/, uint32_t /*metaDataValue1*/,
+                            uint32_t /*metaDataValue2*/,
+                            uint32_t /*metaDataValue3*/,
+                            uint32_t /*metaDataValue4*/) override
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    int newFileAvailableWithMetaData(
+        uint64_t /*length*/, uint32_t /*metaDataValue1*/,
+        uint32_t /*metaDataValue2*/, uint32_t /*metaDataValue3*/,
+        uint32_t /*metaDataValue4*/) override
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    int postDataTransferCallBack(bool /*IsWriteToMemOp*/,
+                                 uint32_t /*length*/) override
+    {
+        return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+    }
+
+    void postWriteAction(
+        const uint16_t /*fileType*/, const uint32_t /*fileHandle*/,
+        const struct fileack_status_metadata& /*metaDataObj*/) override
+    {}
+
+    ~ReconfigLoopHandler() {}
+};
+
+} // namespace responder
+} // namespace pldm


### PR DESCRIPTION
Hostboot sends a NewFileAvailable PLDM command with file type PLDM_FILE_TYPE_RECONFIG_LOOP to notify the BMC of a reconfig loop event. This commit adds support for handling this notification on the BMC side.

When the BMC receives NewFileAvailable with file type PLDM_FILE_TYPE_RECONFIG_LOOP, it creates a marker file at
/run/openbmc/reconfigloop. Other file IO operations are not supported for this file type and return PLDM_ERROR_UNSUPPORTED_PLDM_CMD.

tested on huygens simics, via pldmtool raw .

root@huygens: **pldmtool raw -m 8 -d 0x80 0x3F 0x0a 0x1a 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00**
pldmtool: Tx: 80 3f 0a 1a 00 00 00 00 00 00 00 00 00 00 00 00 00
pldmtool: Rx: 00 3f 0a 00
root@huygens:/run/openbmc# ls
active-bmc  bmc_position  bmc_redundancy_determined  **reconfigloop**
