### PR TITLE
oem-ibm: Improve traces for lid file patching

### DIFF
--- a/oem/ibm/libpldmresponder/file_table.cpp
+++ b/oem/ibm/libpldmresponder/file_table.cpp
@@ -67,6 +67,12 @@ FileTable::FileTable(const std::string& fileTableConfigPath)
             continue;
         }
 
+        if (fsPath.parent_path() == fs::path(LID_RUNNING_PATCH_DIR) ||
+            fsPath.parent_path() == fs::path(LID_ALTERNATE_PATCH_DIR))
+        {
+            info("Using patched LID file '{PATH}'", "PATH", fsPath);
+        }
+
         fileNameLength =
             static_cast<uint16_t>(fsPath.filename().string().size());
         fileSize = static_cast<uint32_t>(fs::file_size(fsPath));


### PR DESCRIPTION
Added traces to file_table.cpp to indicate when a patched lid is picked

Tested:

Confirmed Journal traces are printed when patch lids are placed in /usr/local/share/hostfw/running directory