### PR TITLE
oem-ibm: Host security file size

### DIFF
--- a/oem/ibm/service_files/scripts/create-PHYP-SECURITY-file
+++ b/oem/ibm/service_files/scripts/create-PHYP-SECURITY-file
@@ -1,7 +1,7 @@
 #!/bin/sh
 mkdir -p /var/lib/phosphor-software-manager/hostfw
 PHYP_SECURITY=/var/lib/phosphor-software-manager/hostfw/PHYP-SECURITY
-SIZE=$((1024 * 64))
+SIZE=$((1024 * 128))
 PHYP_SECURITY_FILE_SIZE="$(stat -c%s "$PHYP_SECURITY")"
 
 if [ ! -f "$PHYP_SECURITY" ]; then


### PR DESCRIPTION
Updated host security file system to 128K

Tested:
* Verified on huygens for updated size.

Change-Id: Icae0b9a3b5ed17120fae32e2059cbffe492e11f8