### PR TITLE
bios: Validate persisted BIOS attributes before restore

### DIFF
--- a/libpldmresponder/bios_enum_attribute.cpp
+++ b/libpldmresponder/bios_enum_attribute.cpp
@@ -231,7 +231,18 @@ void BIOSEnumAttribute::constructEntry(
         if (attributeValue.index() == 1)
         {
             auto currValue = std::get<std::string>(attributeValue);
-            currValueIndices[0] = getValueIndex(currValue, possibleValues);
+            try
+            {
+                currValueIndices[0] = getValueIndex(currValue, possibleValues);
+            }
+            catch (std::invalid_argument const& ex)
+            {
+                std::cerr << "Enum Value " << currValue
+                          << " is not one of the possible values. Error: "
+                          << ex.what() << " for Attribute " << name << '\n';
+                currValueIndices[0] =
+                    getValueIndex(defaultValue, possibleValues);
+            }
         }
         else
         {

--- a/libpldmresponder/bios_integer_attribute.cpp
+++ b/libpldmresponder/bios_integer_attribute.cpp
@@ -136,6 +136,15 @@ void BIOSIntegerAttribute::constructEntry(
         currentValue = getAttrValue();
     }
 
+    if (currentValue < (int64_t)integerInfo.lowerBound ||
+        currentValue > (int64_t)integerInfo.upperBound)
+    {
+        std::cerr << "Setting to default value " << integerInfo.defaultValue
+                  << " For Attribute " << name
+                  << " Received value: " << currentValue << std::endl;
+        currentValue = integerInfo.defaultValue;
+    }
+
     table::attribute_value::constructIntegerEntry(attrValueTable, attrHandle,
                                                   attrType, currentValue);
 }

--- a/libpldmresponder/bios_string_attribute.cpp
+++ b/libpldmresponder/bios_string_attribute.cpp
@@ -131,6 +131,14 @@ void BIOSStringAttribute::constructEntry(
         currStr = getAttrValue();
     }
 
+    if (currStr.size() < stringInfo.minLength ||
+        currStr.size() > stringInfo.maxLength)
+    {
+        std::cerr << "Setting to default. Received string size "
+                  << currStr.size() << " For Attribute " << name << std::endl;
+        currStr = stringInfo.defString;
+    }
+
     table::attribute_value::constructStringEntry(attrValueTable, attrHandle,
                                                  attrType, currStr);
 }


### PR DESCRIPTION
Discard persisted BIOS attribute values that are invalid for the current firmware level. Previously, persisted values were restored without validation for integer and string attributes, while invalid enum values caused an error and prevented the attribute from being added to the table.

This could result in multiple unrecoverable errors being logged during IPL when BIOS attribute details changed between firmware versions.

Validate persisted values for integer, string, and enum attributes before restoring them during power-on. If validation fails, restore the attribute with its default value instead