### PR TITLE
oem-ibm: Handle get subtree API gracefully

### DIFF
--- a/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
+++ b/oem/ibm/libpldmresponder/oem_ibm_handler.hpp
@@ -211,9 +211,18 @@ class Handler : public oem_platform::Handler
                         int depth = 0;
                         std::vector<std::string> powerInterface = {
                             "xyz.openbmc_project.State.Decorator.PowerState"};
-                        pldm::utils::GetSubTreeResponse response =
-                            pldm::utils::DBusHandler().getSubtree(
+                        pldm::utils::GetSubTreeResponse response;
+                        try
+                        {
+                            response = pldm::utils::DBusHandler().getSubtree(
                                 searchpath, depth, powerInterface);
+                        }
+                        catch (const std::exception& e)
+                        {
+                            error(
+                                "Unable to get the power interface from motherboard and failed with error - {ERROR}",
+                                "ERROR", e);
+                        }
                         for (const auto& [objPath, serviceMap] : response)
                         {
                             pldm::utils::DBusMapping dbusMapping{


### PR DESCRIPTION
This commit adds the the error exception handling in getSubtree() API during the chassis off path

Tested By:
Tested and verified the changes in Huygens simics setup

Change-Id: Ia1894bf9b3aad85ebbff683ad1581c7fa3b71cb2